### PR TITLE
fixes hold_any(char*) runtime segfault in batchreactor.

### DIFF
--- a/src/batch_reactor.cc
+++ b/src/batch_reactor.cc
@@ -204,21 +204,21 @@ void BatchReactor::InitFrom(cyclus::QueryableBackend* b) {
 
   // initial condition inventories
   std::vector<cyclus::Cond> conds;
-  conds.push_back(cyclus::Cond("inventory", "==", "reserves"));
+  conds.push_back(cyclus::Cond("inventory", "==", std::string("reserves")));
   qr = b->Query("InitialInv", &conds);
   ics_.AddReserves(
     qr.GetVal<int>("nbatches"),
     qr.GetVal<std::string>("recipe"),
     qr.GetVal<std::string>("commod")
     );
-  conds[0] = cyclus::Cond("inventory", "==", "core");
+  conds[0] = cyclus::Cond("inventory", "==", std::string("core"));
   qr = b->Query("InitialInv", &conds);
   ics_.AddCore(
     qr.GetVal<int>("nbatches"),
     qr.GetVal<std::string>("recipe"),
     qr.GetVal<std::string>("commod")
     );
-  conds[0] = cyclus::Cond("inventory", "==", "storage");
+  conds[0] = cyclus::Cond("inventory", "==", std::string("storage"));
   qr = b->Query("InitialInv", &conds);
   ics_.AddStorage(
     qr.GetVal<int>("nbatches"),
@@ -393,19 +393,19 @@ void BatchReactor::Snapshot(cyclus::DbInit di) {
 
   // initial condition inventories
   di.NewDatum("InitialInv")
-      ->AddVal("inventory", "reserves")
+      ->AddVal("inventory", std::string("reserves"))
       ->AddVal("nbatches", ics_.n_reserves)
       ->AddVal("recipe", ics_.reserves_rec)
       ->AddVal("commod", ics_.reserves_commod)
       ->Record();
   di.NewDatum("InitialInv")
-      ->AddVal("inventory", "core")
+      ->AddVal("inventory", std::string("core"))
       ->AddVal("nbatches", ics_.n_core)
       ->AddVal("recipe", ics_.core_rec)
       ->AddVal("commod", ics_.core_commod)
       ->Record();
   di.NewDatum("InitialInv")
-      ->AddVal("inventory", "storage")
+      ->AddVal("inventory", std::string("storage"))
       ->AddVal("nbatches", ics_.n_storage)
       ->AddVal("recipe", ics_.storage_rec)
       ->AddVal("commod", ics_.storage_commod)


### PR DESCRIPTION
In the same way that the char\* handling in the the hold_any function has previously caused seg faults on mavericks before in the cyclus core (https://github.com/cyclus/cyclus/issues/943), the same use of the hold_any function here in the batch reactor causes seg faults. This simple change band-aids it by explicitly declaring the char\* a string. 

On my computer, it fixes the runtime segfaults I was getting when using the batchreactor.

Specifically, I was getting this:

```
khuff@hypatia:~/repos/cyclus/install/bin $ ./cyclus ../../decomm_inst/input/example.xml
              :
          .CL:CC CC             _Q     _Q  _Q_Q    _Q    _Q              _Q
        CC;CCCCCCCC:C;         /_\)   /_\)/_/\\)  /_\)  /_\)            /_\)
        CCCCCCCCCCCCCl       __O|/O___O|/O_OO|/O__O|/O__O|/O____________O|/O__
     CCCCCCf     iCCCLCC     /////////////////////////////////////////////////
     iCCCt  ;;;;;.  CCCC
    CCCC  ;;;;;;;;;. CClL.                          c
   CCCC ,;;       ;;: CCCC  ;                   : CCCCi
    CCC ;;         ;;  CC   ;;:                CCC`   `C;
  lCCC ;;              CCCC  ;;;:             :CC .;;. C;   ;    :   ;  :;;
  CCCC ;.              CCCC    ;;;,           CC ;    ; Ci  ;    :   ;  :  ;
   iCC :;               CC       ;;;,        ;C ;       CC  ;    :   ; .
  CCCi ;;               CCC        ;;;.      .C ;       tf  ;    :   ;  ;.
  CCC  ;;               CCC          ;;;;;;; fC :       lC  ;    :   ;    ;:
   iCf ;;               CC         :;;:      tC ;       CC  ;    :   ;     ;
  fCCC :;              LCCf      ;;;:         LC :.  ,: C   ;    ;   ; ;   ;
  CCCC  ;;             CCCC    ;;;:           CCi `;;` CC.  ;;;; :;.;.  ; ,;
    CCl ;;             CC    ;;;;              CCC    CCL
   tCCC  ;;        ;; CCCL  ;;;                  tCCCCC.
    CCCC  ;;     :;; CCCCf  ;                     ,L
     lCCC   ;;;;;;  CCCL
     CCCCCC  :;;  fCCCCC
      . CCCC     CCCC .
       .CCCCCCCCCCCCCi
          iCCCCCLCf
           .  C. ,
              :
Experimental Warning: the GrowthRegion is experimental.
Segmentation fault: 11
```

And when I debugged, it was one of these:

```
khuff@hypatia:~/repos/cyclus/install/bin $ lldb ./cyclus ../../decomm_inst/input/example.xml
Current executable set to './cyclus' (x86_64).
(lldb) run
Process 59834 launched: './cyclus' (x86_64)
              :
          .CL:CC CC             _Q     _Q  _Q_Q    _Q    _Q              _Q
        CC;CCCCCCCC:C;         /_\)   /_\)/_/\\)  /_\)  /_\)            /_\)
        CCCCCCCCCCCCCl       __O|/O___O|/O_OO|/O__O|/O__O|/O____________O|/O__
     CCCCCCf     iCCCLCC     /////////////////////////////////////////////////
     iCCCt  ;;;;;.  CCCC
    CCCC  ;;;;;;;;;. CClL.                          c
   CCCC ,;;       ;;: CCCC  ;                   : CCCCi
    CCC ;;         ;;  CC   ;;:                CCC`   `C;
  lCCC ;;              CCCC  ;;;:             :CC .;;. C;   ;    :   ;  :;;
  CCCC ;.              CCCC    ;;;,           CC ;    ; Ci  ;    :   ;  :  ;
   iCC :;               CC       ;;;,        ;C ;       CC  ;    :   ; .
  CCCi ;;               CCC        ;;;.      .C ;       tf  ;    :   ;  ;.
  CCC  ;;               CCC          ;;;;;;; fC :       lC  ;    :   ;    ;:
   iCf ;;               CC         :;;:      tC ;       CC  ;    :   ;     ;
  fCCC :;              LCCf      ;;;:         LC :.  ,: C   ;    ;   ; ;   ;
  CCCC  ;;             CCCC    ;;;:           CCi `;;` CC.  ;;;; :;.;.  ; ,;
    CCl ;;             CC    ;;;;              CCC    CCL
   tCCC  ;;        ;; CCCL  ;;;                  tCCCCC.
    CCCC  ;;     :;; CCCCf  ;                     ,L
     lCCC   ;;;;;;  CCCL
     CCCCCC  :;;  fCCCCC
      . CCCC     CCCC .
       .CCCCCCCCCCCCCi
          iCCCCCLCf
           .  C. ,
              :
Experimental Warning: the GrowthRegion is experimental.
Process 59834 stopped
* thread #1: tid = 0x57d076, 0x00007fff8d75dd96 libc++.1.dylib`std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 4, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=EXC_I386_GPFLT)
    frame #0: 0x00007fff8d75dd96 libc++.1.dylib`std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 4
libc++.1.dylib`std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 4:
-> 0x7fff8d75dd96:  testb  $0x1, (%rsi)
   0x7fff8d75dd99:  je     0x7fff8d75dda9            ; std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 23
   0x7fff8d75dd9b:  movq   0x8(%rsi), %rdx
   0x7fff8d75dd9f:  movq   0x10(%rsi), %rsi
(lldb) bt
* thread #1: tid = 0x57d076, 0x00007fff8d75dd96 libc++.1.dylib`std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 4, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=EXC_I386_GPFLT)
  * frame #0: 0x00007fff8d75dd96 libc++.1.dylib`std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 4
    frame #1: 0x0000000100fc09cc libcyclus.dylib`boost::spirit::detail::fxns<mpl_::bool_<false> >::type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, char>::clone(src=0x00007fff5fbfac88, dest=0x00007fff5fbfad00) + 60 at any.hpp:157
    frame #2: 0x000000010397a598 libcycamore.dylib`boost::spirit::basic_hold_any<char>::assign(this=0x00007fff5fbfacf8, x=0x00007fff5fbfac80) + 152 at any.hpp:242
    frame #3: 0x000000010397a4d9 libcycamore.dylib`basic_hold_any(this=0x00007fff5fbfacf8, x=0x00007fff5fbfac80) + 57 at any.hpp:223
    frame #4: 0x000000010397a48d libcycamore.dylib`basic_hold_any(this=0x00007fff5fbfacf8, x=0x00007fff5fbfac80) + 29 at any.hpp:224
    frame #5: 0x000000010399fa3b libcycamore.dylib`Cond(this=0x00007fff5fbfacc0, field=<unavailable>, op=<unavailable>, val=<unavailable>) + 139 at query_backend.h:183
    frame #6: 0x000000010392a475 libcycamore.dylib`Cond(this=0x00007fff5fbfacc0, field=<unavailable>, op=<unavailable>, val=<unavailable>) + 21 at query_backend.h:199
    frame #7: 0x000000010390a751 libcycamore.dylib`cycamore::BatchReactor::InitFrom(this=0x0000000103c245c0, b=0x00007fff5fbfc638) + 4625 at batch_reactor.cc:207
    frame #8: 0x000000010390dacf libcycamore.dylib`non-virtual thunk to cycamore::BatchReactor::InitFrom(this=0x0000000103c245c8, b=0x00007fff5fbfc638) + 47 at batch_reactor.cc:262
    frame #9: 0x00000001013c704a libcyclus.dylib`cyclus::XMLFileLoader::LoadInitialAgents(this=0x00007fff5fbfe268) + 6922 at xml_file_loader.cc:280
    frame #10: 0x00000001013c2328 libcyclus.dylib`cyclus::XMLFileLoader::LoadSim(this=0x00007fff5fbfe268) + 1288 at xml_file_loader.cc:167
    frame #11: 0x000000010000a002 cyclus`main(argc=2, argv=0x00007fff5fbff640) + 10722 at cyclus.cc:155
```

It and similar segfaults in this class disappeared with this change.
