### PR TITLE
fixes schema parse error due to improper install location of cyclus.rng file

### DIFF
--- a/src/post_install/postinstall.cmake.in
+++ b/src/post_install/postinstall.cmake.in
@@ -45,7 +45,7 @@ macro(install_rng)
   clean_includes()
   clean_all_refs()
   CONFIGURE_FILE(${CYCLUS_CORE_SHARE_DIR}/cyclus.rng.in
-    ${CMAKE_INSTALL_PREFIX}/cycamore/share/cyclus.rng @ONLY)
+    ${CMAKE_INSTALL_PREFIX}/share/cyclus.rng @ONLY)
 endmacro()
 
 install_rng()


### PR DESCRIPTION
This is a straggler from @scopatz recent changes to the build/install code.  Simulations fail to run because cyclus can't find the rng file filled with the cycamore module references.
