### PR TITLE
Check vars

### DIFF
--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -49,18 +49,18 @@ class DeployInst : public cyclus::Institution {
   std::vector<std::string> prototypes;
 
   #pragma cyclus var { \
-    "doc": "Time step on which to deploy agents given in prototype list (same order).", \
-    "uilabel": "Deployment times", \
-  }
-  std::vector<int> build_times;
-
-  #pragma cyclus var { \
     "doc": "Number of each prototype given in prototype list that should be deployed (same order).", \
     "uilabel": "Number to deploy", \
   }
   std::vector<int> n_build;
 
   #pragma cyclus var { \
+    "doc": "Time step on which to deploy agents given in prototype list (same order).", \
+    "uilabel": "Deployment times", \
+  }
+  std::vector<int> build_times;
+
+#pragma cyclus var {							\
     "doc": "Lifetimes for each prototype in prototype list (same order)." \
            " These lifetimes override the lifetimes in the original prototype definition." \
            " If unspecified, lifetimes from the original prototype definitions are used." \

--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -21,13 +21,14 @@ typedef std::map<int, std::vector<std::string> > BuildSched;
 class DeployInst : public cyclus::Institution {
   #pragma cyclus note { \
     "doc": \
-      "Builds and manages agents (facilities) according to a manually specified" \
-      " deployment schedule. Deployed agents are automatically decommissioned at" \
-      " the end of their lifetime.  The user specifies a list of prototypes for" \
+      "Builds and manages agents (facilities) according to a manually" \
+      " specified deployment schedule. Deployed agents are automatically" \
+      " decommissioned at the end of their lifetime.  The user specifies a" \
+      " list of prototypes for" \
       " each and corresponding build times, number to build, and (optionally)" \
-      " lifetimes.  The same prototype can be specified multiple times with any" \
-      " combination of the same or different build times, build number, and" \
-      " lifetimes. " \
+      " lifetimes.  The same prototype can be specified multiple times with" \
+      " any combination of the same or different build times, build number," \
+      " and lifetimes. " \
   }
  public:
   DeployInst(cyclus::Context* ctx);
@@ -49,23 +50,30 @@ class DeployInst : public cyclus::Institution {
   std::vector<std::string> prototypes;
 
   #pragma cyclus var { \
-    "doc": "Number of each prototype given in prototype list that should be deployed (same order).", \
+    "doc": "Time step on which to deploy agents given in prototype list " \
+           "(same order).",						\
+    "uilabel": "Deployment times",					\
+  }
+  std::vector<int> build_times;
+
+  #pragma cyclus var { \
+    "doc": "Number of each prototype given in prototype list that should be " \
+           "deployed (same order).", \
     "uilabel": "Number to deploy", \
   }
   std::vector<int> n_build;
 
-  #pragma cyclus var { \
-    "doc": "Time step on which to deploy agents given in prototype list (same order).", \
-    "uilabel": "Deployment times", \
-  }
-  std::vector<int> build_times;
 
 #pragma cyclus var {							\
     "doc": "Lifetimes for each prototype in prototype list (same order)." \
-           " These lifetimes override the lifetimes in the original prototype definition." \
-           " If unspecified, lifetimes from the original prototype definitions are used." \
-           " Although a new prototype is created in the Prototypes table for each lifetime with the suffix '_life_[lifetime]'," \
-           " all deployed agents themselves will have the same original prototype name (and so will the Agents tables).", \
+           " These lifetimes override the lifetimes in the original prototype" \
+           " definition." \
+           " If unspecified, lifetimes from the original prototype definitions"\
+           " are used." \
+           " Although a new prototype is created in the Prototypes table for" \
+           " each lifetime with the suffix '_life_[lifetime]'," \
+           " all deployed agents themselves will have the same original" \
+           " prototype name (and so will the Agents tables).", \
     "default": [], \
     "uilabel": "Lifetimes" \
   }

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -331,7 +331,7 @@ class Enrichment : public cyclus::Facility {
   }
   double max_enrich;
 
- #pragma cyclus var { \
+  #pragma cyclus var { \
     "default": 1,		       \
     "userlevel": 10,							\
     "tooltip": "Rank Material Requests by U235 Content",		\
@@ -341,12 +341,12 @@ class Enrichment : public cyclus::Facility {
   }
   bool order_prefs;
 
-    #pragma cyclus var { \
+  #pragma cyclus var {						       \
     "default": 1e299,						       \
     "tooltip": "SWU capacity (kgSWU/month)",			       \
     "uilabel": "SWU Capacity",                                         \
