### PR TITLE
update to clone testing, removes segfault issue

### DIFF
--- a/src/Models/Facility/BatchReactor/BatchReactorTests.cpp
+++ b/src/Models/Facility/BatchReactor/BatchReactorTests.cpp
@@ -99,26 +99,29 @@ TEST_F(BatchReactorTest,initialstate)
   EXPECT_EQ(cost,src_facility->productionCost(commod));
 }
 
-//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 TEST_F(BatchReactorTest,clone) 
 {
-  Model::loadModule("Facility","BatchReactor");
-  src_facility->setModelImpl("BatchReactor");
-  BatchReactor* new_facility = dynamic_cast<BatchReactor*>(src_facility->clone());
-  EXPECT_EQ( lencycle, new_facility->cycle_length() );
-  EXPECT_EQ( lencycle, new_facility->refuel_delay() );
-  EXPECT_EQ( in_loadcore, new_facility->in_core_loading() );
-  EXPECT_EQ( out_loadcore, new_facility->out_core_loading() );
-  EXPECT_EQ( nbatch, new_facility->batches_per_core() );
-  EXPECT_EQ(in_commod,new_facility->in_commodity());
-  EXPECT_EQ(out_commod,new_facility->out_commodity());
-  EXPECT_EQ(in_recipe,new_facility->in_recipe());
-  EXPECT_EQ(out_recipe,new_facility->out_recipe());
+  BatchReactor* cloned_fac = new BatchReactor();
+  cloned_fac->cloneModuleMembersFrom(src_facility);
+ 
+
+  EXPECT_EQ( lencycle, cloned_fac->cycle_length() );
+  EXPECT_EQ( lencycle, cloned_fac->refuel_delay() );
+  EXPECT_EQ( in_loadcore, cloned_fac->in_core_loading() );
+  EXPECT_EQ( out_loadcore, cloned_fac->out_core_loading() );
+  EXPECT_EQ( nbatch, cloned_fac->batches_per_core() );
+  EXPECT_EQ(in_commod,cloned_fac->in_commodity());
+  EXPECT_EQ(out_commod,cloned_fac->out_commodity());
+  EXPECT_EQ(in_recipe,cloned_fac->in_recipe());
+  EXPECT_EQ(out_recipe,cloned_fac->out_recipe());
 
   Commodity commod(commodity);
-  EXPECT_TRUE(new_facility->producesCommodity(commod)); 
-  EXPECT_EQ(capacity,new_facility->productionCapacity(commod));
-  EXPECT_EQ(cost,new_facility->productionCost(commod));
+  EXPECT_TRUE(cloned_fac->producesCommodity(commod)); 
+  EXPECT_EQ(capacity,cloned_fac->productionCapacity(commod));
+  EXPECT_EQ(cost,cloned_fac->productionCost(commod));
+
+  delete cloned_fac;
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

--- a/src/Models/Facility/EnrichmentFacility/EnrichmentFacilityTests.cpp
+++ b/src/Models/Facility/EnrichmentFacility/EnrichmentFacilityTests.cpp
@@ -103,7 +103,7 @@ TEST_F(EnrichmentFacilityTest,clone)
   EXPECT_DOUBLE_EQ(feed_assay,cloned_fac->feed_assay());
   EXPECT_DOUBLE_EQ(inv_size,cloned_fac->maxInventorySize());
   EXPECT_DOUBLE_EQ(commodity_price,cloned_fac->commodity_price());  
-
+  
   delete cloned_fac;
 }
 

