### PR TITLE
fixed uitype on manager inst

### DIFF
--- a/src/manager_inst.h
+++ b/src/manager_inst.h
@@ -49,7 +49,7 @@ class ManagerInst
 
   #pragma cyclus var {"tooltip": "facility prototypes", \
                       "doc": "a facility to be managed by the institution", \
-                      "uitype": "prototype"}
+                      "uitype": ["none", "prototype"]}
   std::vector<std::string> prototypes;
 };
 


### PR DESCRIPTION
Not only were there undocumented uitypes but they were also implemented incorrectly in cycamore! Related to cyclus/cyclus#1044
