### PR TITLE
New Reactor facility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 USE_CYCLUS("cycamore" "batch_reactor")
 
+USE_CYCLUS("cycamore" "reactor")
+
 USE_CYCLUS("cycamore" "enrichment_facility")
 
 #USE_CYCLUS("cycamore" "inpro_reactor")

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -110,6 +110,24 @@ Reactor::GetMatlRequests() {
   return ports;
 }
 
+void Reactor::GetMatlTrades(
+    const std::vector< cyclus::Trade<Material> >& trades,
+    std::vector<std::pair<cyclus::Trade<Material>,
+    Material::Ptr> >& responses) {
+  using cyclus::Trade;
+
+  std::map<std::string, MatVec> mats = PopSpent();
+  std::vector< cyclus::Trade<cyclus::Material> >::const_iterator it;
+  for (int i = 0; i < trades.size(); i++) {
+    std::string commod = trades[i].request->commodity();
+    Material::Ptr m = mats[commod].back();
+    mats[commod].pop_back();
+    responses.push_back(std::make_pair(trades[i], m));
+    res_indexes.erase(m->obj_id());
+  }
+  PushSpent(mats); // return leftovers back to spent buffer
+}
+
 void Reactor::AcceptMatlTrades(
     const std::vector< std::pair<cyclus::Trade<Material>,
     Material::Ptr> >& responses) {
@@ -185,24 +203,6 @@ Reactor::GetMatlBids(cyclus::CommodMap<Material>::type&
   }
 
   return ports;
-}
-
-void Reactor::GetMatlTrades(
-    const std::vector< cyclus::Trade<Material> >& trades,
-    std::vector<std::pair<cyclus::Trade<Material>,
-    Material::Ptr> >& responses) {
-  using cyclus::Trade;
-
-  std::map<std::string, MatVec> mats = PopSpent();
-  std::vector< cyclus::Trade<cyclus::Material> >::const_iterator it;
-  for (int i = 0; i < trades.size(); i++) {
-    std::string commod = trades[i].request->commodity();
-    Material::Ptr m = mats[commod].back();
-    mats[commod].pop_back();
-    responses.push_back(std::make_pair(trades[i], m));
-    res_indexes.erase(m->obj_id());
-  }
-  PushSpent(mats); // return leftovers back to spent buffer
 }
 
 void Reactor::Tock() {

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -25,6 +25,16 @@ Reactor::Reactor(cyclus::Context* ctx)
                                              "is experimental");
 }
 
+void Reactor::EnterNotify() {
+  cyclus::Facility::EnterNotify();
+
+  if (fuel_prefs.size() == 0) {
+    for (int i = 0; i < fuel_outcommods.size(); i++) {
+      fuel_prefs.push_back(0);
+    }
+  }
+}
+
 void Reactor::Tick() {
   // The following code must go in the Tick so they fire on the time step
   // following the cycle_step update - allowing for the all reactor events to

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -31,10 +31,41 @@ void Reactor::Tick() {
     Discharge();
     Load();
   }
+  
+  int t = context()->time();
 
   // update preferences
+  for (int i = 0; i < pref_change_times.size(); i++) {
+    int change_t = pref_change_times[i];
+    if (t != change_t) {
+      continue;
+    }
+
+    std::string incommod = pref_change_commods[i];
+    for (int j = 0; j < fuel_incommods.size(); j++) {
+      if (fuel_incommods[j] == incommod) {
+        fuel_prefs[j] = pref_change_values[i];
+        break;
+      }
+    }
+  }
 
   // update recipes
+  for (int i = 0; i < recipe_change_times.size(); i++) {
+    int change_t = recipe_change_times[i];
+    if (t != change_t) {
+      continue;
+    }
+
+    std::string incommod = recipe_change_commods[i];
+    for (int j = 0; j < fuel_incommods.size(); j++) {
+      if (fuel_incommods[j] == incommod) {
+        fuel_inrecipes[j] = recipe_change_in[i];
+        fuel_outrecipes[j] = recipe_change_out[i];
+        break;
+      }
+    }
+  }
 }
 
 std::set<cyclus::RequestPortfolio<Material>::Ptr>

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -67,7 +67,6 @@ Reactor::GetMatlRequests() {
   using cyclus::RequestPortfolio;
 
   std::set<RequestPortfolio<Material>::Ptr> ports;
-  RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
   Material::Ptr m;
 
   int n_assem_order = n_assem_core - core.count()
@@ -77,6 +76,7 @@ Reactor::GetMatlRequests() {
   }
 
   for (int i = 0; i < n_assem_order; i++) {
+    RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
     std::vector<Request<Material>*> mreqs;
     for (int j = 0; j < fuel_incommods.size(); j++) {
       std::string commod = fuel_incommods[j];
@@ -87,9 +87,9 @@ Reactor::GetMatlRequests() {
       mreqs.push_back(r);
     }
     port->AddMutualReqs(mreqs);
+    ports.insert(port);
   }
 
-  ports.insert(port);
   return ports;
 }
 

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -35,6 +35,31 @@ void Reactor::EnterNotify() {
       fuel_prefs.push_back(0);
     }
   }
