### PR TITLE
Fix EF tails

### DIFF
--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -172,6 +172,7 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Enrichment::GetMatlBids(
   using cyclus::Converter;
   using cyclus::Material;
   using cyclus::Request;
+  using cyclus::toolkit::MatVec;
 
   std::set<BidPortfolio<Material>::Ptr> ports;
 
@@ -182,8 +183,17 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Enrichment::GetMatlBids(
       out_requests[tails_commod];
     std::vector<Request<Material>*>::iterator it;
     for (it = tails_requests.begin(); it != tails_requests.end(); ++it) {
-      Request<Material>* req = *it;
-      tails_port->AddBid(req, tails.Peek(), this);
+      // offer bids for all tails material, keeping discrete quantities
+      // to preserve possible variation in composition 
+      MatVec mats = tails.PopN(tails.count());
+      tails.Push(mats);
+      for (int k = 0; k < mats.size(); k++) {
+        Material::Ptr m = mats[k];
+	Request<Material>* req = *it;
+	tails_port->AddBid(req, m, this);
+	}
+      //      Request<Material>* req = *it;
+      //      tails_port->AddBid(req, tails.Peek(), this);
     }
     // overbidding (bidding on every offer)
     // add an overall capacity constraint 

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -192,8 +192,6 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Enrichment::GetMatlBids(
 	Request<Material>* req = *it;
 	tails_port->AddBid(req, m, this);
 	}
-      //      Request<Material>* req = *it;
-      //      tails_port->AddBid(req, tails.Peek(), this);
     }
     // overbidding (bidding on every offer)
     // add an overall capacity constraint 


### PR DESCRIPTION
Addresses bug reported by Jenny in which EF facility only trades one unit of tails commodity at each time step, even if the quantity does not meet the requested quantity.  Includes a test.  Jenny can you confirm this PR works for your use case?