-    "doc": "separative work unit (SWU) capacity of enrichment "	       \
-           "facility (kgSWU/month) "                                         \
+    "doc": "separative work unit (SWU) capacity of enrichment "		\
+           "facility (kgSWU/timestep) "                                     \
   }
   double swu_capacity;
 

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -267,13 +267,7 @@ class Enrichment : public cyclus::Facility {
     "uitype": "incommodity" \
   }
   std::string feed_commod;
-  #pragma cyclus var { \
-    "tooltip": "product commodity",					\
-    "doc": "product commodity that the enrichment facility generates",	 \
-    "uilabel": "Product Commodity",                                     \
-    "uitype": "outcommodity" \
-  }
-  std::string product_commod;
+  
   #pragma cyclus var { \
     "tooltip": "feed recipe",						\
     "doc": "recipe for enrichment facility feed commodity",		\
@@ -281,28 +275,39 @@ class Enrichment : public cyclus::Facility {
     "uitype": "recipe" \
   }
   std::string feed_recipe;
+  
   #pragma cyclus var { \
+    "tooltip": "product commodity",					\
+    "doc": "product commodity that the enrichment facility generates",	 \
+    "uilabel": "Product Commodity",                                     \
+    "uitype": "outcommodity" \
+  }
+  std::string product_commod;
+  
+  #pragma cyclus var {							\
     "tooltip": "tails commodity",					\
     "doc": "tails commodity supplied by enrichment facility",		\
     "uilabel": "Tails Commodity",                                   \
     "uitype": "outcommodity" \
   }
   std::string tails_commod;
-  #pragma cyclus var { \
+
+  #pragma cyclus var {							\
     "default": 0.003, "tooltip": "tails assay",				\
     "uilabel": "Tails Assay",                               \
     "doc": "tails assay from the enrichment process",       \
   }
   double tails_assay;
-  #pragma cyclus var { \
-    "default": 1e299,						       \
-    "tooltip": "SWU capacity (kgSWU/month)",			       \
-    "uilabel": "SWU Capacity",                                         \
-    "doc": "separative work unit (SWU) capacity of enrichment "	       \
-           "facility (kgSWU/month) "                                         \
+  
+  #pragma cyclus var {							\
+    "default": 0, "tooltip": "initial uranium reserves (kg)",		\
+    "uilabel": "Initial Feed Inventory",				\
+    "doc": "amount of natural uranium stored at the enrichment "	\
+    "facility at the beginning of the simulation (kg)"			\
   }
-  double swu_capacity;
-  #pragma cyclus var { \
+  double initial_feed;
+
+  #pragma cyclus var {							\
     "default": 1e299, "tooltip": "max inventory of feed material (kg)", \
     "uilabel": "Maximum Feed Inventory",                                \
     "doc": "maximum total inventory of natural uranium in "		\
@@ -326,22 +331,24 @@ class Enrichment : public cyclus::Facility {
   }
   double max_enrich;
 
-  #pragma cyclus var {							\
-    "default": 0, "tooltip": "initial uranium reserves (kg)",		\
-    "uilabel": "Initial Feed Inventory", \
-    "doc": "amount of natural uranium stored at the enrichment "       \
-           "facility at the beginning of the simulation (kg)"		\
-  }
-  double initial_feed;
-  #pragma cyclus var { \
+ #pragma cyclus var { \
     "default": 1,		       \
     "userlevel": 10,							\
-    "tooltip": "order material requests by U235 content",		\
+    "tooltip": "Rank Material Requests by U235 Content",		\
     "uilabel": "Prefer feed with higher U235 content", \
     "doc": "turn on preference ordering for input material "		\
            "so that EF chooses higher U235 content first" \
   }
   bool order_prefs;
+
+    #pragma cyclus var { \
+    "default": 1e299,						       \
+    "tooltip": "SWU capacity (kgSWU/month)",			       \
+    "uilabel": "SWU Capacity",                                         \
+    "doc": "separative work unit (SWU) capacity of enrichment "	       \
+           "facility (kgSWU/month) "                                         \
+  }
+  double swu_capacity;
 
   double current_swu_capacity;
 

--- a/src/fuel_fab.h
+++ b/src/fuel_fab.h
@@ -172,7 +172,7 @@ class FuelFab : public cyclus::Facility {
     "doc": "Name for recipe to be used in fissile stream requests." \
            " Empty string results in use of an empty dummy recipe.", \
     "uitype": "recipe", \
-    "uilabel": "Fissile Stream Recipes", \
+    "uilabel": "Fissile Stream Recipe", \
     "default": "", \
   }
   std::string fiss_recipe;