+
+  // input consistency checking:
+  int n = recipe_change_times.size();
+  std::stringstream ss;
+  if (recipe_change_commods.size() != n) {
+    ss << "prototype '" << prototype() << "' has " << recipe_change_commods.size() << " recipe_change_commods vals, expected " << n << "\n";
+  }
+  if (recipe_change_in.size() != n) {
+    ss << "prototype '" << prototype() << "' has " << recipe_change_in.size() << " recipe_change_in vals, expected " << n << "\n";
+  }
+  if (recipe_change_out.size() != n) {
+    ss << "prototype '" << prototype() << "' has " << recipe_change_out.size() << " recipe_change_out vals, expected " << n << "\n";
+  }
+
+  n = pref_change_times.size();
+  if (pref_change_commods.size() != n) {
+    ss << "prototype '" << prototype() << "' has " << pref_change_commods.size() << " pref_change_commods vals, expected " << n << "\n";
+  }
+  if (pref_change_values.size() != n) {
+    ss << "prototype '" << prototype() << "' has " << pref_change_values.size() << " pref_change_values vals, expected " << n << "\n";
+  }
+
+  if (ss.str().size() > 0) {
+    throw cyclus::ValueError(ss.str());
+  }
 }
 
 void Reactor::Tick() {

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -20,6 +20,7 @@ Reactor::Reactor(cyclus::Context* ctx)
       cycle_time(0),
       refuel_time(0),
       cycle_step(0),
+      power_cap(0),
       discharged(false) {
   cyclus::Warn<cyclus::EXPERIMENTAL_WARNING>("the Reactor archetype "
                                              "is experimental");
@@ -250,6 +251,13 @@ void Reactor::Tock() {
 
   if (cycle_step == 0 && core.count() == n_assem_core) {
     Record("CYCLE_START", "");
+  }
+
+  if (cycle_step >= 0 && cycle_step < cycle_time &&
+      core.count() == n_assem_core) {
+    cyclus::toolkit::RecordTimeSeries<cyclus::toolkit::POWER>(this, power_cap);
+  } else {
+    cyclus::toolkit::RecordTimeSeries<cyclus::toolkit::POWER>(this, 0);
   }
 
   // "if" prevents starting cycle after initial deployment until core is full

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -78,6 +78,10 @@ Reactor::GetMatlRequests() {
 
   int n_assem_order = n_assem_core - core.count()
                       + n_assem_fresh - fresh.count();
+  if (n_assem_order == 0) {
+    return ports;
+  }
+
   for (int i = 0; i < n_assem_order; i++) {
     std::vector<Request<Material>*> mreqs;
     for (int j = 0; j < fuel_incommods.size(); j++) {
@@ -149,6 +153,8 @@ Reactor::GetMatlBids(cyclus::CommodMap<Material>::type&
     for (int j = 0; j < mats.size(); j++) {
       tot_qty += mats[j]->quantity();
     }
+    std::cout << "mats.size() = " << mats.size() << "\n";
+    std::cout << "tot_qty = " << tot_qty << "\n";
     cyclus::CapacityConstraint<Material> cc(tot_qty);
     port->AddConstraint(cc);
     ports.insert(port);
@@ -293,6 +299,10 @@ MatVec Reactor::SpentResFor(std::string outcommod) {
     }
   }
   return found;
+}
+
+extern "C" cyclus::Agent* ConstructReactor(cyclus::Context* ctx) {
+  return new Reactor(ctx);
 }
 
 } // namespace cycamore

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -1,0 +1,21 @@
+#include "reactor.h"
+
+namespace cycamore {
+
+Reactor::Reactor(cyclus::Context* ctx)
+    : cyclus::Facility(ctx),
+      n_batches(0),
+      assem_size(0),
+      integral_assem(0),
+      n_assem_core(0),
+      n_assem_spent(0),
+      n_assem_fresh(0),
+      cycle_time(0),
+      refuel_time(0),
+      cycle_step(0) {
+  cyclus::Warn<cyclus::EXPERIMENTAL_WARNING>("the Reactor archetype "
+                                             "is experimental");
+}
+
+} // namespace cycamore
+

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -28,6 +28,8 @@ Reactor::Reactor(cyclus::Context* ctx)
 void Reactor::EnterNotify() {
   cyclus::Facility::EnterNotify();
 
+  // If the user ommitted fuel_prefs, we set it to zeros for each fuel
+  // type.  Without this segfaults could occur - yuck.
   if (fuel_prefs.size() == 0) {
     for (int i = 0; i < fuel_outcommods.size(); i++) {
       fuel_prefs.push_back(0);

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -22,8 +22,9 @@ Reactor::Reactor(cyclus::Context* ctx)
       cycle_step(0),
       power_cap(0),
       discharged(false) {
-  cyclus::Warn<cyclus::EXPERIMENTAL_WARNING>("the Reactor archetype "
-                                             "is experimental");
+  cyclus::Warn<cyclus::EXPERIMENTAL_WARNING>(
+      "the Reactor archetype "
+      "is experimental");
 }
 
 void Reactor::EnterNotify() {
@@ -41,21 +42,27 @@ void Reactor::EnterNotify() {
   int n = recipe_change_times.size();
   std::stringstream ss;
   if (recipe_change_commods.size() != n) {
-    ss << "prototype '" << prototype() << "' has " << recipe_change_commods.size() << " recipe_change_commods vals, expected " << n << "\n";
+    ss << "prototype '" << prototype() << "' has "
+       << recipe_change_commods.size()
+       << " recipe_change_commods vals, expected " << n << "\n";
   }
   if (recipe_change_in.size() != n) {
-    ss << "prototype '" << prototype() << "' has " << recipe_change_in.size() << " recipe_change_in vals, expected " << n << "\n";
+    ss << "prototype '" << prototype() << "' has " << recipe_change_in.size()
+       << " recipe_change_in vals, expected " << n << "\n";
   }
   if (recipe_change_out.size() != n) {
-    ss << "prototype '" << prototype() << "' has " << recipe_change_out.size() << " recipe_change_out vals, expected " << n << "\n";
+    ss << "prototype '" << prototype() << "' has " << recipe_change_out.size()
+       << " recipe_change_out vals, expected " << n << "\n";
   }
 
   n = pref_change_times.size();
   if (pref_change_commods.size() != n) {
-    ss << "prototype '" << prototype() << "' has " << pref_change_commods.size() << " pref_change_commods vals, expected " << n << "\n";
+    ss << "prototype '" << prototype() << "' has " << pref_change_commods.size()
+       << " pref_change_commods vals, expected " << n << "\n";
   }
   if (pref_change_values.size() != n) {
-    ss << "prototype '" << prototype() << "' has " << pref_change_values.size() << " pref_change_values vals, expected " << n << "\n";
+    ss << "prototype '" << prototype() << "' has " << pref_change_values.size()
+       << " pref_change_values vals, expected " << n << "\n";
   }
 
   if (ss.str().size() > 0) {
@@ -66,7 +73,8 @@ void Reactor::EnterNotify() {
 void Reactor::Tick() {
   // The following code must go in the Tick so they fire on the time step
   // following the cycle_step update - allowing for the all reactor events to
-  // occur and be recorded on the "beginning" of a time step.  Another reason they
+  // occur and be recorded on the "beginning" of a time step.  Another reason
+  // they
   // can't go at the beginnin of the Tock is so that resource exchange has a
   // chance to occur after the discharge on this same time step.
   if (cycle_step == cycle_time) {
@@ -114,18 +122,16 @@ void Reactor::Tick() {
       }
     }
   }
-
 }
 
-std::set<cyclus::RequestPortfolio<Material>::Ptr>
-Reactor::GetMatlRequests() {
+std::set<cyclus::RequestPortfolio<Material>::Ptr> Reactor::GetMatlRequests() {
   using cyclus::RequestPortfolio;
 
   std::set<RequestPortfolio<Material>::Ptr> ports;
   Material::Ptr m;
 
-  int n_assem_order = n_assem_core - core.count()
-                      + n_assem_fresh - fresh.count();
+  int n_assem_order =
+      n_assem_core - core.count() + n_assem_fresh - fresh.count();
   if (n_assem_order == 0) {
     return ports;
   }
@@ -149,13 +155,13 @@ Reactor::GetMatlRequests() {
 }
 
 void Reactor::GetMatlTrades(
-    const std::vector< cyclus::Trade<Material> >& trades,
-    std::vector<std::pair<cyclus::Trade<Material>,
-    Material::Ptr> >& responses) {
+    const std::vector<cyclus::Trade<Material> >& trades,
+    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
+        responses) {
   using cyclus::Trade;
 
   std::map<std::string, MatVec> mats = PopSpent();
-  std::vector< cyclus::Trade<cyclus::Material> >::const_iterator it;
+  std::vector<cyclus::Trade<cyclus::Material> >::const_iterator it;
   for (int i = 0; i < trades.size(); i++) {
     std::string commod = trades[i].request->commodity();
     Material::Ptr m = mats[commod].back();
@@ -163,15 +169,13 @@ void Reactor::GetMatlTrades(
     responses.push_back(std::make_pair(trades[i], m));
     res_indexes.erase(m->obj_id());
   }
-  PushSpent(mats); // return leftovers back to spent buffer
+  PushSpent(mats);  // return leftovers back to spent buffer
 }
 
-void Reactor::AcceptMatlTrades(
-    const std::vector< std::pair<cyclus::Trade<Material>,
-    Material::Ptr> >& responses) {
-
-  std::vector< std::pair<cyclus::Trade<cyclus::Material>,
-                         cyclus::Material::Ptr> >::const_iterator trade;
+void Reactor::AcceptMatlTrades(const std::vector<
+    std::pair<cyclus::Trade<Material>, Material::Ptr> >& responses) {
+  std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                        cyclus::Material::Ptr> >::const_iterator trade;
 
   std::stringstream ss;
   int nload = std::min((int)responses.size(), n_assem_core - core.count());
@@ -193,9 +197,8 @@ void Reactor::AcceptMatlTrades(
   }
 }
 
-std::set<cyclus::BidPortfolio<Material>::Ptr>
-Reactor::GetMatlBids(cyclus::CommodMap<Material>::type&
-                          commod_requests) {
+std::set<cyclus::BidPortfolio<Material>::Ptr> Reactor::GetMatlBids(
+    cyclus::CommodMap<Material>::type& commod_requests) {
   using cyclus::BidPortfolio;
 
   std::set<BidPortfolio<Material>::Ptr> ports;
@@ -297,7 +300,7 @@ std::map<std::string, MatVec> Reactor::PeekSpent() {
 bool Reactor::Discharge() {
   if (n_assem_spent - spent.count() < n_assem_batch) {
     Record("DISCHARGE", "failed");
-    return false; // not enough room in spent buffer
+    return false;  // not enough room in spent buffer
   }
 
   int npop = std::min(n_assem_batch, core.count());
@@ -369,7 +372,8 @@ void Reactor::index_res(cyclus::Resource::Ptr m, std::string incommod) {
       return;
     }
   }
-  throw ValueError("cycamore::Reactor - received unsupported incommod material");
+  throw ValueError(
+      "cycamore::Reactor - received unsupported incommod material");
 }
 
 std::map<std::string, MatVec> Reactor::PopSpent() {
@@ -388,7 +392,7 @@ std::map<std::string, MatVec> Reactor::PopSpent() {
 
   return mapped;
 }
-  
+
 void Reactor::PushSpent(std::map<std::string, MatVec> leftover) {
   std::map<std::string, MatVec>::iterator it;
   for (it = leftover.begin(); it != leftover.end(); ++it) {
@@ -397,19 +401,19 @@ void Reactor::PushSpent(std::map<std::string, MatVec> leftover) {
     spent.Push(it->second);
   }
 }
-  
+
 void Reactor::Record(std::string name, std::string val) {
-  context()->NewDatum("ReactorEvents")
-    ->AddVal("AgentId", id())
-    ->AddVal("Time", context()->time())
-    ->AddVal("Event", name)
-    ->AddVal("Value", val)
-    ->Record();
+  context()
+      ->NewDatum("ReactorEvents")
+      ->AddVal("AgentId", id())
+      ->AddVal("Time", context()->time())
+      ->AddVal("Event", name)
+      ->AddVal("Value", val)
+      ->Record();
 }
 
 extern "C" cyclus::Agent* ConstructReactor(cyclus::Context* ctx) {
   return new Reactor(ctx);
 }
 
-} // namespace cycamore
-
+}  // namespace cycamore

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -17,5 +17,94 @@ Reactor::Reactor(cyclus::Context* ctx)
                                              "is experimental");
 }
 
+void Reactor::Tick() {
+  if (cycle_step == cycle_time) {
+    Transmute();
+  } else if (cycle_step == cycle_time + refuel_time) {
+    Discharge();
+    Load();
+  }
+
+  // update preferences
+
+  // update recipes
+}
+
+// DRE code here - request enough fuel to fill fresh and core inventories.  Fill core first.
+
+void Reactor::Tock() {
+  if (cycle_step >= cycle_time) {
+    Load();
+  }
+
+  if (cycle_step < cycle_time + refuel_time || core.space() < cyclus::eps()) {
+    // move forward if in cycle operation or refueling, but halt if waiting
+    // for fuel at beginning of cycle.
+    cycle_step++;
+  }
+  if (cycle_step > cycle_time + refuel_time) {
+    cycle_step = 0;
+  }
+}
+
+void Reactor::Transmute() {
+  MatVect old;
+  if (discrete_mode()) {
+    old = core.PopN(assem_per_discharge());
+  } else {
+    old = core.PopQty(assem_per_discharge() * assem_size);
+  }
+  MatVect tail = core.PopN(core.count());
+
+  for (int i = 0; i < old.size(); i++) {
+    int id = old[i]->obj_id();
+    old[i]->Transmute(context()->GetRecipe(fuel_outrecipe(id)));
+  }
+  core.Push(old);
+  core.Push(tail);
+}
+
+void Reactor::Discharge() {
+  double qty_pop = assem_per_discharge() * assem_size;
+  if (spent.space() < qty_pop) {
+    return; // not enough space in spent fuel inventory
+  }
+
+  MatVect old;
+  if (discrete_mode()) {
+    old = core.PopN(assem_per_discharge());
+  } else {
+    old = core.PopQty(qty_pop);
+  }
+
+  spent.Push(old);
+}
+
+void Reactor::Load() {
+  if (core.space() < cyclus::eps()) {
+    return; // core is full
+  }
+
+  if (discrete_mode()) {
+    while (core.space() > assem_size && fresh.quantity() >= assem_size) {
+      if (integral_assem) {
+        core.Push(fresh.Pop());
+      } else {
+        core.Push(fresh.Pop(assem_size));
+      }
+    }
+  } else {
+    core.Push(fresh.Pop(std::min(core.space(), fresh.quantity())));
+  }
+}
+
 } // namespace cycamore
+
+double Reactor::assem_per_discharge() {
+  if (discrete_mode()) {
+    return static_cast<int>(n_assem_core / n_batches);
+  } else {
+    return static_cast<double>(n_assem_core) / n_batches;
+  }
+}
 

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -242,54 +242,54 @@ class Reactor : public cyclus::Facility {
   /////////// preference changes ///////////
   #pragma cyclus var { \
     "default": [], \
-    "doc": "The time step on which to change the request preference for a " \
+    "doc": "A time step on which to change the request preference for a " \
            "particular fresh fuel type.", \
   }
   std::vector<int> pref_change_times;
   #pragma cyclus var { \
     "default": [], \
     "doc": "The input commodity for a particular fuel preference change." \
-           " Same order as and direct correspondence to the specified preference change time steps.", \
+           " Same order as and direct correspondence to the specified preference change times.", \
     "uitype": ["oneormore", "incommodity"], \
   }
   std::vector<std::string> pref_change_commods;
   #pragma cyclus var { \
     "default": [], \
     "doc": "The new/changed request preference for a particular fresh fuel." \
-           " Same order as and direct correspondence to the specified preference change time steps.", \
+           " Same order as and direct correspondence to the specified preference change times.", \
   }
   std::vector<double> pref_change_values;
 
   ///////////// recipe changes ///////////
   #pragma cyclus var { \
     "default": [], \
-    "doc": "The time step on which to change the input-output recipe pair for a requested fresh fuel.", \
+    "doc": "A time step on which to change the input-output recipe pair for a requested fresh fuel.", \
   }
   std::vector<int> recipe_change_times;
   #pragma cyclus var { \
     "default": [], \
     "doc": "The input commodity indicating fresh fuel for which recipes will be changed." \
-           " Same order as and direct correspondence to the specified recipe change time steps.", \
+           " Same order as and direct correspondence to the specified recipe change times.", \
     "uitype": ["oneormore", "incommodity"], \
   }
   std::vector<std::string> recipe_change_commods;
   #pragma cyclus var { \
     "default": [], \
     "doc": "The new input recipe to use for this recipe change." \
-           " Same order as and direct correspondence to the specified recipe change time steps.", \
+           " Same order as and direct correspondence to the specified recipe change times.", \
     "uitype": ["oneormore", "recipe"], \
   }
   std::vector<std::string> recipe_change_in;
   #pragma cyclus var { \
     "default": [], \
     "doc": "The new output recipe to use for this recipe change." \
-           " Same order as and direct correspondence to the specified recipe change time steps.", \
+           " Same order as and direct correspondence to the specified recipe change times.", \
     "uitype": ["oneormore", "recipe"], \
   }
   std::vector<std::string> recipe_change_out;
 
-  // should be hidden in ui (internal only). True if fuel has been discharged
-  // this cycle.
+  // should be hidden in ui (internal only). True if fuel has already been
+  // discharged this cycle.
   #pragma cyclus var {"default": 0, "doc": "This should NEVER be set manually."}
   bool discharged;
 };

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -57,11 +57,11 @@ class Reactor : public cyclus::Facility {
   virtual void Tick();
   virtual void Tock();
 
-  void AcceptMatlTrades(
+  virtual void AcceptMatlTrades(
       const std::vector< std::pair<cyclus::Trade<cyclus::Material>,
       cyclus::Material::Ptr> >& responses);
 
-  std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr> GetMatlRequests();
+  virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr> GetMatlRequests();
 
   virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
       GetMatlBids(cyclus::CommodMap<cyclus::Material>::type&
@@ -98,14 +98,17 @@ class Reactor : public cyclus::Facility {
   /// Records a reactor event to the output db with the given name and note val.
   void Record(std::string name, std::string val);
 
-  /// Returns pointers to all the spent fuel materials that should be offered
-  /// on a particular outcommod without removing them from the spent
-  /// fuel buffer.
-  cyclus::toolkit::MatVec SpentResFor(std::string outcommod);
+  /// Complement of PopSpent - must be called with all materials passed that
+  /// were not traded away to other agents.
+  void PushSpent(std::map<std::string, cyclus::toolkit::MatVec> leftover);
 
-  /// Returns a single assembly for the specified outcommod - removing it from
+  /// Returns all spent assemblies indexed by outcommod - removing them from
   /// the spent fuel buffer.
-  cyclus::Material::Ptr PopSpentRes(std::string outcommod);
+  std::map<std::string, cyclus::toolkit::MatVec> PopSpent();
+
+  /// Returns all spent assemblies indexed by outcommod without removing them
+  /// from the spent fuel buffer.
+  std::map<std::string, cyclus::toolkit::MatVec> PeekSpent();
 
   //////////// inventory and core params ////////////
   #pragma cyclus var { \

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -92,9 +92,6 @@ class Reactor : public cyclus::Facility {
   /// Store fuel info index for the given resource received on incommod.
   void index_res(cyclus::Resource::Ptr m, std::string incommod);
 
-  /// Returns true if the reactor is operating in discrete assembly mode.
-  bool discrete_mode() {return n_assem_core > 1 || n_batches == 1;};
-
   /// Discharge a batch from the core if there is room in the spent fuel
   /// inventory.  Returns true if a batch was successfully discharged.
   bool Discharge();
@@ -221,11 +218,11 @@ class Reactor : public cyclus::Facility {
   #pragma cyclus var { \
     "default": [], \
   }
-  std::vector<std::string> recipe_change_incommods;
+  std::vector<std::string> recipe_change_in;
   #pragma cyclus var { \
     "default": [], \
   }
-  std::vector<std::string> recipe_change_outcommods;
+  std::vector<std::string> recipe_change_out;
 
 };
 

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -225,11 +225,6 @@ class Reactor : public cyclus::Facility {
   }
   std::vector<double> fuel_prefs;
 
-  // This variable should be hidden/unavailable in ui.  Maps resource object
-  // id's to the index for the incommod through which they were received.
-  #pragma cyclus var {"default": {}, "doc": "This should NEVER be set manually."}
-  std::map<int, int> res_indexes;
-
   // Resource inventories - these must be defined AFTER/BELOW the member vars
   // referenced (e.g. n_batch_fresh, assem_size, etc.).
   #pragma cyclus var {"capacity": "n_assem_fresh * assem_size"}
@@ -292,6 +287,12 @@ class Reactor : public cyclus::Facility {
   // discharged this cycle.
   #pragma cyclus var {"default": 0, "doc": "This should NEVER be set manually."}
   bool discharged;
+
+  // This variable should be hidden/unavailable in ui.  Maps resource object
+  // id's to the index for the incommod through which they were received.
+  #pragma cyclus var {"default": {}, "doc": "This should NEVER be set manually."}
+  std::map<int, int> res_indexes;
+
 };
 
 } // namespace cycamore

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -22,7 +22,7 @@ namespace cycamore {
 // The Reactor will have 3 resource buffers (all with automatically computed
 // capacities based on above params):
 //
-// * fresh: capacity = n_assem_fresh * assem_size
+// * fresh: capacity = n_assem_fresh * assem_size + eps
 //
 // * core: capacity = n_assem_core * assem_size
 //
@@ -43,32 +43,18 @@ namespace cycamore {
 // enough material can be acquired to complete the full assembly.  In this
 // mode, partial assemblies may not be inserted into the core.  When in this
 // mode, resources will never be split/combined by the reactor post assembly
-// discretization.
-// Under either of the following conditions, a reactor will operate in
-// discrete assembly mode:
+// discretization.  Number of assemblies discharged per cycle is computed:
 //
-// * n_assem_core == n_batches:  pop one assembly per cycle
+//     floor(n_assem_core / n_batches)
 //
-// * n_assem_core > 1:  pop floor(n_assem_core / n_batches) assemblies per cycle
-//
-// If neither of those conditions are met (i.e. n_assem_core == 1 && n_assem_core !=
-// n_batches), then the reactor will operate in continuous assembly mode.  In
-// this mode it discharges 1 / n_batches fraction of the single assembly from
-// the core at the end of each cycle, and the same quantity will be
-// extracted/split from the (not assembly discretized) fresh fuel buffer
-// (or requested on DRE if no fresh) and inserted into the core.  Material can
-// be requested+accepted in non-assembly sized quanta.
-//
-// Time to make it code generatable? - Yes  Bring into compliance? - Yes.
-// The BatchReactor currently has no state variables. A UINT type might be
-// useful here.  We should scavenge the batch reactor for pieces as we
-// reimplement a new code-generated version.
+// If that number is zero or results in a significantly rounded batch size,
+// the reactor will throw an exception or print a warning respectively.
 //
 // Meta-data associated with resource objects in inventory (e.g. the in-commod
 // on which they were received) should be associated with resources based on
-// obj_id.  This is necessary for handling the case where in continuous
-// assembly mode where resources are potentially combined/split inside
-// buffers during extraction - and also when decay could change Resource::id.
+// obj_id.  This is necessary for maintaining continuity in the face of
+// potential decay calcs and other things that might change the regular
+// Resource::id.
 
 class Reactor : public cyclus::Facility {
  public:

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -126,7 +126,7 @@ class Reactor : public cyclus::Facility {
   /// Top up core inventory as much as possible.
   void Load();
 
-  /// Transmute the batch in the core that is about to be discharged to its
+  /// Transmute the batch that is about to be discharged from the core to its
   /// fully burnt state as defined by its outrecipe.
   void Transmute();
 

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -47,42 +47,42 @@ class Reactor : public cyclus::Facility {
 "niche": "reactor", \
 "doc": \
   "Reactor is a simple, general reactor based on static compositional" \
-  "transformations to model fuel burnup.  The user specifies a set of input" \
-  "fuels and corresponding burnt compositions that fuel is transformed to when" \
-  "it is discharged from the core.  No incremental transmutation takes place." \
-  "Rather, at the end of an operational cycle, the batch being discharged from" \
-  "the core is instantaneously transmuted from its original fresh fuel" \
-  "composition into its spent fuel form." \
+  " transformations to model fuel burnup.  The user specifies a set of input" \
+  " fuels and corresponding burnt compositions that fuel is transformed to when" \
+  " it is discharged from the core.  No incremental transmutation takes place." \
+  " Rather, at the end of an operational cycle, the batch being discharged from" \
+  " the core is instantaneously transmuted from its original fresh fuel" \
+  " composition into its spent fuel form." \
   "\n\n" \
   "Each fuel is identified by a specific input commodity and has an associated" \
-  "input recipe (nuclide composition), output recipe, output commidity, and" \
-  "preference.  The preference identifies which input fuels are preferred when" \
-  "requesting.  Changes in these preferences can be specified as a function of" \
-  "time using the pref_change variables.  Changes in the input-output recipe" \
-  "compositions can also be specified as a function of time using the" \
-  "recipe_change variables." \
+  " input recipe (nuclide composition), output recipe, output commidity, and" \
+  " preference.  The preference identifies which input fuels are preferred when" \
+  " requesting.  Changes in these preferences can be specified as a function of" \
+  " time using the pref_change variables.  Changes in the input-output recipe" \
+  " compositions can also be specified as a function of time using the" \
+  " recipe_change variables." \
   "\n\n" \
   "The reactor treats fuel as individual assemblies that are never split," \
-  "combined or otherwise treated in any non-discrete way.  Fuel is requested" \
-  "in full-or-nothing assembly sized quanta.  If real-world assembly modeling" \
-  "is unnecessary, parameters can be adjusted (e.g. n_assem_core, assem_size," \
-  "n_assem_batch).  At the end of every cycle, a full batch is discharged from" \
-  "the core consisting of n_assem_batch assemblies of assem_size kg. The" \
-  "reactor also has a specifiable refueling time period following the end of" \
-  "each cycle at the end of which it will resume operation on the next cycle" \
-  "*if* it has enough fuel for a full core; otherwise it waits until it has" \
-  "enough fresh fuel assemblies." \
+  " combined or otherwise treated in any non-discrete way.  Fuel is requested" \
+  " in full-or-nothing assembly sized quanta.  If real-world assembly modeling" \
+  " is unnecessary, parameters can be adjusted (e.g. n_assem_core, assem_size," \
+  " n_assem_batch).  At the end of every cycle, a full batch is discharged from" \
+  " the core consisting of n_assem_batch assemblies of assem_size kg. The" \
+  " reactor also has a specifiable refueling time period following the end of" \
+  " each cycle at the end of which it will resume operation on the next cycle" \
+  " *if* it has enough fuel for a full core; otherwise it waits until it has" \
+  " enough fresh fuel assemblies." \
   "\n\n" \
   "In addition to its core, the reactor has an on-hand fresh fuel inventory" \
-  "and a spent fuel inventory whose capacities are specified by n_assem_fresh" \
-  "and n_assem_spent respectively.  Each time step the reactor will attempt to" \
-  "acquire enough fresh fuel to fill its fresh fuel inventory (and its core if" \
-  "the core isn't currently full).  If the fresh fuel inventory has zero" \
-  "capacity, fuel will be ordered just-in-time after the end of each" \
-  "operational cycle before the next begins.  If the spent fuel inventory" \
-  "becomes full, the reactor will halt operation at the end of the next cycle" \
-  "until there is more room.  Each time step, the reactor will try to trade" \
-  "away as much of its spent fuel inventory as possible.", \
+  " and a spent fuel inventory whose capacities are specified by n_assem_fresh" \
+  " and n_assem_spent respectively.  Each time step the reactor will attempt to" \
+  " acquire enough fresh fuel to fill its fresh fuel inventory (and its core if" \
+  " the core isn't currently full).  If the fresh fuel inventory has zero" \
+  " capacity, fuel will be ordered just-in-time after the end of each" \
+  " operational cycle before the next begins.  If the spent fuel inventory" \
+  " becomes full, the reactor will halt operation at the end of the next cycle" \
+  " until there is more room.  Each time step, the reactor will try to trade" \
+  " away as much of its spent fuel inventory as possible.", \
 }
 
  public:

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -95,17 +95,23 @@ class Reactor : public cyclus::Facility {
   /// fully burnt state as defined by its outrecipe.
   void Transmute();
 
-  /// record a reactor event
+  /// Records a reactor event to the output db with the given name and note val.
   void Record(std::string name, std::string val);
 
+  /// Returns pointers to all the spent fuel materials that should be offered
+  /// on a particular outcommod without removing them from the spent
+  /// fuel buffer.
   cyclus::toolkit::MatVec SpentResFor(std::string outcommod);
 
+  /// Returns a single assembly for the specified outcommod - removing it from
+  /// the spent fuel buffer.
   cyclus::Material::Ptr PopSpentRes(std::string outcommod);
 
   //////////// inventory and core params ////////////
   #pragma cyclus var { \
     "doc": "Number of assemblies that constitute a single batch." \
-           "This is the number of assemblies discharged from the core fully burned each cycle.", \
+           "This is the number of assemblies discharged from the core fully burned each cycle." \
+           "Batch size is equivalent to ``n_assem_batch / n_assem_core``.", \
   }
   int n_assem_batch;
   #pragma cyclus var { \
@@ -114,7 +120,6 @@ class Reactor : public cyclus::Facility {
   }
   double assem_size;
   #pragma cyclus var { \
-    "doc": "", \
     "doc": "Number of assemblies that constitute a full core.", \
   }
   int n_assem_core;
@@ -125,19 +130,19 @@ class Reactor : public cyclus::Facility {
   int n_assem_spent;
   #pragma cyclus var { \
     "default": 0, \
-    "doc": "Number of fresh fuel assemblies to keep on-hand.", \
+    "doc": "Number of fresh fuel assemblies to keep on-hand if possible.", \
   }
   int n_assem_fresh;
 
   ///////// cycle params ///////////
   #pragma cyclus var { \
     "doc": "The duration of a full operational cycle (excluding refueling time) in time steps.", \
-    "units": "time step duration", \
+    "units": "time steps", \
   }
   int cycle_time;
   #pragma cyclus var { \
-    "doc": "The duration of a full refueling period - the time between a cycle end" \
-           " and the start of the next cycle.", \
+    "doc": "The duration of a full refueling period - the minimum time between" \
+           " a cycle end and the start of the next cycle.", \
     "units": "time steps", \
   }
   int refuel_time;
@@ -152,7 +157,7 @@ class Reactor : public cyclus::Facility {
   /////// fuel specifications /////////
   #pragma cyclus var { \
     "uitype": ["oneormore", "incommodity"], \
-    "doc": "Ordered list of input commodities for requesting fuel.", \
+    "doc": "Ordered list of input commodities on which to requesting fuel.", \
   }
   std::vector<std::string> fuel_incommods;
   #pragma cyclus var { \
@@ -195,7 +200,6 @@ class Reactor : public cyclus::Facility {
   #pragma cyclus var {"capacity": "n_assem_spent * assem_size"}
   cyclus::toolkit::ResBuf<cyclus::Material> spent;
 
-
   /////////// preference changes ///////////
   #pragma cyclus var { \
     "default": [], \
@@ -207,6 +211,7 @@ class Reactor : public cyclus::Facility {
     "default": [], \
     "doc": "The input commodity for a particular fuel preference change." \
            " Same order as and direct correspondence to the specified preference change time steps.", \
+    "uitype": ["oneormore", "incommodity"], \
   }
   std::vector<std::string> pref_change_commods;
   #pragma cyclus var { \
@@ -226,18 +231,21 @@ class Reactor : public cyclus::Facility {
     "default": [], \
     "doc": "The input commodity indicating fresh fuel for which recipes will be changed." \
            " Same order as and direct correspondence to the specified recipe change time steps.", \
+    "uitype": ["oneormore", "incommodity"], \
   }
   std::vector<std::string> recipe_change_commods;
   #pragma cyclus var { \
     "default": [], \
     "doc": "The new input recipe to use for this recipe change." \
            " Same order as and direct correspondence to the specified recipe change time steps.", \
+    "uitype": ["oneormore", "recipe"], \
   }
   std::vector<std::string> recipe_change_in;
   #pragma cyclus var { \
     "default": [], \
     "doc": "The new output recipe to use for this recipe change." \
            " Same order as and direct correspondence to the specified recipe change time steps.", \
+    "uitype": ["oneormore", "recipe"], \
   }
   std::vector<std::string> recipe_change_out;
 

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -212,7 +212,7 @@ class Reactor : public cyclus::Facility {
   std::vector<std::string> fuel_outrecipes;
   #pragma cyclus var { \
     "uitype": ["oneormore", "incommodity"], \
-    "doc": "Output commodities on which to offer spent fuel originally received as each particular " \ 
+    "doc": "Output commodities on which to offer spent fuel originally received as each particular " \
            " input commodity (same order)." \
   }
   std::vector<std::string> fuel_outcommods;

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -138,7 +138,7 @@ class Reactor : public cyclus::Facility {
   }
   int refuel_time;
   #pragma cyclus var { \
-    "default": "cycle_time + refuel_time + 1", \
+    "default": 0, \
     "doc": "Number of time steps since the beginning of the last cycle.", \
   }
   int cycle_step;
@@ -193,6 +193,7 @@ class Reactor : public cyclus::Facility {
   #pragma cyclus var {"capacity": "n_assem_spent * assem_size"}
   cyclus::toolkit::ResBuf<cyclus::Material> spent;
 
+
   /////////// preference changes ///////////
   #pragma cyclus var { \
     "default": [], \
@@ -225,6 +226,10 @@ class Reactor : public cyclus::Facility {
   }
   std::vector<std::string> recipe_change_out;
 
+  // should be hidden in ui (internal only). True if fuel has been discharged
+  // this cycle.
+  #pragma cyclus var {"default": 0}
+  bool discharged;
 };
 
 } // namespace cycamore

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -293,6 +293,13 @@ class Reactor : public cyclus::Facility {
   #pragma cyclus var {"default": {}, "doc": "This should NEVER be set manually."}
   std::map<int, int> res_indexes;
 
+  #pragma cyclus var { \
+    "default": 0, \
+    "doc": "Amount of electrical power the facility produces when operating normally.", \
+    "units": "MWe", \
+  }
+  double power_cap;
+
 };
 
 } // namespace cycamore

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -102,18 +102,33 @@ class Reactor : public cyclus::Facility {
   #pragma cyclus
 
  private:
+  std::string fuel_outcommod(int obj_id);
+  std::string fuel_inrecipe(int obj_id);
+  std::string fuel_outrecipe(int obj_id);
+  std::string fuel_pref(int obj_id);
+  /// Returns true if the reactor is operating in discrete assembly mode.
+  bool discrete_mode() {return n_assem_core > 1 || n_batches == 1};
+
+  /// discharge a batch from the core
+  void Discharge();
+
+  /// top up core inventory if possible
+  void Load();
+
+  double assem_per_discharge();
+
   // inventory and core params
   #pragma cyclus var {}
   double n_batches;
   #pragma cyclus var {}
   double assem_size;
-  #pragma cyclus var {'default': 1}
+  #pragma cyclus var {"default": 1}
   bool integral_assem;
-  #pragma cyclus var {'default': 'n_batches'}
+  #pragma cyclus var {"default": 'n_batches'}
   int n_assem_core;
-  #pragma cyclus var {'default': 1e250}
+  #pragma cyclus var {"default": 1000000000}
   int n_assem_spent;
-  #pragma cyclus var {'default': 'n_assem_core'}
+  #pragma cyclus var {"default": 'n_assem_core'}
   int n_assem_fresh;
 
   // cycle params
@@ -121,43 +136,36 @@ class Reactor : public cyclus::Facility {
   int cycle_time;
   #pragma cyclus var {}
   int refuel_time;
-  #pragma cyclus var {'default': 0}
+  #pragma cyclus var { \
+    "default": 0, \
+    "doc": "number of time steps since the beginning of the last cycle", \
+  }
   int cycle_step;
 
   // fuel specifications
-  #pragma cyclus var {}
-  std::vector<std::string> incommods;
-  #pragma cyclus var {}
-  std::vector<std::string> inrecipes;
-  #pragma cyclus var {}
-  std::vector<std::string> outrecipes;
-  #pragma cyclus var {}
-  std::vector<std::string> outcommods;
-  #pragma cyclus var {'default': []} // if this is empty, assume zero for all
-  std::vector<double> incommod_prefs;
+  #pragma cyclus var { \
+    "uitype": ["oneormore", "incommodity"], \
+  }
+  std::vector<std::string> fuel_incommods;
+  #pragma cyclus var { \
+    "uitype": ["oneormore", "recipe"], \
+  }
+  std::vector<std::string> fuel_inrecipes;
+  #pragma cyclus var { \
+    "uitype": ["oneormore", "recipe"], \
+  }
+  std::vector<std::string> fuel_outrecipes;
+  #pragma cyclus var { \
+    "uitype": ["oneormore", "incommodity"], \
+  }
+  std::vector<std::string> fuel_outcommods;
+  #pragma cyclus var {"default": []} // if this is empty, assume zero for all
+  std::vector<double> fuel_prefs;
 
-  // This variable should be hidden/unavailable in ui.  Maps resource id's to
-  // the incommods through which they were received.
+  // This variable should be hidden/unavailable in ui.  Maps resource object
+  // id's to the incommods through which they were received.
   #pragma cyclus var {}
   std::map<int, std::string> res_commods;
-
-  // preference changes
-  #pragma cyclus var {'default': []}
-  std::vector<int> pref_change_times;
-  #pragma cyclus var {'default': []}
-  std::vector<std::string> pref_change_commods;
-  #pragma cyclus var {'default': []}
-  std::vector<double> pref_change_values;
-
-  // recipe changes
-  #pragma cyclus var {'default': []}
-  std::vector<int> recipe_change_times;
-  #pragma cyclus var {'default': []}
-  std::vector<std::string> recipe_change_commods;
-  #pragma cyclus var {'default': []}
-  std::vector<std::string> recipe_change_incommods;
-  #pragma cyclus var {'default': []}
-  std::vector<std::string> recipe_change_outcommods;
 
   // Resource inventories
   #pragma cyclus var {'capacity': 'n_assem_fresh * assem_size'}
@@ -166,6 +174,24 @@ class Reactor : public cyclus::Facility {
   ResBuf<Material> core;
   #pragma cyclus var {'capacity': 'n_assem_spent * assem_size'}
   ResBuf<Material> spent;
+
+  // preference changes
+  #pragma cyclus var {"default": []}
+  std::vector<int> pref_change_times;
+  #pragma cyclus var {"default": []}
+  std::vector<std::string> pref_change_commods;
+  #pragma cyclus var {"default": []}
+  std::vector<double> pref_change_values;
+
+  // recipe changes
+  #pragma cyclus var {"default": []}
+  std::vector<int> recipe_change_times;
+  #pragma cyclus var {"default": []}
+  std::vector<std::string> recipe_change_commods;
+  #pragma cyclus var {"default": []}
+  std::vector<std::string> recipe_change_incommods;
+  #pragma cyclus var {"default": []}
+  std::vector<std::string> recipe_change_outcommods;
 
 };
 

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -138,7 +138,7 @@ class Reactor : public cyclus::Facility {
   }
   int refuel_time;
   #pragma cyclus var { \
-    "default": 0, \
+    "default": "cycle_time + refuel_time + 1", \
     "doc": "Number of time steps since the beginning of the last cycle.", \
   }
   int cycle_step;

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -19,13 +19,6 @@ namespace cycamore {
 // * n_assem_fresh (int, default n_assem_core) - the number of fresh assemblies to keep on
 //   hand
 //
-// * integral_assem (bool, default true) - true if requests require DRE to
-//   match all or nothing of each assembly.  Note that this is different from
-//   and roughly orthogonal to whether the reactor is operating in discrete or
-//   continuous assembly mode.  “True” is the recommended value for this
-//   variable.  “False” can result in materials being combined resulting in
-//   incorrect transmutations.
-//
 // The Reactor will have 3 resource buffers (all with automatically computed
 // capacities based on above params):
 //
@@ -44,16 +37,13 @@ namespace cycamore {
 // * There is no room in the spent_fuel buffer to discharge a fully-burned assembly to.
 //
 // If a reactor is operating in discrete assembly mode, when it receives fresh
-// fuel, it discretizes the material into assembly quanta (of size
+// fuel, it only requests and accepts material in discrete assembly quanta (of size
 // assem_size).  Discrete assembly mode is the recommended mode of operation
 // for a reactor.  If a partial assembly is received, it is stored until
 // enough material can be acquired to complete the full assembly.  In this
 // mode, partial assemblies may not be inserted into the core.  When in this
 // mode, resources will never be split/combined by the reactor post assembly
-// discretization.  If integral_assem is false, then this discretization will
-// happen upon extraction of an assembly’s worth of material from the fresh
-// inventory for placement into the core.  If integral_assem is true, then
-// this discretization will happen automatically as part of resource exchange.
+// discretization.
 // Under either of the following conditions, a reactor will operate in
 // discrete assembly mode:
 //
@@ -65,27 +55,20 @@ namespace cycamore {
 // n_batches), then the reactor will operate in continuous assembly mode.  In
 // this mode it discharges 1 / n_batches fraction of the single assembly from
 // the core at the end of each cycle, and the same quantity will be
-// extracted/split from the (not assembly discretized) fresh fresh fuel buffer
-// (or requested on DRE if no fresh) and inserted into the core.
+// extracted/split from the (not assembly discretized) fresh fuel buffer
+// (or requested on DRE if no fresh) and inserted into the core.  Material can
+// be requested+accepted in non-assembly sized quanta.
 //
 // Time to make it code generatable? - Yes  Bring into compliance? - Yes.
 // The BatchReactor currently has no state variables. A UINT type might be
 // useful here.  We should scavenge the batch reactor for pieces as we
 // reimplement a new code-generated version.
 //
-// * integral_assem == true, discrete assembly mode - discretization is automatic - Pop() from fresh buffer.
-//
-// * integral_assem == false, discrete assembly mode - discretization upon extraction from fresh buffer.  Just ExtractQty from fresh buffer
-//
-// * integral_assem == true, continuous assembly mode - discretization doesn’t matter. Just ExtractQty from fresh buffer.
-//
-// * integral_assem == false, continuous assembly mode - discretization doesn’t matter.  Just ExtractQty from fresh buffer.
-//
 // Meta-data associated with resource objects in inventory (e.g. the in-commod
 // on which they were received) should be associated with resources based on
-// obj_id.  This is necessary for handling the case where integral_assem is
-// true in discrete assembly mode where resources are combined inside buffers
-// during extraction.
+// obj_id.  This is necessary for handling the case where in continuous
+// assembly mode where resources are potentially combined/split inside
+// buffers during extraction - and also when decay could change Resource::id.
 
 class Reactor : public cyclus::Facility {
  public:
@@ -96,6 +79,12 @@ class Reactor : public cyclus::Facility {
   virtual void Tick();
   virtual void Tock();
 
+  void AcceptMatlTrades(
+      const std::vector< std::pair<cyclus::Trade<cyclus::Material>,
+      cyclus::Material::Ptr> >& responses);
+
+  std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr> GetMatlRequests();
+
   #pragma cyclus
 
  private:
@@ -105,6 +94,9 @@ class Reactor : public cyclus::Facility {
   std::string fuel_outrecipe(cyclus::Material::Ptr m);
   double fuel_pref(cyclus::Material::Ptr m);
 
+  /// Store fuel info index for the given resource received on incommod.
+  void index_res(cyclus::Resource::Ptr m, std::string incommod);
+
   /// Returns true if the reactor is operating in discrete assembly mode.
   bool discrete_mode() {return n_assem_core > 1 || n_batches == 1;};
 
@@ -112,7 +104,7 @@ class Reactor : public cyclus::Facility {
   /// inventory.  Returns true if a batch was successfully discharged.
   bool Discharge();
 
-  /// Top up core inventory if possible.
+  /// Top up core inventory as much as possible.
   void Load();
 
   /// Transmute the batch in the core that is about to be discharged to its
@@ -122,48 +114,72 @@ class Reactor : public cyclus::Facility {
   double assem_per_discharge();
 
   // inventory and core params
-  #pragma cyclus var {}
+  #pragma cyclus var { \
+    "doc": "", \
+  }
   double n_batches;
-  #pragma cyclus var {}
+  #pragma cyclus var { \
+    "doc": "", \
+  }
   double assem_size;
-  #pragma cyclus var {"default": 1}
-  bool integral_assem;
-  #pragma cyclus var {"default": 'n_batches'}
+  #pragma cyclus var { \
+    "default": "n_batches", \
+  }
   int n_assem_core;
-  #pragma cyclus var {"default": 1000000000}
-  int n_assem_spent;
-  #pragma cyclus var {"default": 'n_assem_core'}
-  int n_assem_fresh;
+  #pragma cyclus var { \
+    "default": 1000000000, \
+  }
+  int n_batch_spent;
+  #pragma cyclus var { \
+    "default": 1, \
+  }
+  int n_batch_fresh;
 
   // cycle params
-  #pragma cyclus var {}
+  #pragma cyclus var { \
+    "doc": "", \
+  }
   int cycle_time;
-  #pragma cyclus var {}
+  #pragma cyclus var { \
+    "doc": "", \
+  }
   int refuel_time;
   #pragma cyclus var { \
     "default": 0, \
-    "doc": "number of time steps since the beginning of the last cycle", \
+    "doc": "Number of time steps since the beginning of the last cycle.", \
   }
   int cycle_step;
 
   // fuel specifications
   #pragma cyclus var { \
     "uitype": ["oneormore", "incommodity"], \
