### PR TITLE
makes cycamore compliant with add_pure_virtual branch of cyclus

### DIFF
--- a/src/Models/Inst/ManagerInst/ManagerInstTests.h
+++ b/src/Models/Inst/ManagerInst/ManagerInstTests.h
@@ -14,13 +14,12 @@ class TestProducer :
   TestProducer();
   virtual ~TestProducer();
 
+  void cloneModuleMembersFrom(FacilityModel* source) {};
+  void handleTock(int time){};
+  void handleTick(int time){};
   void receiveMessage(msg_ptr msg) {
     msg->setDir(DOWN_MSG);
   }
-
-  /* void receiveMaterial(Transaction trans, std::vector<mat_rsrc_ptr> manifest) { } */
-  
-  /* Prototype* clone() { return new TestFacility(); } */
 
 };
 


### PR DESCRIPTION
This brings cycamore up to date with the pull request in cyclus that makes cloneModuleMembersFrom, handleTick and handleTock pure virtual.  Please pull the cyclus pull request first. That pull request is here: https://github.com/cyclus/cyclus/pull/422 .
