### PR TITLE
Fixes Cycamore build fail. 

### DIFF
--- a/src/Models/Region/GrowthRegion/GrowthRegion.cpp
+++ b/src/Models/Region/GrowthRegion/GrowthRegion.cpp
@@ -77,7 +77,7 @@ void GrowthRegion::init(xmlNodePtr cur, xmlXPathContextPtr context) {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 void GrowthRegion::initBuildManager() {
   buildmanager_ = 
-    shared_ptr<BuildingManager>(new BuildingManager(sdmanager_));
+    shared_ptr<BuildingManager>(new BuildingManager(&sdmanager_));
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 


### PR DESCRIPTION
In cyclus pull request https://github.com/cyclus/core/pull/285, the BuildManager constructor was changed to take a pointer. This pull request makes cycamore's GrowthRegion compatible with that change. Without this pull request, cycamore fails to build on my machine. It exits with one of these : 

```
[ 81%] Building CXX object CMakeFiles/CycamoreUnitTestDriver.dir/Models/Region/NullRegion/NullRegionTests.cpp.o
/Users/khuff/repos/cycamore/src/Models/Region/GrowthRegion/GrowthRegion.cpp:80:37: error: no matching constructor for initialization of 'BuildingManager'
   shared_ptr<BuildingManager>(new BuildingManager(sdmanager_));
                                   ^               ~~~~~~~~~~
/usr/local/cyclus/include/BuildingManager.h:45:3: note: candidate constructor not viable: no known conversion from 'SupplyDemandManager' to 'SupplyDemandManager *' for 1st argument; take the address of the argument with &
 BuildingManager(SupplyDemandManager* m);
 ^
/usr/local/cyclus/include/BuildingManager.h:38:7: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'SupplyDemandManager' to 'const BuildingManager' for 1st argument;
class BuildingManager {
```

A previously noted occaisionally failing test 'TestBuildDecision' continues to fail despite this change.
