### PR TITLE
added fix that allows regressions tests to work on pythons > 3.1

### DIFF
--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -26,7 +26,10 @@ def setup():
     for r in refs:
         fpath = os.path.join(fetchdir, r["fname"])
         if not os.path.exists(fpath):
-            urllib.urlretrieve(base_url+r["fname"], fpath)
+            try:
+                urllib.urlretrieve(base_url+r["fname"], fpath)
+            except AttributeError: # try python 3.1+ api version
+                urllib.request.urlretrieve(base_url+r["fname"], fpath)
         h = hashlib.sha1()
         with open(fpath, "rb") as f: 
             h.update(f.read())


### PR DESCRIPTION
python 3.1 changed the urllib api.  This catches those cases and uses the new api.