+    "doc": "Ordered list of input commodities for requesting fuel.", \
   }
   std::vector<std::string> fuel_incommods;
   #pragma cyclus var { \
     "uitype": ["oneormore", "recipe"], \
+    "doc": "Fresh fuel recipes to request for each of the given fuel_incommods (same order).", \
   }
   std::vector<std::string> fuel_inrecipes;
   #pragma cyclus var { \
     "uitype": ["oneormore", "recipe"], \
+    "doc": "Spent fuel recipes corresponding to the given fuel_incommods (by order)." \
+           " Fuel received via a particular incommod is transmuted to the recipe specified" \
+           " here after being burned during a cycle.", \
   }
   std::vector<std::string> fuel_outrecipes;
   #pragma cyclus var { \
     "uitype": ["oneormore", "incommodity"], \
+    "doc": "Output commodities on which to offer spent fuel for each of the given" \ 
+           " incommods (same order)." \
   }
   std::vector<std::string> fuel_outcommods;
-  #pragma cyclus var {"default": []} // if this is empty, assume zero for all
+  #pragma cyclus var { \
+    "default": [], \
+    "doc": "The preference for each type of fresh fuel requested via the given" \
+           " incommods (same order).  If no preferences are specified, zero is" \
+           " used for all fuel requests.", \
+  }
   std::vector<double> fuel_prefs;
 
   // This variable should be hidden/unavailable in ui.  Maps resource object
