### PR TITLE
Fix units of buf_size to match shape expected/required by cycic

### DIFF
--- a/src/mixer.h
+++ b/src/mixer.h
@@ -77,7 +77,7 @@ class Mixer : public cyclus::Facility {
     "doc": "Size of input material stream inventory - i.e. the quantity of each" \
            " stream type to keep on-hand)", \
     "uilabel": "Input Inventory Capacity", \
-    "units": "kg", \
+    "units": [ "", "kg"],                  \
   }
   std::vector<double> in_buf_sizes;
 


### PR DESCRIPTION
This fixes an error in the Cycic annotations for the Mixer archetype