### PR TITLE
move enrichment intra timestep reset to tock

### DIFF
--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -66,6 +66,9 @@ void Enrichment::Tock() {
   using cyclus::toolkit::RecordTimeSeries;
   RecordTimeSeries<cyclus::toolkit::ENRICH_SWU>(this, intra_timestep_swu_);
   RecordTimeSeries<cyclus::toolkit::ENRICH_FEED>(this, intra_timestep_feed_);
+  
+  intra_timestep_swu_ = 0;
+  intra_timestep_feed_ = 0;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -253,9 +256,6 @@ void Enrichment::GetMatlTrades(
 
   using cyclus::Material;
   using cyclus::Trade;
-
-  intra_timestep_swu_ = 0;
-  intra_timestep_feed_ = 0;
 
   std::vector< Trade<Material> >::const_iterator it;
   for (it = trades.begin(); it != trades.end(); ++it) {


### PR DESCRIPTION
Hi everyone,

I found that in some scenarios I've run that the enrichment time series was being recorded wrong. I have to apologize because this languished long enough for me not to remember how I was planning to test it -- this is the first time I've run into the issue. I don't have time to add tests now, but if we want to block the PR until tests are added, it could be a good exercise for a new dev.
