### PR TITLE
fixed error in documentation rendering for Enrichment Facility

### DIFF
--- a/src/enrichment_facility.h
+++ b/src/enrichment_facility.h
@@ -157,12 +157,6 @@ class Enrichment : public cyclus::Facility {
 
   #pragma cyclus
 
-  #pragma cyclus note {"doc": "An enrichment facility that intakes a "\
-                              "commodity (usually natural uranium) and " \
-                              "supplies a user-specified enriched product "\
-                              "based on SWU capacity", \
-                       "niche": "enrichment"}
-
   ///     Print information about this agent
   virtual std::string str();
   // ---


### PR DESCRIPTION
Had two #pragma cyclus note statements, resulting in a rendering error for the documentation in the Enrichment Facility.  Fixed here.