### PR TITLE
remove greater-than req constraints from sink and enrichment

### DIFF
--- a/src/enrichment_facility.cc
+++ b/src/enrichment_facility.cc
@@ -69,7 +69,6 @@ void EnrichmentFacility::Tock() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
 EnrichmentFacility::GetMatlRequests() {
-  using cyclus::CapacityConstraint;
   using cyclus::Material;
   using cyclus::RequestPortfolio;
   using cyclus::Request;
@@ -80,13 +79,9 @@ EnrichmentFacility::GetMatlRequests() {
   double amt = mat->quantity();
 
   if (amt > cyclus::eps()) {
-    CapacityConstraint<Material> cc(amt);
-    port->AddConstraint(cc);
-
     port->AddRequest(mat, this, in_commod);
-
     ports.insert(port);
-  }  // if amt > eps
+  }
 
   return ports;
 }

--- a/src/enrichment_facility_tests.cc
+++ b/src/enrichment_facility_tests.cc
@@ -297,9 +297,7 @@ TEST_F(EnrichmentFacilityTest, AddRequests) {
 
   const std::set< CapacityConstraint<Material> >& constraints =
       ports.begin()->get()->constraints();
-  CapacityConstraint<Material> c(inv_size);
-  EXPECT_EQ(constraints.size(), 1);
-  EXPECT_EQ(*constraints.begin(), c);
+  EXPECT_EQ(constraints.size(), 0);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/sink.cc
+++ b/src/sink.cc
@@ -59,7 +59,6 @@ std::string Sink::str() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
 Sink::GetMatlRequests() {
-  using cyclus::CapacityConstraint;
   using cyclus::Material;
   using cyclus::RequestPortfolio;
   using cyclus::Request;
@@ -70,9 +69,6 @@ Sink::GetMatlRequests() {
   Material::Ptr mat = cyclus::NewBlankMaterial(amt);
 
   if (amt > cyclus::eps()) {
-    CapacityConstraint<Material> cc(amt);
-    port->AddConstraint(cc);
-
     std::vector<std::string>::const_iterator it;
     std::vector<Request<Material>*> mutuals;
     for (it = in_commods.begin(); it != in_commods.end(); ++it) {

--- a/src/sink_tests.cc
+++ b/src/sink_tests.cc
@@ -130,9 +130,7 @@ TEST_F(SinkTest, Requests) {
 
   const std::set< CapacityConstraint<Material> >& constraints =
       ports.begin()->get()->constraints();
-  ASSERT_TRUE(constraints.size() > 0);
-  EXPECT_EQ(constraints.size(), 1);
-  EXPECT_EQ(*constraints.begin(), CapacityConstraint<Material>(capacity_));
+  EXPECT_EQ(constraints.size(), 0);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
coder must have been thinking they were LT constraints.  Previously, enrichment and sink facilities would reject material transactions that were not exactly equal to what they requested.  Now they accept transactions of any quantity up to the amount they request.