--- a/src/Models/Facility/SinkFacility/SinkFacilityTests.cpp
+++ b/src/Models/Facility/SinkFacility/SinkFacilityTests.cpp
@@ -13,7 +13,7 @@ void SinkFacilityTest::SetUp() {
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 void SinkFacilityTest::TearDown() {
-  delete sink_facility;
+  delete src_facility;
   delete commod_market;
 }
 
@@ -27,48 +27,51 @@ void SinkFacilityTest::initParameters() {
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 void SinkFacilityTest::setUpSinkFacility() {
-  sink_facility = new SinkFacility();
-  sink_facility->addCommodity(commod_);
+  src_facility = new SinkFacility();
+  src_facility->addCommodity(commod_);
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 TEST_F(SinkFacilityTest, InitialState) {
   int time = 1;
-  EXPECT_DOUBLE_EQ(0.0, sink_facility->inventorySize());
+  EXPECT_DOUBLE_EQ(0.0, src_facility->inventorySize());
 }
 
-// //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-// TEST_F(SinkFacilityTest,clone) {
-//   SinkFacility* new_facility = dynamic_cast<SinkFacility*>(sink_facility->clone());
-//   EXPECT_EQ(sink_facility->capacity(),new_facility->capacity());
-//   EXPECT_EQ(sink_facility->maxInventorySize(),new_facility->maxInventorySize());
-//   delete new_facility;
-// }
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+TEST_F(SinkFacilityTest,clone) {
+  SinkFacility* cloned_fac = new SinkFacility();
+  cloned_fac->cloneModuleMembersFrom(src_facility);
+  
+  EXPECT_EQ(src_facility->capacity(),cloned_fac->capacity());
+  EXPECT_EQ(src_facility->maxInventorySize(),cloned_fac->maxInventorySize());
+
+  delete cloned_fac;
+}
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 TEST_F(SinkFacilityTest, Print) {
-  EXPECT_NO_THROW(std::string s = sink_facility->str());
+  EXPECT_NO_THROW(std::string s = src_facility->str());
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 TEST_F(SinkFacilityTest, ReceiveMessage) {
-  msg_ptr msg = msg_ptr(new Message(sink_facility));
-  EXPECT_NO_THROW(sink_facility->receiveMessage(msg));
+  msg_ptr msg = msg_ptr(new Message(src_facility));
+  EXPECT_NO_THROW(src_facility->receiveMessage(msg));
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 TEST_F(SinkFacilityTest, Tick) {
   int time = 1;
-  EXPECT_DOUBLE_EQ(0.0, sink_facility->inventorySize());
-  EXPECT_NO_THROW(sink_facility->handleTick(time));
-  EXPECT_DOUBLE_EQ(0.0,sink_facility->inventorySize());
+  EXPECT_DOUBLE_EQ(0.0, src_facility->inventorySize());
+  EXPECT_NO_THROW(src_facility->handleTick(time));
+  EXPECT_DOUBLE_EQ(0.0,src_facility->inventorySize());
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 TEST_F(SinkFacilityTest, Tock) {
   int time = 1;
-  EXPECT_DOUBLE_EQ(0.0,sink_facility->inventorySize());
-  EXPECT_NO_THROW(sink_facility->handleTock(time));
+  EXPECT_DOUBLE_EQ(0.0,src_facility->inventorySize());
+  EXPECT_NO_THROW(src_facility->handleTock(time));
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

--- a/src/Models/Facility/SinkFacility/SinkFacilityTests.h
+++ b/src/Models/Facility/SinkFacility/SinkFacilityTests.h
@@ -20,7 +20,7 @@ FacilityModel* SinkFacilityConstructor(){
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 class SinkFacilityTest : public ::testing::Test {
 protected:
-  SinkFacility* sink_facility;
+  SinkFacility* src_facility;
   TestMarket* commod_market;
   std::string commod_;
     

--- a/src/Models/Facility/SourceFacility/SourceFacilityTests.cpp
+++ b/src/Models/Facility/SourceFacility/SourceFacilityTests.cpp
@@ -41,21 +41,23 @@ TEST_F(SourceFacilityTest, InitialState) {
   EXPECT_DOUBLE_EQ(0.0, src_facility->inventorySize());
 }
 
-// //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-// TEST_F(SourceFacilityTest,clone) {
-//   SourceFacility* new_facility = dynamic_cast<SourceFacility*>(src_facility->clone());
-//   EXPECT_EQ(src_facility->commodity(),new_facility->commodity());
-//   EXPECT_EQ(src_facility->capacity(),new_facility->capacity());
-//   EXPECT_EQ(src_facility->maxInventorySize(),new_facility->maxInventorySize());
-//   EXPECT_EQ(src_facility->recipe(),new_facility->recipe());
-//   delete new_facility;
-// }
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+TEST_F(SourceFacilityTest,clone) {
+  SourceFacility* cloned_fac = new SourceFacility();
+  cloned_fac->cloneModuleMembersFrom(src_facility);
+
+  EXPECT_EQ(src_facility->commodity(),cloned_fac->commodity());
+  EXPECT_EQ(src_facility->capacity(),cloned_fac->capacity());
+  EXPECT_EQ(src_facility->maxInventorySize(),cloned_fac->maxInventorySize());
+  EXPECT_EQ(src_facility->recipe(),cloned_fac->recipe());
+  
+  delete cloned_fac;
+}
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 TEST_F(SourceFacilityTest, Print) {
   EXPECT_NO_THROW(std::string s = src_facility->str());
 }
-
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 TEST_F(SourceFacilityTest, ReceiveMessage) {
@@ -82,4 +84,3 @@ TEST_F(SourceFacilityTest, Tock) {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 INSTANTIATE_TEST_CASE_P(SourceFac, FacilityModelTests, Values(&SourceFacilityConstructor));
 INSTANTIATE_TEST_CASE_P(SourceFac, ModelTests, Values(&SourceFacilityModelConstructor));
-


### PR DESCRIPTION
updated tests for clone method testing for each currently supported facility module. I also streamlined the nomenclature such that all clones are named cloned_fac and all sources are named src_facility

It will pass all tests once cyclus/cyclus#444 is pulled.
