### PR TITLE
Handle reactor retirement better:

### DIFF
--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -223,7 +223,6 @@ void Reactor::GetMatlTrades(
   using cyclus::Trade;
 
   std::map<std::string, MatVec> mats = PopSpent();
-  std::vector<cyclus::Trade<cyclus::Material> >::const_iterator it;
   for (int i = 0; i < trades.size(); i++) {
     std::string commod = trades[i].request->commodity();
     Material::Ptr m = mats[commod].back();
@@ -267,8 +266,16 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Reactor::GetMatlBids(
 
   bool gotmats = false;
   std::map<std::string, MatVec> all_mats;
-  for (int i = 0; i < fuel_outcommods.size(); i++) {
-    std::string commod = fuel_outcommods[i];
+
+  if (uniq_outcommods_.empty()) {
+    for (int i = 0; i < fuel_outcommods.size(); i++) {
+      uniq_outcommods_.insert(fuel_outcommods[i]);
+    }
+  }
+
+  std::set<std::string>::iterator it;
+  for (it = uniq_outcommods_.begin(); it != uniq_outcommods_.end(); ++it) {
+    std::string commod = *it;
     std::vector<Request<Material>*>& reqs = commod_requests[commod];
     if (reqs.size() == 0) {
       continue;

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -191,13 +191,13 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> Reactor::GetMatlRequests() {
   if (exit_time() != -1) {
     // the +1 accounts for the fact that the reactor is alive and gets to
     // operate during its exit_time time step.
-    int tleft = exit_time() - context()->time() + 1;
-    int tleftcycle = cycle_time + refuel_time - cycle_step;
-    double ncyclesleft = static_cast<double>(tleft - tleftcycle) /
+    int t_left = exit_time() - context()->time() + 1;
+    int t_left_cycle = cycle_time + refuel_time - cycle_step;
+    double n_cycles_left = static_cast<double>(t_left - t_left_cycle) /
                          static_cast<double>(cycle_time + refuel_time);
-    ncyclesleft = ceil(ncyclesleft);
-    int nneed = std::max(0.0, ncyclesleft * n_assem_batch - n_assem_fresh);
-    n_assem_order = std::min(n_assem_order, nneed);
+    n_cycles_left = ceil(n_cycles_left);
+    int n_need = std::max(0.0, n_cycles_left * n_assem_batch - n_assem_fresh);
+    n_assem_order = std::min(n_assem_order, n_need);
   }
 
   if (n_assem_order == 0) {

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -109,9 +109,6 @@ void Reactor::Tick() {
   // they
   // can't go at the beginnin of the Tock is so that resource exchange has a
   // chance to occur after the discharge on this same time step.
-  std::cout << context()->time() << ": " << "fresh.count=" << fresh.count() << "\n";
-  std::cout << "    core.count=" << core.count() << "\n";
-  std::cout << "    spent.count=" << spent.count() << "\n";
 
   if (retired()) {
     Record("RETIRED", "");

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -42,6 +42,15 @@ namespace cycamore {
 /// becomes full, the reactor will halt operation at the end of the next cycle
 /// until there is more room.  Each time step, the reactor will try to trade
 /// away as much of its spent fuel inventory as possible.
+///
+/// When the reactor reaches the end of its lifetime, it will discharge all
+/// material from its core and trade away all its spent fuel as quickly as
+/// possible.  Full decommissioning will be delayed until all spent fuel is
+/// gone.  If the reactor has a full core when it is decommissioned (i.e. is
+/// mid-cycle) when the reactor is decommissioned, half (rounded up to nearest
+/// int) of its assemblies are transmuted to their respective burnt
+/// compositions.
+
 class Reactor : public cyclus::Facility,
   public cyclus::toolkit::CommodityProducer {
 #pragma cyclus note { \
@@ -83,7 +92,16 @@ class Reactor : public cyclus::Facility,
   " operational cycle before the next begins.  If the spent fuel inventory" \
   " becomes full, the reactor will halt operation at the end of the next cycle" \
   " until there is more room.  Each time step, the reactor will try to trade" \
-  " away as much of its spent fuel inventory as possible.", \
+  " away as much of its spent fuel inventory as possible." \
+  "\n\n" \
+  "When the reactor reaches the end of its lifetime, it will discharge all" \
+  " material from its core and trade away all its spent fuel as quickly as" \
+  " possible.  Full decommissioning will be delayed until all spent fuel is" \
+  " gone.  If the reactor has a full core when it is decommissioned (i.e. is" \
+  " mid-cycle) when the reactor is decommissioned, half (rounded up to nearest" \
+  " int) of its assemblies are transmuted to their respective burnt" \
+  " compositions." \
+  "", \
 }
 
  public:
@@ -135,6 +153,10 @@ class Reactor : public cyclus::Facility,
   /// Transmute the batch that is about to be discharged from the core to its
   /// fully burnt state as defined by its outrecipe.
   void Transmute();
+
+  /// Transmute the specified number of assemblies in the core to their
+  /// fully burnt state as defined by their outrecipe.
+  void Transmute(int n_assem);
 
   /// Records a reactor event to the output db with the given name and note val.
   void Record(std::string name, std::string val);

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -93,6 +93,7 @@ class Reactor : public cyclus::Facility,
   virtual void Tick();
   virtual void Tock();
   virtual void EnterNotify();
+  virtual bool CheckDecommissionCondition();
 
   virtual void AcceptMatlTrades(const std::vector<std::pair<
       cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr> >& responses);
@@ -116,6 +117,10 @@ class Reactor : public cyclus::Facility,
   std::string fuel_inrecipe(cyclus::Material::Ptr m);
   std::string fuel_outrecipe(cyclus::Material::Ptr m);
   double fuel_pref(cyclus::Material::Ptr m);
+
+  bool retired() {
+    return exit_time() != -1 && context()->time() >= exit_time();
+  }
 
   /// Store fuel info index for the given resource received on incommod.
   void index_res(cyclus::Resource::Ptr m, std::string incommod);

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -362,6 +362,9 @@ class Reactor : public cyclus::Facility,
                       "internal": True \
   }
   std::map<int, int> res_indexes;
+
+  // populated lazily and no need to persist.
+  std::set<std::string> uniq_outcommods_;
 };
 
 } // namespace cycamore


### PR DESCRIPTION
* discharge all fuel fuel from core at end of life (and transmute it).

* if nearing end of life, only order up to enough fresh fuel to reach end of life.

* block decommissioning until all fuel has been removed from core and traded away out of spent inventory.

Note that testing this will require an adjustement to MockSim.  This helps results for FCO related analysis significantly.