--- a/src/fuel_fab.h
+++ b/src/fuel_fab.h
@@ -132,13 +132,7 @@ class FuelFab : public cyclus::Facility {
     "uilabel": "Filler Stream Commodities", \
     "uitype": ["oneormore", "incommodity"], \
   }
- std::vector<std::string> fill_commods;
-  #pragma cyclus var { \
-    "doc": "Name of recipe to be used in filler material stream requests.", \
-    "uilabel": "Filler Stream Recipe", \
-    "uitype": "recipe", \
-  }
-  std::string fill_recipe;
+  std::vector<std::string> fill_commods;
   #pragma cyclus var { \
     "default": [], \
     "uilabel": "Filler Stream Preferences", \
@@ -146,6 +140,12 @@ class FuelFab : public cyclus::Facility {
            " If unspecified, default is to use 1.0 for all preferences.", \
   }
   std::vector<double> fill_commod_prefs;
+  #pragma cyclus var { \
+    "doc": "Name of recipe to be used in filler material stream requests.", \
+    "uilabel": "Filler Stream Recipe", \
+    "uitype": "recipe", \
+  }
+  std::string fill_recipe;
   #pragma cyclus var { \
     "doc": "Size of filler material stream inventory.", \
     "uilabel": "Filler Stream Inventory Capacity", \
@@ -194,6 +194,12 @@ class FuelFab : public cyclus::Facility {
   }
   std::string topup_commod;
   #pragma cyclus var { \
+    "doc": "Top-up material stream request preference.", \
+    "uilabel": "Top-up Stream Preference", \
+    "default": 0, \
+  }
+  double topup_pref;
+  #pragma cyclus var { \
     "doc": "Name of recipe to be used in top-up material stream requests." \
            " This MUST be set if 'topup_size > 0'.", \
     "uilabel": "Top-up Stream Recipe", \
@@ -201,12 +207,6 @@ class FuelFab : public cyclus::Facility {
     "default": "", \
   }
   std::string topup_recipe;
-  #pragma cyclus var { \
-    "doc": "Top-up material stream request preference.", \
-    "uilabel": "Top-up Stream Preference", \
-    "default": 0, \
-  }
-  double topup_pref;
   #pragma cyclus var { \
     "doc": "Size of top-up material stream inventory.", \
     "uilabel": "Top-up Stream Inventory Capacity", \
@@ -216,14 +216,6 @@ class FuelFab : public cyclus::Facility {
   double topup_size;
   #pragma cyclus var {"capacity": "topup_size"}
   cyclus::toolkit::ResBuf<cyclus::Material> topup;
-
-  #pragma cyclus var { \
-    "uilabel": "Spectrum type", \
-    "categorical": ['fission_spectrum_ave','thermal'], \
-    "doc": "The type of cross-sections to use for composition property calculation." \
-           " Use 'fission_spectrum_ave' for fast reactor compositions or 'thermal' for thermal reactors.", \
-  }
-  std::string spectrum;
 
   #pragma cyclus var { \
     "doc": "Commodity on which to offer/supply mixed fuel material.", \
@@ -238,6 +230,14 @@ class FuelFab : public cyclus::Facility {
     "units": "kg", \
   }
   double throughput;
+
+  #pragma cyclus var {		\
+    "uilabel": "Spectrum type", \
+    "categorical": ['fission_spectrum_ave','thermal'], \
+    "doc": "The type of cross-sections to use for composition property calculation." \
+           " Use 'fission_spectrum_ave' for fast reactor compositions or 'thermal' for thermal reactors.", \
+  }
+  std::string spectrum;
 
   // intra-time-step state - no need to be a state var
   // map<request, inventory name>

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -172,24 +172,6 @@ class Reactor : public cyclus::Facility,
   /// Returns all spent assemblies indexed by outcommod without removing them
   /// from the spent fuel buffer.
   std::map<std::string, cyclus::toolkit::MatVec> PeekSpent();
-
-  //////////// power params ////////////
-  #pragma cyclus var { \
-    "default": 0, \
-    "doc": "Amount of electrical power the facility produces when operating " \
-           "normally.", \
-    "uilabel": "Nominal Reactor Power", \
-    "units": "MWe", \
-  }
-  double power_cap;
-
-  #pragma cyclus var { \
-    "default": "power", \
-    "uilabel": "Power Commodity Name", \
-    "doc": "The name of the 'power' commodity used in conjunction with a " \
-           "deployment curve.", \
-  }
-  std::string power_name;
   
   /////// fuel specifications /////////
   #pragma cyclus var { \
@@ -327,6 +309,24 @@ class Reactor : public cyclus::Facility,
     "units": "time steps", \
   }
   int cycle_step;
