### PR TITLE
companion for cyclus/cyclus#912

### DIFF
--- a/cmake/UseCyclus.cmake
+++ b/cmake/UseCyclus.cmake
@@ -226,7 +226,7 @@ ENDMACRO()
 MACRO(INSTALL_AGENT_LIB_ lib_name lib_src lib_h inst_dir)
   # add lib
   ADD_LIBRARY(${lib_name} ${lib_src})
-  TARGET_LINK_LIBRARIES(${lib_name} dl ${LIBS} ${CYCLUS_AGENT_TEST_LIBRARIES})
+  TARGET_LINK_LIBRARIES(${lib_name} dl ${LIBS})
   SET(CYCLUS_LIBRARIES ${CYCLUS_LIBRARIES} ${lib_root})
   ADD_DEPENDENCIES(${lib_name} ${lib_src} ${lib_h})
 

--- a/src/batch_reactor.cc
+++ b/src/batch_reactor.cc
@@ -1037,10 +1037,3 @@ extern "C" cyclus::Agent* ConstructBatchReactor(cyclus::Context* ctx) {
 }
 
 }  // namespace cycamore
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/src/batch_reactor_tests.cc
+++ b/src/batch_reactor_tests.cc
@@ -377,15 +377,22 @@ TEST_F(BatchReactorTest, BatchInOut) {
   EXPECT_THROW(TestBatchOut(1, 0), cyclus::Error);
 }
 
+}  // namespace cycamore
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 cyclus::Agent* BatchReactorConstructor(cyclus::Context* ctx) {
   return new cycamore::BatchReactor(ctx);
 }
+
+// required to get functionality in cyclus agent unit tests library
+#ifndef CYCLUS_AGENT_TESTS_CONNECTED
+int ConnectAgentTests();
+static int cyclus_agent_tests_connected = ConnectAgentTests();
+#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
+#endif // CYCLUS_AGENT_TESTS_CONNECTED
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // INSTANTIATE_TEST_CASE_P(BatchReactor, FacilityTests,
 //                         Values(&BatchReactorConstructor));
 INSTANTIATE_TEST_CASE_P(BatchReactor, AgentTests,
                         Values(&BatchReactorConstructor));
-
-}  // namespace cycamore

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -94,10 +94,3 @@ extern "C" cyclus::Agent* ConstructDeployInst(cyclus::Context* ctx) {
 }
 
 } // namespace cycamore
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/src/deploy_inst_tests.cc
+++ b/src/deploy_inst_tests.cc
@@ -20,6 +20,13 @@ class DeployInstTest : public ::testing::Test {
   virtual void TearDown() {}
 };
 
+// required to get functionality in cyclus agent unit tests library
+#ifndef CYCLUS_AGENT_TESTS_CONNECTED
+int ConnectAgentTests();
+static int cyclus_agent_tests_connected = ConnectAgentTests();
+#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
+#endif // CYCLUS_AGENT_TESTS_CONNECTED
+
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_CASE_P(DeployInst, InstitutionTests,
                         Values(&DeployInstitutionConstructor));

--- a/src/enrichment_facility.cc
+++ b/src/enrichment_facility.cc
@@ -342,10 +342,3 @@ extern "C" cyclus::Agent* ConstructEnrichmentFacility(cyclus::Context* ctx) {
 } // namespace cycamore
 
 
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/src/enrichment_facility_tests.cc
+++ b/src/enrichment_facility_tests.cc
@@ -592,15 +592,22 @@ TEST_F(EnrichmentFacilityTest, Response) {
   EXPECT_DOUBLE_EQ(src_facility->CurrentSwuCapacity(), swu_req);
 }
 
+} // namespace cycamore
+
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 cyclus::Agent* EnrichmentFacilityConstructor(cyclus::Context* ctx) {
   return new cycamore::EnrichmentFacility(ctx);
 }
+
+// required to get functionality in cyclus agent unit tests library
+#ifndef CYCLUS_AGENT_TESTS_CONNECTED
+int ConnectAgentTests();
+static int cyclus_agent_tests_connected = ConnectAgentTests();
+#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
+#endif // CYCLUS_AGENT_TESTS_CONNECTED
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_CASE_P(EnrichmentFac, FacilityTests,
                         Values(&EnrichmentFacilityConstructor));
 INSTANTIATE_TEST_CASE_P(EnrichmentFac, AgentTests,
                         Values(&EnrichmentFacilityConstructor));
-
-} // namespace cycamore

--- a/src/growth_region.cc
+++ b/src/growth_region.cc
@@ -154,10 +154,3 @@ extern "C" cyclus::Agent* ConstructGrowthRegion(cyclus::Context* ctx) {
 }
 
 } // namespace cycamore
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/src/growth_region_tests.cc
+++ b/src/growth_region_tests.cc
@@ -22,12 +22,6 @@ void GrowthRegionTests::TearDown() {
   delete ctx;
 }
 