@@ -171,30 +187,45 @@ class Reactor : public cyclus::Facility {
   #pragma cyclus var {}
   std::map<int, int> res_indexes;
 
-  // Resource inventories
-  #pragma cyclus var {'capacity': 'n_assem_fresh * assem_size'}
+  // Resource inventories - these must be defined AFTER/BELOW the member vars
+  // referenced (e.g. n_batch_fresh, assem_size, etc.).
+  #pragma cyclus var {"capacity": "assem_per_discharge() * assem_size * n_batch_fresh"}
   cyclus::toolkit::ResBuf<cyclus::Material> fresh;
-  #pragma cyclus var {'capacity': 'n_assem_core * assem_size'}
+  #pragma cyclus var {"capacity": "n_assem_core * assem_size"}
   cyclus::toolkit::ResBuf<cyclus::Material> core;
-  #pragma cyclus var {'capacity': 'n_assem_spent * assem_size'}
+  #pragma cyclus var {"capacity": "assem_per_discharge() * assem_size * n_batch_spent"}
   cyclus::toolkit::ResBuf<cyclus::Material> spent;
 
   // preference changes
-  #pragma cyclus var {"default": []}
+  #pragma cyclus var { \
+    "default": [], \
+  }
   std::vector<int> pref_change_times;
-  #pragma cyclus var {"default": []}
+  #pragma cyclus var { \
+    "default": [], \
+  }
   std::vector<std::string> pref_change_commods;