+
+  //////////// power params ////////////
+  #pragma cyclus var { \
+    "default": 0, \
+    "doc": "Amount of electrical power the facility produces when operating " \
+           "normally.", \
+    "uilabel": "Nominal Reactor Power", \
+    "units": "MWe", \
+  }
+  double power_cap;
+
+  #pragma cyclus var { \
+    "default": "power", \
+    "uilabel": "Power Commodity Name", \
+    "doc": "The name of the 'power' commodity used in conjunction with a " \
+           "deployment curve.", \
+  }
+  std::string power_name;
 
   /////////// preference changes ///////////
   #pragma cyclus var { \

--- a/src/separations.h
+++ b/src/separations.h
@@ -97,15 +97,9 @@ class Separations : public cyclus::Facility {
 
  private:
   #pragma cyclus var { \
-    "doc" : "Maximum quantity of feed material that can be processed per time step.", \
-    "uilabel": "Maximum Separations Throughput", \
-    "units": "kg", \
-  }
-  double throughput;
-
-  #pragma cyclus var { \
-    "doc": "Ordered list of commodities on which to request feed material to separate." \
-           " Order only matters for matching up with feed commodity preferences if specified.", \
+    "doc": "Ordered list of commodities on which to request feed material to " \
+           "separate. Order only matters for matching up with feed commodity " \
+           "preferences if specified.", \
     "uilabel": "Feed Commodity List", \
     "uitype": ["oneormore", "incommodity"], \
   }
@@ -114,7 +108,8 @@ class Separations : public cyclus::Facility {
   #pragma cyclus var { \
     "default": [], \
     "uilabel": "Feed Commodity Preference List", \
-    "doc": "Feed commodity request preferences for each of the given feed commodities (same order)." \
+    "doc": "Feed commodity request preferences for each of the given feed " \
+           "commodities (same order)." \
            " If unspecified, default is to use zero for all preferences.", \
   }
   std::vector<double> feed_commod_prefs;
@@ -141,18 +136,17 @@ class Separations : public cyclus::Facility {
   cyclus::toolkit::ResBuf<cyclus::Material> feed;
 
   #pragma cyclus var { \
-    "doc" : "Maximum amount of leftover separated material (not included in" \
-            " any other stream) that can be stored." \
-            " If full, the facility halts operation until space becomes available.", \
-    "uilabel": "Maximum Leftover Inventory", \
-    "default": 1e299, \
+    "doc" : "Maximum quantity of feed material that can be processed per time "\
+            "step.", \
+    "uilabel": "Maximum Separations Throughput", \
     "units": "kg", \
   }
-  double leftoverbuf_size;
+  double throughput;
 
   #pragma cyclus var { \
-    "doc": "Commodity on which to trade the leftover separated material stream." \
-           " This MUST NOT be the same as any commodity used to define the other separations streams.", \
+    "doc": "Commodity on which to trade the leftover separated material " \
+           "stream. This MUST NOT be the same as any commodity used to define "\
+           "the other separations streams.", \
     "uitype": "outcommodity", \
     "uilabel": "Leftover Commodity", \
     "default": "default-waste-stream", \
@@ -160,6 +154,17 @@ class Separations : public cyclus::Facility {
   std::string leftover_commod;
 
   #pragma cyclus var { \
+    "doc" : "Maximum amount of leftover separated material (not included in" \
+            " any other stream) that can be stored." \
+            " If full, the facility halts operation until space becomes " \
+            "available.", \
+    "uilabel": "Maximum Leftover Inventory", \
+    "default": 1e299, \
+    "units": "kg", \
+  }
+  double leftoverbuf_size;
+
+ #pragma cyclus var { \
     "capacity" : "leftoverbuf_size", \
   }
   cyclus::toolkit::ResBuf<cyclus::Material> leftover;
@@ -169,14 +174,17 @@ class Separations : public cyclus::Facility {
     "uitype": ["oneormore", "outcommodity", ["pair", "double", ["oneormore", "nuclide", "double"]]], \
     "uilabel": "Separations Streams and Efficiencies", \
     "doc": "Output streams for separations." \
-           " Each stream must have a unique name identifying the commodity on which its material is traded," \
+           " Each stream must have a unique name identifying the commodity on "\
+           " which its material is traded," \
            " a max buffer capacity in kg (neg values indicate infinite size)," \
            " and a set of component efficiencies." \
            " 'comp' is a component to be separated into the stream" \
-           " (e.g. U, Pu, etc.) and 'eff' is the mass fraction of the component" \
-           " that is separated from the feed into this output stream." \
-           " If any stream buffer is full, the facility halts operation until space becomes available." \
-           " The sum total of all component efficiencies across streams must be less than or equal to 1" \
+           " (e.g. U, Pu, etc.) and 'eff' is the mass fraction of the" \
+           " component that is separated from the feed into this output" \
+           " stream. If any stream buffer is full, the facility halts" \
+           " operation until space becomes available." \
+           " The sum total of all component efficiencies across streams must" \
+           " be less than or equal to 1" \
            " (e.g. sum of U efficiencies for all streams must be <= 1).", \
   }
   std::map<std::string, std::pair<double, std::map<int, double> > > streams_;

