### PR TITLE
added a hint that find the installed version of gtest over a one in /usr...

### DIFF
--- a/src/CMake/Findcycluscore.cmake
+++ b/src/CMake/Findcycluscore.cmake
@@ -39,6 +39,7 @@ FIND_PATH(CYCLUS_CORE_SHARE_DIR cyclus.rng.in
   HINTS "${CYCLUS_ROOT_DIR}" "${CYCLUS_ROOT_DIR}/cyclus" 
   /usr/local/cyclus /opt/local/cyclus
   PATH_SUFFIXES cyclus/share share)
+MESSAGE(STATUS "CYCLUS_CORE_SHARE_DIR Found : ${CYCLUS_CORE_SHARE_DIR}")
 
 # Look for the library
 FIND_LIBRARY(CYCLUS_CORE_LIBRARY NAMES cycluscore 
@@ -46,13 +47,16 @@ FIND_LIBRARY(CYCLUS_CORE_LIBRARY NAMES cycluscore
   /usr/local/cyclus/lib /usr/local/cyclus 
   /opt/local /opt/local/cyclus
   PATH_SUFFIXES cyclus/lib lib)
+MESSAGE(STATUS "CYCLUS_CORE_LIBRARY Found : ${CYCLUS_CORE_LIBRARY}")
 
 # Look for the library
 FIND_LIBRARY(CYCLUS_GTEST_LIBRARY NAMES gtest
   HINTS "${CYCLUS_ROOT_DIR}" "${CYCLUS_ROOT_DIR}/cyclus" 
+  "${CYCLUS_ROOT_DIR}/lib"  "${CYCLUS_CORE_SHARE_DIR}/../lib"
   /usr/local/cyclus/lib /usr/local/cyclus 
   /opt/local/lib /opt/local/cyclus/lib 
   PATH_SUFFIXES cyclus/lib lib)
+MESSAGE(STATUS "CYCLUS_GTEST_LIBRARY Found : ${CYCLUS_GTEST_LIBRARY}")
 
 # Copy the results to the output variables.
 IF (CYCLUS_CORE_INCLUDE_DIR AND CYCLUS_CORE_LIBRARY AND CYCLUS_GTEST_LIBRARY AND CYCLUS_CORE_SHARE_DIR)


### PR DESCRIPTION
.../lib

CAE decided to install gtest in /usr/lib, which broke my build.