-  #pragma cyclus var {"default": []}
+  #pragma cyclus var { \
+    "default": [], \
+  }
   std::vector<double> pref_change_values;
 
   // recipe changes
-  #pragma cyclus var {"default": []}
+  #pragma cyclus var { \
+    "default": [], \
+  }
   std::vector<int> recipe_change_times;
-  #pragma cyclus var {"default": []}
+  #pragma cyclus var { \
+    "default": [], \
+  }
   std::vector<std::string> recipe_change_commods;
-  #pragma cyclus var {"default": []}
+  #pragma cyclus var { \
+    "default": [], \
+  }
   std::vector<std::string> recipe_change_incommods;
-  #pragma cyclus var {"default": []}
+  #pragma cyclus var { \
+    "default": [], \
+  }
   std::vector<std::string> recipe_change_outcommods;
 
 };

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -91,6 +91,7 @@ class Reactor : public cyclus::Facility {
 
   virtual void Tick();
   virtual void Tock();
+  virtual void EnterNotify();
 
   virtual void AcceptMatlTrades(
       const std::vector< std::pair<cyclus::Trade<cyclus::Material>,

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -103,8 +103,6 @@ class Reactor : public cyclus::Facility {
   /// fully burnt state as defined by its outrecipe.
   void Transmute();
 
-  int assem_per_discharge();
-
   cyclus::toolkit::MatVec SpentResFor(std::string outcommod);
 
   cyclus::Material::Ptr PopSpentRes(std::string outcommod);
@@ -113,13 +111,13 @@ class Reactor : public cyclus::Facility {
   #pragma cyclus var { \
     "doc": "", \
   }
-  double n_batches;
+  int n_assem_batch;
   #pragma cyclus var { \
     "doc": "", \
   }
   double assem_size;
   #pragma cyclus var { \
-    "default": "n_batches", \
+    "doc": "", \
   }
   int n_assem_core;
   #pragma cyclus var { \
@@ -127,7 +125,7 @@ class Reactor : public cyclus::Facility {
   }
   int n_assem_spent;
   #pragma cyclus var { \
-    "default": 1, \
+    "default": 0, \
   }
   int n_assem_fresh;
 

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -1,0 +1,174 @@
+#ifndef CYCAMORE_SRC_REACTOR_H_
+#define CYCAMORE_SRC_REACTOR_H_
+
+#include "cyclus.h"
+
+using cyclus::Material;
+using cyclus::toolkit::ResBuf;
+
+namespace cycamore {
+
+// Configurable parameters:
+//
+// * n_batches (double) - the inverse of the core fraction discharged per cycle
+//
+// * assem_size (double) - the mass in kg of a single assembly
+//
+// * n_assem_core (int) - the number of assemblies that constitute a core.
+//
+// * n_assem_spent (int, default infinite) - the number of spent fuel assemblies
+//   that can be stored
+//
+// * n_assem_fresh (int, default n_assem_core) - the number of fresh assemblies to keep on
+//   hand
+//
+// * integral_assem (bool, default true) - true if requests require DRE to
+//   match all or nothing of each assembly.  Note that this is different from
+//   and roughly orthogonal to whether the reactor is operating in discrete or
+//   continuous assembly mode.  “True” is the recommended value for this
+//   variable.  “False” can result in materials being combined resulting in
+//   incorrect transmutations.
+//
+// The Reactor will have 3 resource buffers (all with automatically computed
+// capacities based on above params):
+//
+// * fresh: capacity = n_assem_fresh * assem_size
+//
+// * core: capacity = n_assem_core * assem_size
+//
+// * spent: capacity = n_assem_spent * assem_size
+//
+// The reactor will always try to keep its fresh_fuel and core buffers full.
+// The cycle progresses/runs only if the reactor is in active operation. The
+// following conditions result in reactor operation being suspended:
+//
+// * There are not enough full assemblies (with unspent life) to provide a full core
+//
+// * There is no room in the spent_fuel buffer to discharge a fully-burned assembly to.
+//
+// If a reactor is operating in discrete assembly mode, when it receives fresh
+// fuel, it discretizes the material into assembly quanta (of size
+// assem_size).  Discrete assembly mode is the recommended mode of operation
+// for a reactor.  If a partial assembly is received, it is stored until
+// enough material can be acquired to complete the full assembly.  In this
+// mode, partial assemblies may not be inserted into the core.  When in this
+// mode, resources will never be split/combined by the reactor post assembly
+// discretization.  If integral_assem is false, then this discretization will
+// happen upon extraction of an assembly’s worth of material from the fresh
+// inventory for placement into the core.  If integral_assem is true, then
+// this discretization will happen automatically as part of resource exchange.
+// Under either of the following conditions, a reactor will operate in
+// discrete assembly mode:
+//
+// * n_assem_core == n_batches:  pop one assembly per cycle
+//
+// * n_assem_core > 1:  pop floor(n_assem_core / n_batches) assemblies per cycle
+//
+// If neither of those conditions are met (i.e. n_assem_core == 1 && n_assem_core !=
+// n_batches), then the reactor will operate in continuous assembly mode.  In
+// this mode it discharges 1 / n_batches fraction of the single assembly from
+// the core at the end of each cycle, and the same quantity will be
+// extracted/split from the (not assembly discretized) fresh fresh fuel buffer
+// (or requested on DRE if no fresh) and inserted into the core.
+//
+// Time to make it code generatable? - Yes  Bring into compliance? - Yes.
+// The BatchReactor currently has no state variables. A UINT type might be
+// useful here.  We should scavenge the batch reactor for pieces as we
+// reimplement a new code-generated version.
+//
+// * integral_assem == true, discrete assembly mode - discretization is automatic - Pop() from fresh buffer.
+//
+// * integral_assem == false, discrete assembly mode - discretization upon extraction from fresh buffer.  Just ExtractQty from fresh buffer
+//
+// * integral_assem == true, continuous assembly mode - discretization doesn’t matter. Just ExtractQty from fresh buffer.
+//
+// * integral_assem == false, continuous assembly mode - discretization doesn’t matter.  Just ExtractQty from fresh buffer.
+//
+// Meta-data associated with resource objects in inventory (e.g. the in-commod
+// on which they were received) should be associated with resources based on
+// obj_id.  This is necessary for handling the case where integral_assem is
+// true in discrete assembly mode where resources are combined inside buffers
+// during extraction.
+
+class Reactor : public cyclus::Facility {
+ public:
+  Reactor(cyclus::Context* ctx);
+  virtual ~Reactor() {};
+
+  virtual void EnterNotify() {};
+  virtual void Tick() {};
+  virtual void Tock() {};
+
+  #pragma cyclus
+
+ private:
+  // inventory and core params
+  #pragma cyclus var {}
+  double n_batches;
+  #pragma cyclus var {}
+  double assem_size;
+  #pragma cyclus var {'default': 1}
+  bool integral_assem;
+  #pragma cyclus var {'default': 'n_batches'}
+  int n_assem_core;
+  #pragma cyclus var {'default': 1e250}
+  int n_assem_spent;
+  #pragma cyclus var {'default': 'n_assem_core'}
+  int n_assem_fresh;
+
+  // cycle params
+  #pragma cyclus var {}
+  int cycle_time;
+  #pragma cyclus var {}
+  int refuel_time;
+  #pragma cyclus var {'default': 0}
+  int cycle_step;
+
+  // fuel specifications
+  #pragma cyclus var {}
+  std::vector<std::string> incommods;
+  #pragma cyclus var {}
+  std::vector<std::string> inrecipes;
+  #pragma cyclus var {}
+  std::vector<std::string> outrecipes;
+  #pragma cyclus var {}
+  std::vector<std::string> outcommods;
+  #pragma cyclus var {'default': []} // if this is empty, assume zero for all
+  std::vector<double> incommod_prefs;
+
+  // This variable should be hidden/unavailable in ui.  Maps resource id's to
+  // the incommods through which they were received.
+  #pragma cyclus var {}
+  std::map<int, std::string> res_commods;
+
+  // preference changes
+  #pragma cyclus var {'default': []}
+  std::vector<int> pref_change_times;
+  #pragma cyclus var {'default': []}
+  std::vector<std::string> pref_change_commods;
+  #pragma cyclus var {'default': []}
+  std::vector<double> pref_change_values;
+
+  // recipe changes
+  #pragma cyclus var {'default': []}
+  std::vector<int> recipe_change_times;
+  #pragma cyclus var {'default': []}
+  std::vector<std::string> recipe_change_commods;
+  #pragma cyclus var {'default': []}
+  std::vector<std::string> recipe_change_incommods;
+  #pragma cyclus var {'default': []}
+  std::vector<std::string> recipe_change_outcommods;
+
+  // Resource inventories
+  #pragma cyclus var {'capacity': 'n_assem_fresh * assem_size'}
+  ResBuf<Material> fresh;
+  #pragma cyclus var {'capacity': 'n_assem_core * assem_size'}
+  ResBuf<Material> core;
+  #pragma cyclus var {'capacity': 'n_assem_spent * assem_size'}
+  ResBuf<Material> spent;
+
+};
+
+} // namespace cycamore
+
+#endif  // CYCAMORE_SRC_REACTOR_H_

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -87,26 +87,25 @@ class Reactor : public cyclus::Facility {
 
  public:
   Reactor(cyclus::Context* ctx);
-  virtual ~Reactor() {};
+  virtual ~Reactor(){};
 
   virtual void Tick();
   virtual void Tock();
   virtual void EnterNotify();
 
-  virtual void AcceptMatlTrades(
-      const std::vector< std::pair<cyclus::Trade<cyclus::Material>,
-      cyclus::Material::Ptr> >& responses);
+  virtual void AcceptMatlTrades(const std::vector<std::pair<
+      cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr> >& responses);
 
-  virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr> GetMatlRequests();
+  virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
+  GetMatlRequests();
 
-  virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
-      GetMatlBids(cyclus::CommodMap<cyclus::Material>::type&
-                  commod_requests);
+  virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> GetMatlBids(
+      cyclus::CommodMap<cyclus::Material>::type& commod_requests);
 
   virtual void GetMatlTrades(
-      const std::vector< cyclus::Trade<cyclus::Material> >& trades,
+      const std::vector<cyclus::Trade<cyclus::Material> >& trades,
       std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-      cyclus::Material::Ptr> >& responses);
+                            cyclus::Material::Ptr> >& responses);
 
   #pragma cyclus
 

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -61,7 +61,6 @@ class Reactor : public cyclus::Facility {
   Reactor(cyclus::Context* ctx);
   virtual ~Reactor() {};
 
-  virtual void EnterNotify() {};
   virtual void Tick();
   virtual void Tock();
 
@@ -178,8 +177,12 @@ class Reactor : public cyclus::Facility {
 
   // This variable should be hidden/unavailable in ui.  Maps resource object
   // id's to the index for the incommod through which they were received.
-  #pragma cyclus var {}
+  #pragma cyclus var {"default": {}}
   std::map<int, int> res_indexes;
+
+  // TODO: do we need this?
+  std::vector<std::string> init_core_fuel;
+  std::vector<int> init_core_assem;
 
   // Resource inventories - these must be defined AFTER/BELOW the member vars
   // referenced (e.g. n_batch_fresh, assem_size, etc.).

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -102,6 +102,9 @@ class Reactor : public cyclus::Facility {
   /// fully burnt state as defined by its outrecipe.
   void Transmute();
 
+  /// record a reactor event
+  void Record(std::string name);
+
   cyclus::toolkit::MatVec SpentResFor(std::string outcommod);
 
   cyclus::Material::Ptr PopSpentRes(std::string outcommod);

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -85,6 +85,15 @@ class Reactor : public cyclus::Facility {
 
   std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr> GetMatlRequests();
 
+  virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
+      GetMatlBids(cyclus::CommodMap<cyclus::Material>::type&
+                  commod_requests);
+
+  virtual void GetMatlTrades(
+      const std::vector< cyclus::Trade<cyclus::Material> >& trades,
+      std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+      cyclus::Material::Ptr> >& responses);
+
   #pragma cyclus
 
  private:
@@ -111,9 +120,13 @@ class Reactor : public cyclus::Facility {
   /// fully burnt state as defined by its outrecipe.
   void Transmute();
 
-  double assem_per_discharge();
+  int assem_per_discharge();
 
-  // inventory and core params
+  cyclus::toolkit::MatVec SpentResFor(std::string outcommod);
+
+  cyclus::Material::Ptr PopSpentRes(std::string outcommod);
+
+  //////////// inventory and core params ////////////
   #pragma cyclus var { \
     "doc": "", \
   }
@@ -129,13 +142,13 @@ class Reactor : public cyclus::Facility {
   #pragma cyclus var { \
     "default": 1000000000, \
   }
-  int n_batch_spent;
+  int n_assem_spent;
   #pragma cyclus var { \
     "default": 1, \
   }
-  int n_batch_fresh;
+  int n_assem_fresh;
 
-  // cycle params
+  ///////// cycle params ///////////
   #pragma cyclus var { \
     "doc": "", \
   }
@@ -150,7 +163,7 @@ class Reactor : public cyclus::Facility {
   }
   int cycle_step;
 
-  // fuel specifications
+  /////// fuel specifications /////////
   #pragma cyclus var { \
     "uitype": ["oneormore", "incommodity"], \
     "doc": "Ordered list of input commodities for requesting fuel.", \
@@ -189,14 +202,14 @@ class Reactor : public cyclus::Facility {
 
   // Resource inventories - these must be defined AFTER/BELOW the member vars
   // referenced (e.g. n_batch_fresh, assem_size, etc.).
-  #pragma cyclus var {"capacity": "assem_per_discharge() * assem_size * n_batch_fresh"}
+  #pragma cyclus var {"capacity": "n_assem_fresh * assem_size"}
   cyclus::toolkit::ResBuf<cyclus::Material> fresh;
   #pragma cyclus var {"capacity": "n_assem_core * assem_size"}
   cyclus::toolkit::ResBuf<cyclus::Material> core;
-  #pragma cyclus var {"capacity": "assem_per_discharge() * assem_size * n_batch_spent"}
+  #pragma cyclus var {"capacity": "n_assem_spent * assem_size"}
   cyclus::toolkit::ResBuf<cyclus::Material> spent;
 
-  // preference changes
+  /////////// preference changes ///////////
   #pragma cyclus var { \
     "default": [], \
   }
@@ -210,7 +223,7 @@ class Reactor : public cyclus::Facility {
   }
   std::vector<double> pref_change_values;
 
-  // recipe changes
+  ///////////// recipe changes ///////////
   #pragma cyclus var { \
     "default": [], \
   }

--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+#include "cyclus.h"
+
+using pyne::nucname::id;
+using cyclus::Composition;
+using cyclus::QueryResult;
+using cyclus::Cond;
+
+namespace cycamore {
+
+TEST(ReactorTests, JustInTimeOrdering) {
+  cyclus::CompMap m;
+  m[id("U235")] = .05;
+  m[id("U238")] = .95;
+  Composition::Ptr fresh = Composition::CreateFromMass(m);
+  m.clear();
+  m[id("U235")] = .01;
+  m[id("U238")] = .99;
+  Composition::Ptr spent = Composition::CreateFromMass(m);
+
+  std::string config = 
+     "  <fuel_inrecipes>  <val>lwr_fresh</val>    </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>lwr_spent</val>    </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>enriched_u</val>   </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>        </fuel_outcommods>  "
+     "  <fuel_prefs>      <val>1.0</val>          </fuel_prefs>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>300</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  ";
+
+  int simdur = 50;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
+  sim.AddSource("enriched_u").Finalize();
+  sim.AddRecipe("lwr_fresh", fresh);
+  sim.AddRecipe("lwr_spent", spent);
+  int id = sim.Run();
+
+  QueryResult qr = sim.db().Query("Transactions", NULL);
+  EXPECT_EQ(simdur, qr.rows.size()) << "failed to order+run on fresh fuel inside 1 time step";
+}
+
+}  // namespace cycamore
+

--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -12,6 +12,7 @@ using cyclus::Cond;
 using cyclus::toolkit::MatQuery;
 
 namespace cycamore {
+namespace reactortests {
 
 Composition::Ptr c_uox() {
   cyclus::CompMap m;
@@ -460,5 +461,6 @@ TEST(ReactorTests, RecipeChange) {
   EXPECT_TRUE(0 < mq.mass(id("H1")));
 }
 
+} // namespace reactortests
 } // namespace cycamore
 

--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -8,25 +8,58 @@ using pyne::nucname::id;
 using cyclus::Composition;
 using cyclus::QueryResult;
 using cyclus::Cond;
+using cyclus::toolkit::MatQuery;
 
 namespace cycamore {
 
-TEST(ReactorTests, JustInTimeOrdering) {
+Composition::Ptr c_uox() {
   cyclus::CompMap m;
-  m[id("U235")] = .05;
-  m[id("U238")] = .95;
-  Composition::Ptr fresh = Composition::CreateFromMass(m);
-  m.clear();
-  m[id("U235")] = .01;
-  m[id("U238")] = .99;
-  Composition::Ptr spent = Composition::CreateFromMass(m);
+  m[id("u235")] = 0.04;
+  m[id("u238")] = 0.96;
+  return Composition::CreateFromMass(m);
+};
 
+Composition::Ptr c_mox() {
+  cyclus::CompMap m;
+  m[id("u235")] = .7;
+  m[id("u238")] = 100;
+  m[id("pu239")] = 3.3;
+  return Composition::CreateFromMass(m);
+};
+
+Composition::Ptr c_spentuox() {
+  cyclus::CompMap m;
+  m[id("u235")] =  .8;
+  m[id("u238")] =  100;
+  m[id("pu239")] = 1;
+  return Composition::CreateFromMass(m);
+};
+
+Composition::Ptr c_spentmox() {
+  cyclus::CompMap m;
+  m[id("u235")] =  .2;
+  m[id("u238")] =  100;
+  m[id("pu239")] = .9;
+  return Composition::CreateFromMass(m);
+};
+
+Composition::Ptr c_water() {
+  cyclus::CompMap m;
+  m[id("O16")] =  1;
+  m[id("H1")] =  2;
+  return Composition::CreateFromAtom(m);
+};
+
+// Test that with a zero refuel_time and a zero capacity fresh fuel buffer
+// (the default), fuel can be ordered and the cycle started with no time step
+// delay.
+TEST(ReactorTests, JustInTimeOrdering) {
   std::string config = 
-     "  <fuel_inrecipes>  <val>lwr_fresh</val>    </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>lwr_spent</val>    </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>enriched_u</val>   </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>        </fuel_outcommods>  "
-     "  <fuel_prefs>      <val>1.0</val>          </fuel_prefs>  "
+     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+     "  <fuel_prefs>      <val>1.0</val>        </fuel_prefs>  "
      ""
      "  <cycle_time>1</cycle_time>  "
      "  <refuel_time>0</refuel_time>  "
@@ -37,13 +70,148 @@ TEST(ReactorTests, JustInTimeOrdering) {
   int simdur = 50;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
   sim.AddSource("enriched_u").Finalize();
-  sim.AddRecipe("lwr_fresh", fresh);
-  sim.AddRecipe("lwr_spent", spent);
+  sim.AddRecipe("lwr_fresh", c_uox());
+  sim.AddRecipe("lwr_spent", c_spentuox());
   int id = sim.Run();
 
   QueryResult qr = sim.db().Query("Transactions", NULL);
   EXPECT_EQ(simdur, qr.rows.size()) << "failed to order+run on fresh fuel inside 1 time step";
 }
 
-}  // namespace cycamore
+// The user can optionally omit fuel preferences.  In the case where
+// preferences are adjusted, the ommitted preference vector must be populated
+// with default values - if it wasn't then preferences won't be adjusted
+// correctly and the reactor could segfault.  Check that this doesn't happen.
+TEST(ReactorTests, PrefChange) {
+  // it is important that the fuel_prefs not be present in the config below.
+  std::string config = 
+     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>300</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  "
+     ""
+     "  <pref_change_times>   <val>25</val>         </pref_change_times>"
+     "  <pref_change_commods> <val>enriched_u</val> </pref_change_commods>"
+     "  <pref_change_values>  <val>-1</val>         </pref_change_values>";
+
+  int simdur = 50;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
+  sim.AddSource("enriched_u").Finalize();
+  sim.AddRecipe("lwr_fresh", c_uox());
+  sim.AddRecipe("lwr_spent", c_spentuox());
+  int id = sim.Run();
+
+  QueryResult qr = sim.db().Query("Transactions", NULL);
+  EXPECT_EQ(25, qr.rows.size()) << "failed to adjust preferences properly";
+}
+
+// tests that the reactor handles requesting multiple types of fuel correctly
+// - with proper inventory constraints, etc.
+TEST(ReactorTests, MultiFuelMix) {
+  FAIL() << "not implemented";
+}
+
+// tests that the reactor halts operation when it has no more room in its
+// spent fuel inventory buffer.
+TEST(ReactorTests, FullSpentInventory) {
+  FAIL() << "not implemented";
+}
+
+// tests that the reactor cycle is delayed as expected when it is unable to
+// acquire fuel in time for the next cycle start.
+TEST(ReactorTests, FuelShortage) {
+  FAIL() << "not implemented";
+}
+
+// tests that the refueling period between cycle end and start of the next
+// cycle is honored.
+TEST(ReactorTests, RefuelTimes) {
+  FAIL() << "not implemented";
+}
+
+// tests that the correct number of assemblies are popped from the core each
+// cycle.
+TEST(ReactorTests, BatchSizes) {
+  FAIL() << "not implemented";
+}
+
+TEST(ReactorTests, RecipeChange) {
+  // it is important that the fuel_prefs not be present in the config below.
+  std::string config = 
+     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>300</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  "
+     ""
+     "  <recipe_change_times>   <val>25</val>         <val>35</val>         </recipe_change_times>"
+     "  <recipe_change_commods> <val>enriched_u</val> <val>enriched_u</val> </recipe_change_commods>"
+     "  <recipe_change_in>      <val>water</val>      <val>water</val>      </recipe_change_in>"
+     "  <recipe_change_out>     <val>lwr_spent</val>  <val>water</val>      </recipe_change_out>";
+
+  int simdur = 50;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
+  sim.AddSource("enriched_u").Finalize();
+  sim.AddSink("waste").Finalize();
+  sim.AddRecipe("lwr_fresh", c_uox());
+  sim.AddRecipe("lwr_spent", c_spentuox());
+  sim.AddRecipe("water", c_water());
+  int aid = sim.Run();
+
+  std::vector<Cond> conds;
+  QueryResult qr;
+
+  // check that received recipe is not water
+  conds.clear();
+  conds.push_back(Cond("Time", "==", 24));
+  conds.push_back(Cond("ReceiverId", "==", aid));
+  qr = sim.db().Query("Transactions", &conds);
+  MatQuery mq = MatQuery(sim.GetMaterial(qr.GetVal<int>("ResourceId")));
+
+  EXPECT_TRUE(0 < mq.qty());
+  EXPECT_TRUE(0 == mq.mass(id("H1")));
+
+  // check that received recipe changed to water
+  conds.clear();
+  conds.push_back(Cond("Time", "==", 26));
+  conds.push_back(Cond("ReceiverId", "==", aid));
+  qr = sim.db().Query("Transactions", &conds);
+  mq = MatQuery(sim.GetMaterial(qr.GetVal<int>("ResourceId")));
+
+  EXPECT_TRUE(0 < mq.qty());
+  EXPECT_TRUE(0 < mq.mass(id("H1")));
+
+  // check that sent recipe is not water
+  conds.clear();
+  conds.push_back(Cond("Time", "==", 34));
+  conds.push_back(Cond("SenderId", "==", aid));
+  qr = sim.db().Query("Transactions", &conds);
+  mq = MatQuery(sim.GetMaterial(qr.GetVal<int>("ResourceId")));
+
+  EXPECT_TRUE(0 < mq.qty());
+  EXPECT_TRUE(0 == mq.mass(id("H1")));
+
+  // check that sent recipe changed to water
+  conds.clear();
+  conds.push_back(Cond("Time", "==", 36));
+  conds.push_back(Cond("SenderId", "==", aid));
+  qr = sim.db().Query("Transactions", &conds);
+  mq = MatQuery(sim.GetMaterial(qr.GetVal<int>("ResourceId")));
+
+  EXPECT_TRUE(0 < mq.qty());
+  EXPECT_TRUE(0 < mq.mass(id("H1")));
+}
+
+} // namespace cycamore
 

--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -212,6 +212,11 @@ TEST(ReactorTests, FuelShortage) {
   FAIL() << "not implemented";
 }
 
+// tests that discharged fuel is transmuted properly immediately at cycle end.
+TEST(ReactorTests, DischargedFuelTransmute) {
+  FAIL() << "not implemented";
+}
+
 // The user can optionally omit fuel preferences.  In the case where
 // preferences are adjusted, the ommitted preference vector must be populated
 // with default values - if it wasn't then preferences won't be adjusted


### PR DESCRIPTION
~~This isn't 100% ready, but it is functional and nearly complete.  Still needs a bit more annotations and a few tests but otherwise done.~~ (done now)  After some discussion with @gidden and a bit with Paul, we decided that any continuous batch/assembly mode would not work well - and would likely provide poor results in analysis.  One consequence of this is that the new Reactor will not be able to exactly match the physor regression/integration results.  However, I tweaked the 1_enrichment_2_reactors input file to have 10 0.1kg assemblies in the core instead of 1 1kg assembly - and the results rounded to the nearest integer are in perfect agreement.

What do we want to do for testing?

I also added a nifty ReactorEvents table that records things like cycle start, cycle end, discharging, reloading, etc. for each reactor.

depends on cyclus/cyclus#1084