### PR TITLE
max enrich condition was sometimes failing due to floating point errors

### DIFF
--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -220,8 +220,10 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Enrichment::GetMatlBids(
       Material::Ptr mat = req->target();
       double request_enrich = cyclus::toolkit::UraniumAssay(mat) ;
 
-      if (ValidReq(req->target()) && (request_enrich <= max_enrich)) {
-        Material::Ptr offer = Offer_(req->target());
+       if (ValidReq(req->target()) &&
+	  ((request_enrich < max_enrich) ||
+	   (cyclus::AlmostEq(request_enrich, max_enrich)))){
+         Material::Ptr offer = Offer_(req->target());
         commod_port->AddBid(req, offer, this);
       }
     }

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -218,15 +218,15 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Enrichment::GetMatlBids(
     for (it = commod_requests.begin(); it != commod_requests.end(); ++it) {
       Request<Material>* req = *it;
       Material::Ptr mat = req->target();
-      double request_enrich = cyclus::toolkit::UraniumAssay(mat) ;
-
-       if (ValidReq(req->target()) &&
-	  ((request_enrich < max_enrich) ||
-	   (cyclus::AlmostEq(request_enrich, max_enrich)))){
-         Material::Ptr offer = Offer_(req->target());
+      double request_enrich = cyclus::toolkit::UraniumAssay(mat);
+      if (ValidReq(req->target()) &&
+          ((request_enrich < max_enrich) ||
+	   (cyclus::AlmostEq(request_enrich, max_enrich)))) {
+        Material::Ptr offer = Offer_(req->target());
         commod_port->AddBid(req, offer, this);
       }
     }
+
     Converter<Material>::Ptr sc(new SWUConverter(FeedAssay(), tails_assay));
     Converter<Material>::Ptr nc(new NatUConverter(FeedAssay(), tails_assay));
     CapacityConstraint<Material> swu(swu_capacity, sc);


### PR DESCRIPTION
Drew found that a <= condition was failing on the = (though it had passed in the unit test).  