--- a/src/sink.h
+++ b/src/sink.h
@@ -104,16 +104,10 @@ class Sink : public cyclus::Facility  {
                       "uitype": ["oneormore", "incommodity"]}
   std::vector<std::string> in_commods;
 
-  /// monthly acceptance capacity
-  #pragma cyclus var {"default": 1e299, "tooltip": "sink capacity", \
-                      "uilabel": "Maximum Throughput", \
-                      "doc": "capacity the sink facility can " \
-                             "accept at each time step"}
-  double capacity;
-
   #pragma cyclus var {"default": "", "tooltip": "requested composition", \
-                      "doc": "name of recipe to use for material requests, where " \
-                             "the default (empty string) is to accept everything", \
+                      "doc": "name of recipe to use for material requests, " \
+                             "where the default (empty string) is to accept " \
+                             "everything", \
                        "uilabel": "Input Recipe", \
                       "uitype": "recipe"}
   std::string recipe_name;
@@ -124,6 +118,13 @@ class Sink : public cyclus::Facility  {
                       "uilabel": "Maximum Inventory", \
                       "doc": "total maximum inventory size of sink facility"}
   double max_inv_size;
+
+  /// monthly acceptance capacity
+  #pragma cyclus var {"default": 1e299, "tooltip": "sink capacity", \
+                      "uilabel": "Maximum Throughput", \
+                      "doc": "capacity the sink facility can " \
+                             "accept at each time step"}
+  double capacity;
 
   /// this facility holds material in storage.
   #pragma cyclus var {'capacity': 'max_inv_size'}

--- a/src/source.h
+++ b/src/source.h
@@ -79,8 +79,9 @@ class Source : public cyclus::Facility,
 
   #pragma cyclus var { \
     "tooltip": "name of material recipe to provide", \
-    "doc": "Name of composition recipe that this source provides regardless of requested composition." \
-           " If empty, source creates and provides whatever compositions are requested.", \
+    "doc": "Name of composition recipe that this source provides regardless " \
+           "of requested composition. If empty, source creates and provides " \
+           "whatever compositions are requested.", \
     "uilabel": "Output Recipe", \
     "default": "", \
     "uitype": "recipe", \
@@ -88,6 +89,17 @@ class Source : public cyclus::Facility,
   std::string outrecipe;
 
   #pragma cyclus var { \
+    "doc": "Total amount of material this source has remaining." \
+           " Every trade decreases this value by the supplied material " \
+           "quantity.  When it reaches zero, the source cannot provide any " \
+           " more material.", \
+    "default": 1e299, \
+    "uilabel": "Initial Inventory", \
+    "units": "kg", \
+  }
+  double inventory_size;
+
+  #pragma cyclus var {  \
     "default": 1e299, \
     "tooltip": "per time step throughput", \
     "units": "kg/(time step)", \
@@ -96,15 +108,6 @@ class Source : public cyclus::Facility,
   }
   double throughput;
 
-  #pragma cyclus var { \
-    "doc": "Total amount of material this source has remaining." \
-           " Every trade decreases this value by the supplied material quantity'." \
-           " When it reaches zero, the source cannot provide any more material.", \
-    "default": 1e299, \
-    "uilabel": "Initial Inventory", \
-    "units": "kg", \
-  }
-  double inventory_size;
 };
 
 }  // namespace cycamore


### PR DESCRIPTION
Goal was to reorganize pragma variables so they will show up consistently and logically in Cycic.  For some reason I was unable to load some archetypes into Cyclist, so feel free to suggest/PR other ordering if desired.  Full list of changes is:
- Pragma variables were reorganized to show up consistently in Cyclist.  Code was shuffled but not removed.  
- One uilabel error was corrected (in reactor.h).  
- All pragma variables were confirmed to have uilabels, with the exception of ResBuf pragmas, which are invisible to the user.  
- Some formatting was done to keep to the 80 character line limit.  
- A couple of typos corrected.

Unit tests, nosetests, and run_inputs all pass on Mac.