### PR TITLE
tries ${CYCLUS_ROOT_DIR} instead of ../

### DIFF
--- a/src/Models/Facility/BatchReactor/BatchReactorTests.cpp
+++ b/src/Models/Facility/BatchReactor/BatchReactorTests.cpp
@@ -100,7 +100,7 @@ TEST_F(BatchReactorTest,initialstate)
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-TEST_F(BatchReactorTest,DISABLED_clone) 
+TEST_F(BatchReactorTest,clone) 
 {
   Model::loadModule("Facility","BatchReactor");
   src_facility->setModelImpl("BatchReactor");


### PR DESCRIPTION
This fixes https://github.com/cyclus/cyclus/issues/408 for me. Check it with full clean reinstall of Cyclus and Cycamore. I am pull-requesting a similar change to CycStub.