-//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-cyclus::Agent* GrowthRegionConstructor(cyclus::Context* ctx) {
-  return new cycamore::GrowthRegion(ctx);
-}
-
-
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 bool GrowthRegionTests::ManagesCommodity(cyclus::toolkit::Commodity& commodity) {
   return region->sdmanager()->ManagesCommodity(commodity);
@@ -41,11 +35,22 @@ TEST_F(GrowthRegionTests, init) {
   EXPECT_TRUE(ManagesCommodity(commodity));
 }
 
+} // namespace cycamore
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+cyclus::Agent* GrowthRegionConstructor(cyclus::Context* ctx) {
+  return new cycamore::GrowthRegion(ctx);
+}
+
+// required to get functionality in cyclus agent unit tests library
+#ifndef CYCLUS_AGENT_TESTS_CONNECTED
+int ConnectAgentTests();
+static int cyclus_agent_tests_connected = ConnectAgentTests();
+#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
+#endif // CYCLUS_AGENT_TESTS_CONNECTED
+
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_CASE_P(GrowthRegion, RegionTests,
                         Values(&GrowthRegionConstructor));
 INSTANTIATE_TEST_CASE_P(GrowthRegion, AgentTests,
                         Values(&GrowthRegionConstructor));
-
-} // namespace cycamore
-

--- a/src/manager_inst.cc
+++ b/src/manager_inst.cc
@@ -83,10 +83,3 @@ extern "C" cyclus::Agent* ConstructManagerInst(cyclus::Context* ctx) {
 } // namespace cycamore
 
 
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/src/manager_inst_tests.cc
+++ b/src/manager_inst_tests.cc
@@ -52,6 +52,13 @@ TEST_F(ManagerInstTests, productioncapacity) {
   EXPECT_EQ(src_inst->TotalCapacity(commodity), 0);
 }
 
+// required to get functionality in cyclus agent unit tests library
+#ifndef CYCLUS_AGENT_TESTS_CONNECTED
+int ConnectAgentTests();
+static int cyclus_agent_tests_connected = ConnectAgentTests();
+#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
+#endif // CYCLUS_AGENT_TESTS_CONNECTED
+
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_CASE_P(ManagerInst, InstitutionTests,
                         Values(&ManagerInstitutionConstructor));

--- a/src/sink.cc
+++ b/src/sink.cc
@@ -178,10 +178,3 @@ extern "C" cyclus::Agent* ConstructSink(cyclus::Context* ctx) {
   return new Sink(ctx);
 }
 } // namespace cycamore
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/src/sink_tests.cc
+++ b/src/sink_tests.cc
@@ -188,6 +188,13 @@ cyclus::Agent* SinkConstructor(cyclus::Context* ctx) {
   return new cycamore::Sink(ctx);
 }
 
+// required to get functionality in cyclus agent unit tests library
+#ifndef CYCLUS_AGENT_TESTS_CONNECTED
+int ConnectAgentTests();
+static int cyclus_agent_tests_connected = ConnectAgentTests();
+#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
+#endif // CYCLUS_AGENT_TESTS_CONNECTED
+
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_CASE_P(SinkFac, FacilityTests,
                         Values(&SinkConstructor));

--- a/src/source.cc
+++ b/src/source.cc
@@ -164,10 +164,3 @@ extern "C" cyclus::Agent* ConstructSource(cyclus::Context* ctx) {
 }
 
 } // namespace cycamore
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/src/source_tests.cc
+++ b/src/source_tests.cc
@@ -193,6 +193,13 @@ cyclus::Agent* SourceConstructor(cyclus::Context* ctx) {
   return new cycamore::Source(ctx);
 }
 
+// required to get functionality in cyclus agent unit tests library
+#ifndef CYCLUS_AGENT_TESTS_CONNECTED
+int ConnectAgentTests();
+static int cyclus_agent_tests_connected = ConnectAgentTests();
+#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
+#endif // CYCLUS_AGENT_TESTS_CONNECTED
+
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_CASE_P(SourceFac, FacilityTests,
                         Values(&SourceConstructor));


### PR DESCRIPTION
```
08:56 ~/work/cyclus/cycamore [atbuild|…9]$ ldd ~/.local/lib/cyclus/libcycamore.so | grep test
08:56 ~/work/cyclus/cycamore [atbuild|…9]$ ldd ~/.local/bin/cycamore_unit_tests | grep test
    libgtest.so => /home/gidden/.local/lib/libgtest.so (0x00007f8654198000)
    libbaseagentunittests.so => /home/gidden/.local/lib/cyclus/libbaseagentunittests.so (0x00007f8653f36000)
```
