### PR TITLE
Better end-of-life behavior for separations:

### DIFF
--- a/src/separations.h
+++ b/src/separations.h
@@ -82,7 +82,7 @@ class Separations : public cyclus::Facility {
       std::vector<std::pair<cyclus::Trade<cyclus::Material>,
                             cyclus::Material::Ptr> >& responses);
 
-  bool CheckDecommissionCondition();
+  virtual bool CheckDecommissionCondition();
 
   #pragma cyclus clone
   #pragma cyclus initfromcopy

--- a/src/separations.h
+++ b/src/separations.h
@@ -82,6 +82,8 @@ class Separations : public cyclus::Facility {
       std::vector<std::pair<cyclus::Trade<cyclus::Material>,
                             cyclus::Material::Ptr> >& responses);
 
+  bool CheckDecommissionCondition();
+
   #pragma cyclus clone
   #pragma cyclus initfromcopy
   #pragma cyclus infiletodb


### PR DESCRIPTION
* Refuse to decommission until all separated stream buffers are empty

* Stop requesting new material if there is enough to satisfy throughput until
  end-of-life

... still needs tests - coming later.