### PR TITLE
The GreedyMarket needs to be registered in the test 

### DIFF
--- a/src/Models/Market/GreedyMarket/GreedyMarketTests.cpp
+++ b/src/Models/Market/GreedyMarket/GreedyMarketTests.cpp
@@ -29,6 +29,8 @@ class FakeGreedyMarket : public GreedyMarket {
       Transaction trans(this, OFFER);
       msg_ = msg_ptr(new Message(this, this, trans));
       msg_->trans().setResource(res);
+      commodity_ = "none";
+      registerMarket(this);
     }
 
     virtual ~FakeGreedyMarket() {
@@ -101,12 +103,12 @@ class GreedyMarketTest : public ::testing::Test {
       requester = new FakeFacility();
 
       Transaction req(requester, REQUEST);
-      req.setCommod("none");
+      req.setCommod(src_market->commodity());
       req.setMinFrac(0.1);
       req.setPrice(3);
 
       Transaction off(supplier, OFFER);
-      off.setCommod("none");
+      off.setCommod(new_market->commodity());
       off.setMinFrac(0.1);
       off.setPrice(3);
 


### PR DESCRIPTION
The GreedyMarket needs to be registered in the test in order to find itself in the marketForCommod function call. The registration wasn't happening in the test (because init is never called), so the test fails after the cyclus pull request https://github.com/cyclus/cyclus/pull/341. 

When I added the MarketID to the Transaction table in the core, the marketForCommod function is now called during the GreedyMarketTest and the test fails with a CycMarketlessCommodException. To fix the test, I made sure the greedy market being tested was registered just as it would be in the simulation.
