### PR TITLE
prevent separation to make bid with 0 quantity

### DIFF
--- a/src/separations.cc
+++ b/src/separations.cc
@@ -243,7 +243,8 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
       for (int k = 0; k < mats.size(); k++) {
         Material::Ptr m = mats[k];
         tot_bid += m->quantity();
-        port->AddBid(req, m, this, exclusive);
+          if(m->quantity() > 0)
+              port->AddBid(req, m, this, exclusive);
         if (tot_bid >= req->target()->quantity()) {
           break;
         }
@@ -270,7 +271,8 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
       for (int k = 0; k < mats.size(); k++) {
         Material::Ptr m = mats[k];
         tot_bid += m->quantity();
-        port->AddBid(req, m, this, exclusive);
+          if(m->quantity() > 0)
+              port->AddBid(req, m, this, exclusive);
         if (tot_bid >= req->target()->quantity()) {
           break;
         }

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -243,8 +243,12 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
       for (int k = 0; k < mats.size(); k++) {
         Material::Ptr m = mats[k];
         tot_bid += m->quantity();
-          if(m->quantity() > 0)
-              port->AddBid(req, m, this, exclusive);
+
+        // this fix the problem of the cyclus exchange manager which crashes when a bid with a quantity <=0 is offered.
+        if(m->quantity() > cyclus::eps()){
+          port->AddBid(req, m, this, exclusive);
+        }
+
         if (tot_bid >= req->target()->quantity()) {
           break;
         }
@@ -271,8 +275,12 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
       for (int k = 0; k < mats.size(); k++) {
         Material::Ptr m = mats[k];
         tot_bid += m->quantity();
-          if(m->quantity() > 0)
-              port->AddBid(req, m, this, exclusive);
+
+        // this fix the problem of the cyclus exchange manager which crashes when a bid with a quantity <=0 is offered.
+        if(m->quantity() > cyclus::eps()){
+          port->AddBid(req, m, this, exclusive);
+        }
+
         if (tot_bid >= req->target()->quantity()) {
           break;
         }


### PR DESCRIPTION
In some case, separation was making bid with a 0 quantity, which cause some problem for the cyclus Greedy solver.
