### PR TITLE
Limit the total separation efficiency per nuclei

### DIFF
--- a/src/separations.cc
+++ b/src/separations.cc
@@ -72,12 +72,26 @@ void Separations::EnterNotify() {
     
   }
   
+  std::vector<int> eff_pb_;
   for( it2 = efficiency_.begin(); it2 != efficiency_.end(); it2++  ){
     if( it2->second > 1){
-      std::stringstream ss;
-      ss << "In " << prototype() << ": Nuclei " << it2->first << " has a cumulativ seperation efficiency greater than 1 ";
-      throw cyclus::ValueError(ss.str());
+      eff_pb_.push_back(it2->first);
     }
+  }
+  
+  if(eff_pb_.size() > 0){
+    std::stringstream ss;
+    ss << "In " << prototype() << ": Nuclide";
+    if(eff_pb_.size() == 1){
+      ss << " " << eff_pb_[0] << " has a cumulative separation efficiency greater than 1 !";
+    } else {
+      ss << "s {" << eff_pb_[0];
+      for(int i = 1; i < eff_pb_.size(); i++){
+        ss << ", " << eff_pb_[i];
+      }
+      ss << "} have a repsective cumulative separation efficiency greater than 1 !";
+    }
+    throw cyclus::ValueError(ss.str());
   }
 
 

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -81,16 +81,17 @@ void Separations::EnterNotify() {
   
   if(eff_pb_.size() > 0){
     std::stringstream ss;
-    ss << "In " << prototype() << ": Nuclide";
-    if(eff_pb_.size() == 1){
-      ss << " " << eff_pb_[0] << " has a cumulative separation efficiency greater than 1 !";
-    } else {
-      ss << "s {" << eff_pb_[0];
-      for(int i = 1; i < eff_pb_.size(); i++){
-        ss << ", " << eff_pb_[i];
+    ss << "In " << prototype() << ", ";
+    ss << "the following nuclide(s) have a cumulative separation efficiency greater than 1:";
+    for(int i = 0; i < eff_pb_.size(); i++){
+      ss << "\n" << eff_pb_[i];
+      if( i < eff_pb_.size()-1 ){
+        ss << ",";
+      } else{
+        ss << ".";
       }
-      ss << "} have a repsective cumulative separation efficiency greater than 1 !";
     }
+    
     throw cyclus::ValueError(ss.str());
   }
 

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -52,11 +52,11 @@ typedef std::map<std::string, Stream> StreamSet;
 
 void Separations::EnterNotify() {
   cyclus::Facility::EnterNotify();
+  std::map<int, double> efficiency_;
+
   StreamSet::iterator it;
   std::map< int, double>::iterator it2;
 
-  
-  std::map<int, double> efficiency;
 
   for (it = streams_.begin(); it != streams_.end(); ++it) {
     std::string name = it->first;
@@ -67,12 +67,12 @@ void Separations::EnterNotify() {
     }
     
     for( it2 = stream.second.begin(); it2 != stream.second.end(); it2++  ){
-      efficiency[it2->first] += it2->second;
+      efficiency_[it2->first] += it2->second;
     }
     
   }
   
-  for( it2 = efficiency.begin(); it2 != efficiency.end(); it2++  ){
+  for( it2 = efficiency_.begin(); it2 != efficiency_.end(); it2++  ){
     if( it2->second > 1){
       std::stringstream ss;
       ss << "In " << prototype() << ": Nuclei " << it2->first << " has a cumulativ seperation efficiency greater than 1 ";

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -84,7 +84,7 @@ void Separations::EnterNotify() {
     ss << "In " << prototype() << ", ";
     ss << "the following nuclide(s) have a cumulative separation efficiency greater than 1:";
     for(int i = 0; i < eff_pb_.size(); i++){
-      ss << "\n" << eff_pb_[i];
+      ss << "\n    " << eff_pb_[i];
       if( i < eff_pb_.size()-1 ){
         ss << ",";
       } else{

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -53,6 +53,11 @@ typedef std::map<std::string, Stream> StreamSet;
 void Separations::EnterNotify() {
   cyclus::Facility::EnterNotify();
   StreamSet::iterator it;
+  std::map< int, double>::iterator it2;
+
+  
+  std::map<int, double> efficiency;
+
   for (it = streams_.begin(); it != streams_.end(); ++it) {
     std::string name = it->first;
     Stream stream = it->second;
@@ -60,7 +65,21 @@ void Separations::EnterNotify() {
     if (cap >= 0) {
       streambufs[name].capacity(cap);
     }
+    
+    for( it2 = stream.second.begin(); it2 != stream.second.end(); it2++  ){
+      efficiency[it2->first] += it2->second;
+    }
+    
   }
+  
+  for( it2 = efficiency.begin(); it2 != efficiency.end(); it2++  ){
+    if( it2->second > 1){
+      std::stringstream ss;
+      ss << "In " << prototype() << ": Nuclei " << it2->first << " has a cumulativ seperation efficiency greater than 1 ";
+      throw cyclus::ValueError(ss.str());
+    }
+  }
+
 
   if (feed_commod_prefs.size() == 0) {
     for (int i = 0; i < feed_commods.size(); i++) {

--- a/src/separations_tests.cc
+++ b/src/separations_tests.cc
@@ -44,7 +44,7 @@ TEST(SeparationsTests, SepMaterial) {
 }
 
   
-// Test if a total separation of 1 and less works as expected.
+// Check that cumulative separations efficiency for a single nuclide of less than or equal to one does not trigger an error.
 TEST(SeparationsTests, SeparationEfficiency) {
 
   int simdur = 2;
@@ -88,7 +88,7 @@ TEST(SeparationsTests, SeparationEfficiency) {
   
   cyclus::MockSim sim1(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
   
-  EXPECT_NO_THROW(sim1.Run()) << "Cumulative separation efficiency smaler than 1 is throwing an error but should not.\n";
+  EXPECT_NO_THROW(sim1.Run()) << "Cumulative separation efficiency smaler than 1 is throwing an error but should not.";
   
   
   config =
@@ -134,14 +134,14 @@ TEST(SeparationsTests, SeparationEfficiency) {
   
   cyclus::MockSim sim2(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
   
-  EXPECT_NO_THROW(sim2.Run()) << "Cumulative separation efficiency of 1 is throwing an error but should not.\n";
+  EXPECT_NO_THROW(sim2.Run()) << "Cumulative separation efficiency of 1 is throwing an error but should not.";
 }
 
-  
+// Check that an error is correctly thrown when separations efficiency of greater than one.
 TEST(SeparationsTests, SeparationEfficiencyThrowing) {
   int simdur = 2;
 
-  // Check if a unique separation efficiency greater than 1 throw an error as expected.
+  // Check that single separations efficiency for a single nuclide of greater than one does not trigger an error.
   std::string config =
       "<streams>"
       "    <item>"
@@ -164,9 +164,9 @@ TEST(SeparationsTests, SeparationEfficiencyThrowing) {
 
   cyclus::MockSim sim1(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
   
-  EXPECT_THROW(sim1.Run(), cyclus::ValueError) << "Direct separation efficiency greater than 1 is no throwing an error but should.\n";
+  EXPECT_THROW(sim1.Run(), cyclus::ValueError) << "Direct separation efficiency greater than 1 is not throwing an error but should.";
   
-  // Check if a cumulative separation efficiency greater than 1 for a unique nuclide throw an error as expected.
+// Check if a cumulative separation efficiency greater than 1 for a unique nuclide throw an error as expected.
   config =
     "<streams>"
     "    <item>"
@@ -199,8 +199,8 @@ TEST(SeparationsTests, SeparationEfficiencyThrowing) {
   
   cyclus::MockSim sim2(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
   
-  EXPECT_THROW(sim2.Run(), cyclus::ValueError) << "Single cumulative separation efficiency greater than 1 is no throwing an error but should.\n";
-  // Check if a cumulative separation efficiency greater than 1 for multiple nuclides throw an error as expected.
+  EXPECT_THROW(sim2.Run(), cyclus::ValueError) << "Single cumulative separation efficiency greater than 1 is not throwing an error but should.";
+// Check if a cumulative separation efficiency greater than 1 for multiple nuclides throw an error as expected.
   config =
       "<streams>"
       "    <item>"
@@ -233,7 +233,7 @@ TEST(SeparationsTests, SeparationEfficiencyThrowing) {
   
   cyclus::MockSim sim3(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
   
-  EXPECT_THROW(sim3.Run(), cyclus::ValueError) << "Multiple cumulative separation efficiencies greater than 1 are no throwing an error but should.\n";
+  EXPECT_THROW(sim3.Run(), cyclus::ValueError) << "Multiple cumulative separation efficiencies greater than 1 are not throwing an error but should.";
 }
   
 TEST(SeparationsTests, SepMixElemAndNuclide) {

--- a/src/separations_tests.cc
+++ b/src/separations_tests.cc
@@ -42,7 +42,153 @@ TEST(SeparationsTests, SepMaterial) {
   EXPECT_DOUBLE_EQ(effs[id("Am241")] * mqorig.mass("Am241"), mqsep.mass("Am241"));
   EXPECT_DOUBLE_EQ(0, mqsep.mass("Am242"));
 }
+  
+TEST(SeparationsTests, SeparationEfficiency) {
+  std::string config =
+      "<streams>"
+      "    <item>"
+      "        <commod>stream1</commod>"
+      "        <info>"
+      "            <buf_size>-1</buf_size>"
+      "            <efficiencies>"
+      "                <item><comp>U</comp> <eff>0.1</eff></item>"
+      "                <item><comp>Pu239</comp> <eff>.2</eff></item>"
+      "            </efficiencies>"
+      "        </info>"
+      "    </item>"
+      "    <item>"
+      "        <commod>stream1</commod>"
+      "        <info>"
+      "            <buf_size>-1</buf_size>"
+      "            <efficiencies>"
+      "                <item><comp>U</comp> <eff>0.2</eff></item>"
+      "                <item><comp>Pu239</comp> <eff>.1</eff></item>"
+      "            </efficiencies>"
+      "        </info>"
+      "    </item>"
+      "    <item>"
+      "        <commod>stream1</commod>"
+      "        <info>"
+      "            <buf_size>-1</buf_size>"
+      "            <efficiencies>"
+      "                <item><comp>U</comp> <eff>0.7</eff></item>"
+      "                <item><comp>Pu239</comp> <eff>.5</eff></item>"
+      "            </efficiencies>"
+      "        </info>"
+      "    </item>"
+      "</streams>"
+      ""
+      "<leftover_commod>waste</leftover_commod>"
+      "<throughput>100</throughput>"
+      "<feedbuf_size>100</feedbuf_size>"
+      "<feed_commods> <val>feed</val> </feed_commods>"
+      ;
+  
+  
+  int simdur = 2;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
+  
+  EXPECT_NO_THROW(sim.Run());
+}
 
+  
+TEST(SeparationsTests, SeparationEfficiencyThrowing) {
+  int simdur = 2;
+  std::string config =
+      "<streams>"
+      "    <item>"
+      "        <commod>stream1</commod>"
+      "        <info>"
+      "            <buf_size>-1</buf_size>"
+      "            <efficiencies>"
+      "                <item><comp>U</comp> <eff>1.6</eff></item>"
+      "                <item><comp>Pu239</comp> <eff>.7</eff></item>"
+      "            </efficiencies>"
+      "        </info>"
+      "    </item>"
+      "</streams>"
+      ""
+      "<leftover_commod>waste</leftover_commod>"
+      "<throughput>100</throughput>"
+      "<feedbuf_size>100</feedbuf_size>"
+      "<feed_commods> <val>feed</val> </feed_commods>"
+      ;
+
+  
+  cyclus::MockSim sim1(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
+  
+  EXPECT_THROW(sim1.Run(), cyclus::ValueError);
+  
+  config =
+    "<streams>"
+    "    <item>"
+    "        <commod>stream1</commod>"
+    "        <info>"
+    "            <buf_size>-1</buf_size>"
+    "            <efficiencies>"
+    "                <item><comp>U</comp> <eff>0.6</eff></item>"
+    "                <item><comp>Pu239</comp> <eff>.7</eff></item>"
+    "            </efficiencies>"
+    "        </info>"
+    "    </item>"
+    "    <item>"
+    "        <commod>stream2</commod>"
+    "        <info>"
+    "            <buf_size>-1</buf_size>"
+    "            <efficiencies>"
+    "                <item><comp>U</comp> <eff>0.1</eff></item>"
+    "                <item><comp>Pu239</comp> <eff>.7</eff></item>"
+    "            </efficiencies>"
+    "        </info>"
+    "    </item>"
+    "</streams>"
+    ""
+    "<leftover_commod>waste</leftover_commod>"
+    "<throughput>100</throughput>"
+    "<feedbuf_size>100</feedbuf_size>"
+    "<feed_commods> <val>feed</val> </feed_commods>"
+    ;
+  
+  cyclus::MockSim sim2(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
+  
+  EXPECT_THROW(sim2.Run(), cyclus::ValueError);
+  
+  config =
+      "<streams>"
+      "    <item>"
+      "        <commod>stream1</commod>"
+      "        <info>"
+      "            <buf_size>-1</buf_size>"
+      "            <efficiencies>"
+      "                <item><comp>U</comp> <eff>0.6</eff></item>"
+      "                <item><comp>Pu239</comp> <eff>.7</eff></item>"
+      "            </efficiencies>"
+      "        </info>"
+      "    </item>"
+      "    <item>"
+      "        <commod>stream2</commod>"
+      "        <info>"
+      "            <buf_size>-1</buf_size>"
+      "            <efficiencies>"
+      "                <item><comp>U</comp> <eff>0.6</eff></item>"
+      "                <item><comp>Pu239</comp> <eff>.7</eff></item>"
+      "            </efficiencies>"
+      "        </info>"
+      "    </item>"
+      "</streams>"
+      ""
+      "<leftover_commod>waste</leftover_commod>"
+      "<throughput>100</throughput>"
+      "<feedbuf_size>100</feedbuf_size>"
+      "<feed_commods> <val>feed</val> </feed_commods>"
+      ;
+  
+  cyclus::MockSim sim3(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
+  
+  EXPECT_THROW(sim3.Run(), cyclus::ValueError);
+  
+}
+  
 TEST(SeparationsTests, SepMixElemAndNuclide) {
   std::string config =
       "<streams>"

--- a/src/separations_tests.cc
+++ b/src/separations_tests.cc
@@ -42,9 +42,56 @@ TEST(SeparationsTests, SepMaterial) {
   EXPECT_DOUBLE_EQ(effs[id("Am241")] * mqorig.mass("Am241"), mqsep.mass("Am241"));
   EXPECT_DOUBLE_EQ(0, mqsep.mass("Am242"));
 }
+
   
+// Test if a total separation of 1 and less works as expected.
 TEST(SeparationsTests, SeparationEfficiency) {
+
+  int simdur = 2;
   std::string config =
+      "<streams>"
+      "    <item>"
+      "        <commod>stream1</commod>"
+      "        <info>"
+      "            <buf_size>-1</buf_size>"
+      "            <efficiencies>"
+      "                <item><comp>Pu239</comp> <eff>.2</eff></item>"
+      "            </efficiencies>"
+      "        </info>"
+      "    </item>"
+      "    <item>"
+      "        <commod>stream1</commod>"
+      "        <info>"
+      "            <buf_size>-1</buf_size>"
+      "            <efficiencies>"
+      "                <item><comp>Pu239</comp> <eff>.1</eff></item>"
+      "            </efficiencies>"
+      "        </info>"
+      "    </item>"
+      "    <item>"
+      "        <commod>stream1</commod>"
+      "        <info>"
+      "            <buf_size>-1</buf_size>"
+      "            <efficiencies>"
+      "                <item><comp>Pu239</comp> <eff>.5</eff></item>"
+      "            </efficiencies>"
+      "        </info>"
+      "    </item>"
+      "</streams>"
+      ""
+      "<leftover_commod>waste</leftover_commod>"
+      "<throughput>100</throughput>"
+      "<feedbuf_size>100</feedbuf_size>"
+      "<feed_commods> <val>feed</val> </feed_commods>"
+  ;
+  
+  
+  cyclus::MockSim sim1(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
+  
+  EXPECT_NO_THROW(sim1.Run()) << "Cumulative separation efficiency smaler than 1 is throwing an error but should not.\n";
+  
+  
+  config =
       "<streams>"
       "    <item>"
       "        <commod>stream1</commod>"
@@ -85,15 +132,16 @@ TEST(SeparationsTests, SeparationEfficiency) {
       ;
   
   
-  int simdur = 2;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
+  cyclus::MockSim sim2(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
   
-  EXPECT_NO_THROW(sim.Run());
+  EXPECT_NO_THROW(sim2.Run()) << "Cumulative separation efficiency of 1 is throwing an error but should not.\n";
 }
 
   
 TEST(SeparationsTests, SeparationEfficiencyThrowing) {
   int simdur = 2;
+
+  // Check if a unique separation efficiency greater than 1 throw an error as expected.
   std::string config =
       "<streams>"
       "    <item>"
@@ -114,11 +162,11 @@ TEST(SeparationsTests, SeparationEfficiencyThrowing) {
       "<feed_commods> <val>feed</val> </feed_commods>"
       ;
 
-  
   cyclus::MockSim sim1(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
   
-  EXPECT_THROW(sim1.Run(), cyclus::ValueError);
+  EXPECT_THROW(sim1.Run(), cyclus::ValueError) << "Direct separation efficiency greater than 1 is no throwing an error but should.\n";
   
+  // Check if a cumulative separation efficiency greater than 1 for a unique nuclide throw an error as expected.
   config =
     "<streams>"
     "    <item>"
@@ -151,8 +199,8 @@ TEST(SeparationsTests, SeparationEfficiencyThrowing) {
   
   cyclus::MockSim sim2(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
   
-  EXPECT_THROW(sim2.Run(), cyclus::ValueError);
-  
+  EXPECT_THROW(sim2.Run(), cyclus::ValueError) << "Single cumulative separation efficiency greater than 1 is no throwing an error but should.\n";
+  // Check if a cumulative separation efficiency greater than 1 for multiple nuclides throw an error as expected.
   config =
       "<streams>"
       "    <item>"
@@ -185,8 +233,7 @@ TEST(SeparationsTests, SeparationEfficiencyThrowing) {
   
   cyclus::MockSim sim3(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
   
-  EXPECT_THROW(sim3.Run(), cyclus::ValueError);
-  
+  EXPECT_THROW(sim3.Run(), cyclus::ValueError) << "Multiple cumulative separation efficiencies greater than 1 are no throwing an error but should.\n";
 }
   
 TEST(SeparationsTests, SepMixElemAndNuclide) {


### PR DESCRIPTION
Throw an error when defining a total separation efficiency greater than 1 for a nuclei.