### PR TITLE
fix duplicate prototype entries in db

### DIFF
--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -18,11 +18,17 @@ void DeployInst::Build(cyclus::Agent* parent) {
 
     if (lifetimes.size() == prototypes.size()) {
       cyclus::Agent* a = context()->CreateAgent<Agent>(proto);
-      a->lifetime(lifetimes[i]);
+      if (a->lifetime() != lifetimes[i]) {
+        a->lifetime(lifetimes[i]);
 
-      ss << "_life_" << lifetimes[i];
-      proto = ss.str();
-      context()->AddPrototype(proto, a);
+        if (lifetimes[i] == -1) {
+          ss << "_life_forever";
+        } else {
+          ss << "_life_" << lifetimes[i];
+        }
+        proto = ss.str();
+        context()->AddPrototype(proto, a);
+      }
     }
 
     int t = build_times[i];

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -10,6 +10,7 @@ DeployInst::~DeployInst() {}
 void DeployInst::Build(cyclus::Agent* parent) {
   cyclus::Institution::Build(parent);
   BuildSched::iterator it;
+  std::set<std::string> protos;
   for (int i = 0; i < prototypes.size(); i++) {
     std::string proto = prototypes[i];
 
@@ -27,7 +28,10 @@ void DeployInst::Build(cyclus::Agent* parent) {
           ss << "_life_" << lifetimes[i];
         }
         proto = ss.str();
-        context()->AddPrototype(proto, a);
+        if (protos.count(proto) == 0) {
+          protos.insert(proto);
+          context()->AddPrototype(proto, a);
+        }
       }
     }
 

--- a/src/deploy_inst_tests.cc
+++ b/src/deploy_inst_tests.cc
@@ -109,7 +109,35 @@ TEST(DeployInstTests, FiniteLifetimes) {
   EXPECT_EQ(8, stmt->GetInt(0));
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST(DeployInstTests, NoDupProtos) {
+  std::string config = 
+     "<prototypes>  <val>foobar</val> <val>foobar</val> <val>foobar</val> </prototypes>"
+     "<build_times> <val>1</val>      <val>1</val>      <val>2</val>      </build_times>"
+     "<n_build>     <val>1</val>      <val>7</val>      <val>3</val>      </n_build>"
+     "<lifetimes>   <val>1</val>      <val>1</val>      <val>-1</val>     </lifetimes>"
+     ;
+
+  int simdur = 5;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  sim.DummyProto("foobar");
+  int id = sim.Run();
+
+  // don't duplicate same prototypes with same custom lifetime
+  cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
+      "SELECT COUNT(*) FROM Prototypes WHERE Prototype = 'foobar_life_1';"
+      );
+  stmt->Step();
+  EXPECT_EQ(1, stmt->GetInt(0));
+
+  // don't duplicate custom lifetimes that are identical to original prototype
+  // lifetime.
+  stmt = sim.db().db().Prepare(
+      "SELECT COUNT(*) FROM Prototypes WHERE Prototype = 'foobar';"
+      );
+  stmt->Step();
+  EXPECT_EQ(1, stmt->GetInt(0));
+}
+
 // required to get functionality in cyclus agent unit tests library
 cyclus::Agent* DeployInstitutionConstructor(cyclus::Context* ctx) {
   return new cycamore::DeployInst(ctx);


### PR DESCRIPTION
deploy inst was previously causing many duplicate entries in the output db for a single prototype.  This fixes that.