### PR TITLE
Absolute precision

### DIFF
--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -6,6 +6,7 @@
 #include <limits>
 #include <sstream>
 #include <vector>
+
 #include <boost/lexical_cast.hpp>
 
 namespace cycamore {
@@ -15,13 +16,13 @@ Enrichment::Enrichment(cyclus::Context* ctx)
     : cyclus::Facility(ctx),
       tails_assay(0),
       swu_capacity(0),
-      max_enrich(1), 
+      max_enrich(1),
       initial_feed(0),
       feed_commod(""),
       feed_recipe(""),
       product_commod(""),
       tails_commod(""),
-      order_prefs(true){}
+      order_prefs(true) {}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Enrichment::~Enrichment() {}
@@ -29,11 +30,9 @@ Enrichment::~Enrichment() {}
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::string Enrichment::str() {
   std::stringstream ss;
-  ss << cyclus::Facility::str()
-     << " with enrichment facility parameters:"
+  ss << cyclus::Facility::str() << " with enrichment facility parameters:"
      << " * SWU capacity: " << SwuCapacity()
-     << " * Tails assay: " << tails_assay
-     << " * Feed assay: " << FeedAssay()
+     << " * Tails assay: " << tails_assay << " * Feed assay: " << FeedAssay()
      << " * Input cyclus::Commodity: " << feed_commod
      << " * Output cyclus::Commodity: " << product_commod
      << " * Tails cyclus::Commodity: " << tails_commod;
@@ -46,37 +45,32 @@ void Enrichment::Build(cyclus::Agent* parent) {
 
   Facility::Build(parent);
   if (initial_feed > 0) {
-    inventory.Push(
-      Material::Create(
-        this, initial_feed, context()->GetRecipe(feed_recipe)));
+    inventory.Push(Material::Create(this, initial_feed,
+                                    context()->GetRecipe(feed_recipe)));
   }
 
   LOG(cyclus::LEV_DEBUG2, "EnrFac") << "Enrichment "
-				    << " entering the simuluation: ";
+                                    << " entering the simuluation: ";
   LOG(cyclus::LEV_DEBUG2, "EnrFac") << str();
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-void Enrichment::Tick() {
-  current_swu_capacity = SwuCapacity();
-}
+void Enrichment::Tick() { current_swu_capacity = SwuCapacity(); }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::Tock() {
   using cyclus::toolkit::RecordTimeSeries;
-  LOG(cyclus::LEV_INFO4, "EnrFac") << prototype()
-                                   << " used " << intra_timestep_swu_
-                                   << " SWU";
+  LOG(cyclus::LEV_INFO4, "EnrFac") << prototype() << " used "
+                                   << intra_timestep_swu_ << " SWU";
   RecordTimeSeries<cyclus::toolkit::ENRICH_SWU>(this, intra_timestep_swu_);
-  LOG(cyclus::LEV_INFO4, "EnrFac") << prototype()
-                                   << " used " << intra_timestep_feed_
-                                   << " feed";
+  LOG(cyclus::LEV_INFO4, "EnrFac") << prototype() << " used "
+                                   << intra_timestep_feed_ << " feed";
   RecordTimeSeries<cyclus::toolkit::ENRICH_FEED>(this, intra_timestep_feed_);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-    Enrichment::GetMatlRequests() {
+Enrichment::GetMatlRequests() {
   using cyclus::Material;
   using cyclus::RequestPortfolio;
   using cyclus::Request;
@@ -95,9 +89,8 @@ std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-bool SortBids(
-    cyclus::Bid<cyclus::Material>* i, cyclus::Bid<cyclus::Material>* j) {
-
+bool SortBids(cyclus::Bid<cyclus::Material>* i,
+              cyclus::Bid<cyclus::Material>* j) {
   cyclus::Material::Ptr mat_i = i->offer();
   cyclus::Material::Ptr mat_j = j->offer();
 
@@ -105,18 +98,17 @@ bool SortBids(
   cyclus::toolkit::MatQuery mq_j(mat_j);
 
   return ((mq_i.mass(922350000) / mq_i.qty()) <=
-	  (mq_j.mass(922350000) / mq_j.qty()));
+          (mq_j.mass(922350000) / mq_j.qty()));
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Sort offers of input material to have higher preference for more
 //  U-235 content
 void Enrichment::AdjustMatlPrefs(
     cyclus::PrefMap<cyclus::Material>::type& prefs) {
-
   using cyclus::Bid;
   using cyclus::Material;
   using cyclus::Request;
-  
+
   if (order_prefs == false) {
     return;
   }
@@ -125,53 +117,52 @@ void Enrichment::AdjustMatlPrefs(
 
   // Loop over all requests
   for (reqit = prefs.begin(); reqit != prefs.end(); ++reqit) {
-    std::vector<Bid<Material>* > bids_vector;    
+    std::vector<Bid<Material>*> bids_vector;
     std::map<Bid<Material>*, double>::iterator mit;
     for (mit = reqit->second.begin(); mit != reqit->second.end(); ++mit) {
       Bid<Material>* bid = mit->first;
       bids_vector.push_back(bid);
     }
-    std::sort (bids_vector.begin(), bids_vector.end(), SortBids); 
+    std::sort(bids_vector.begin(), bids_vector.end(), SortBids);
 
     // Assign preferences to the sorted vector
     double n_bids = bids_vector.size();
     bool u235_mass = 0;
 
-    for (int bidit = 0 ; bidit < bids_vector.size(); bidit++) {
+    for (int bidit = 0; bidit < bids_vector.size(); bidit++) {
       int new_pref = bidit + 1;
-      
-      // For any bids with U-235 qty=0, set pref to zero. 
+
+      // For any bids with U-235 qty=0, set pref to zero.
       if (!u235_mass) {
-	cyclus::Material::Ptr mat = bids_vector[bidit]->offer();
-	cyclus::toolkit::MatQuery mq(mat);
-	if (mq.mass(922350000) == 0) {
-	  new_pref = -1;
-	}
-	else {
-	  u235_mass = true;
-	}
+        cyclus::Material::Ptr mat = bids_vector[bidit]->offer();
+        cyclus::toolkit::MatQuery mq(mat);
+        if (mq.mass(922350000) == 0) {
+          new_pref = -1;
+        } else {
+          u235_mass = true;
+        }
       }
       (reqit->second)[bids_vector[bidit]] = new_pref;
-    } // each bid
-  } // each Material Request
+    }  // each bid
+  }    // each Material Request
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::AcceptMatlTrades(
-    const std::vector< std::pair<cyclus::Trade<cyclus::Material>,
-    cyclus::Material::Ptr> >& responses) {
+    const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                                cyclus::Material::Ptr> >& responses) {
   // see
   // http://stackoverflow.com/questions/5181183/boostshared-ptr-and-inheritance
-  std::vector< std::pair<cyclus::Trade<cyclus::Material>,
-      cyclus::Material::Ptr> >::const_iterator it;
+  std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                        cyclus::Material::Ptr> >::const_iterator it;
   for (it = responses.begin(); it != responses.end(); ++it) {
     AddMat_(it->second);
   }
 }
-  
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Enrichment::GetMatlBids(
-    cyclus::CommodMap<cyclus::Material>::type& out_requests){
+    cyclus::CommodMap<cyclus::Material>::type& out_requests) {
   using cyclus::Bid;
   using cyclus::BidPortfolio;
   using cyclus::CapacityConstraint;
@@ -184,36 +175,36 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Enrichment::GetMatlBids(
 
   if ((out_requests.count(tails_commod) > 0) && (tails.quantity() > 0)) {
     BidPortfolio<Material>::Ptr tails_port(new BidPortfolio<Material>());
-    
+
     std::vector<Request<Material>*>& tails_requests =
-      out_requests[tails_commod];
+        out_requests[tails_commod];
     std::vector<Request<Material>*>::iterator it;
     for (it = tails_requests.begin(); it != tails_requests.end(); ++it) {
       // offer bids for all tails material, keeping discrete quantities
-      // to preserve possible variation in composition 
+      // to preserve possible variation in composition
       MatVec mats = tails.PopN(tails.count());
       tails.Push(mats);
       for (int k = 0; k < mats.size(); k++) {
         Material::Ptr m = mats[k];
-	Request<Material>* req = *it;
-	tails_port->AddBid(req, m, this);
-	}
+        Request<Material>* req = *it;
+        tails_port->AddBid(req, m, this);
+      }
     }
     // overbidding (bidding on every offer)
-    // add an overall capacity constraint 
+    // add an overall capacity constraint
     CapacityConstraint<Material> tails_constraint(tails.quantity());
     tails_port->AddConstraint(tails_constraint);
     LOG(cyclus::LEV_INFO5, "EnrFac") << prototype()
-				     << " adding tails capacity constraint of "
-				     << tails.capacity();
+                                     << " adding tails capacity constraint of "
+                                     << tails.capacity();
     ports.insert(tails_port);
   }
 
   if ((out_requests.count(product_commod) > 0) && (inventory.quantity() > 0)) {
-    BidPortfolio<Material>::Ptr commod_port(new BidPortfolio<Material>()); 
-    
+    BidPortfolio<Material>::Ptr commod_port(new BidPortfolio<Material>());
+
     std::vector<Request<Material>*>& commod_requests =
-      out_requests[product_commod];
+        out_requests[product_commod];
     std::vector<Request<Material>*>::iterator it;
     for (it = commod_requests.begin(); it != commod_requests.end(); ++it) {
       Request<Material>* req = *it;
@@ -221,7 +212,7 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Enrichment::GetMatlBids(
       double request_enrich = cyclus::toolkit::UraniumAssay(mat);
       if (ValidReq(req->target()) &&
           ((request_enrich < max_enrich) ||
-	   (cyclus::AlmostEq(request_enrich, max_enrich)))) {
+           (cyclus::AlmostEq(request_enrich, max_enrich)))) {
         Material::Ptr offer = Offer_(req->target());
         commod_port->AddBid(req, offer, this);
       }
@@ -233,13 +224,11 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Enrichment::GetMatlBids(
     CapacityConstraint<Material> natu(inventory.quantity(), nc);
     commod_port->AddConstraint(swu);
     commod_port->AddConstraint(natu);
-    
-    LOG(cyclus::LEV_INFO5, "EnrFac") << prototype()
-				     << " adding a swu constraint of "
-				     << swu.capacity();
-    LOG(cyclus::LEV_INFO5, "EnrFac") << prototype()
-				     << " adding a natu constraint of "
-				     << natu.capacity();
+
+    LOG(cyclus::LEV_INFO5, "EnrFac")
+        << prototype() << " adding a swu constraint of " << swu.capacity();
+    LOG(cyclus::LEV_INFO5, "EnrFac")
+        << prototype() << " adding a natu constraint of " << natu.capacity();
     ports.insert(commod_port);
   }
   return ports;
@@ -252,20 +241,19 @@ bool Enrichment::ValidReq(const cyclus::Material::Ptr mat) {
   double u238 = q.atom_frac(922380000);
   return (u238 > 0 && u235 / (u235 + u238) > tails_assay);
 }
-  
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::GetMatlTrades(
-    const std::vector< cyclus::Trade<cyclus::Material> >& trades,
+    const std::vector<cyclus::Trade<cyclus::Material> >& trades,
     std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-    cyclus::Material::Ptr> >& responses) {
-
+                          cyclus::Material::Ptr> >& responses) {
   using cyclus::Material;
   using cyclus::Trade;
 
   intra_timestep_swu_ = 0;
   intra_timestep_feed_ = 0;
 
-  std::vector< Trade<Material> >::const_iterator it;
+  std::vector<Trade<Material> >::const_iterator it;
   for (it = trades.begin(); it != trades.end(); ++it) {
     double qty = it->amt;
     std::string commod_type = it->bid->request()->commodity();
@@ -274,20 +262,18 @@ void Enrichment::GetMatlTrades(
     // Figure out whether material is tails or enriched,
     // if tails then make transfer of material
     if (commod_type == tails_commod) {
-      LOG(cyclus::LEV_INFO5, "EnrFac") << prototype()
-				       << " just received an order"
-				       << " for " << it->amt
-				       << " of " << tails_commod;
+      LOG(cyclus::LEV_INFO5, "EnrFac")
+          << prototype() << " just received an order"
+          << " for " << it->amt << " of " << tails_commod;
       double pop_qty = std::min(qty, tails.quantity());
-      response = tails.Pop( pop_qty, cyclus::eps_rsrc() );
+      response = tails.Pop(pop_qty, cyclus::eps_rsrc());
     } else {
-      LOG(cyclus::LEV_INFO5, "EnrFac") << prototype()
-				       << " just received an order"
-				       << " for " << it->amt
-				       << " of " << product_commod;
+      LOG(cyclus::LEV_INFO5, "EnrFac")
+          << prototype() << " just received an order"
+          << " for " << it->amt << " of " << product_commod;
       response = Enrich_(it->bid->offer(), qty);
     }
-    responses.push_back(std::make_pair(*it, response));	
+    responses.push_back(std::make_pair(*it, response));
   }
 
   if (cyclus::IsNegative(tails.quantity())) {
@@ -296,10 +282,9 @@ void Enrichment::GetMatlTrades(
     throw cyclus::ValueError(Agent::InformErrorMsg(ss.str()));
   }
   if (cyclus::IsNegative(current_swu_capacity)) {
-    throw cyclus::ValueError(
-			     "EnrFac " + prototype()
-			     + " is being asked to provide more than" +
-			     " its SWU capacity.");
+    throw cyclus::ValueError("EnrFac " + prototype() +
+                             " is being asked to provide more than" +
+                             " its SWU capacity.");
   }
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -312,44 +297,44 @@ void Enrichment::AddMat_(cyclus::Material::Ptr mat) {
     if (pyne::nucname::znum(it->first) == 92) {
       if (pyne::nucname::anum(it->first) != 235 &&
           pyne::nucname::anum(it->first) != 238 && it->second > 0) {
-	extra_u = true;
+        extra_u = true;
       }
-    }
-    else if (it->second > 0) {
-      other_elem = true ;
+    } else if (it->second > 0) {
+      other_elem = true;
     }
   }
   if (extra_u) {
-    cyclus::Warn<cyclus::VALUE_WARNING> ("More than 2 isotopes of U.  "  \
-      "Istopes other than U-235, U-238 are sent directly to tails.");
+    cyclus::Warn<cyclus::VALUE_WARNING>(
+        "More than 2 isotopes of U.  "
+        "Istopes other than U-235, U-238 are sent directly to tails.");
   }
   if (other_elem) {
-    cyclus::Warn<cyclus::VALUE_WARNING> ("Non-uranium elements are "   \
-      "sent directly to tails.");
+    cyclus::Warn<cyclus::VALUE_WARNING>(
+        "Non-uranium elements are "
+        "sent directly to tails.");
   }
 
   LOG(cyclus::LEV_INFO5, "EnrFac") << prototype() << " is initially holding "
-				   << inventory.quantity() << " total.";
-  
+                                   << inventory.quantity() << " total.";
+
   try {
     inventory.Push(mat);
-  }
-  catch (cyclus::Error& e) {
+  } catch (cyclus::Error& e) {
     e.msg(Agent::InformErrorMsg(e.msg()));
     throw e;
   }
 
-  LOG(cyclus::LEV_INFO5, "EnrFac") << prototype() << " added "
-                                   << mat->quantity() << " of " << feed_commod
-                                   << " to its inventory, which is holding "
-                                   << inventory.quantity() << " total.";
+  LOG(cyclus::LEV_INFO5, "EnrFac")
+      << prototype() << " added " << mat->quantity() << " of " << feed_commod
+      << " to its inventory, which is holding " << inventory.quantity()
+      << " total.";
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 cyclus::Material::Ptr Enrichment::Request_() {
   double qty = std::max(0.0, inventory.capacity() - inventory.quantity());
   return cyclus::Material::CreateUntracked(qty,
-					   context()->GetRecipe(feed_recipe));
+                                           context()->GetRecipe(feed_recipe));
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -359,13 +344,11 @@ cyclus::Material::Ptr Enrichment::Offer_(cyclus::Material::Ptr mat) {
   comp[922350000] = q.atom_frac(922350000);
   comp[922380000] = q.atom_frac(922380000);
   return cyclus::Material::CreateUntracked(
-           mat->quantity(), cyclus::Composition::CreateFromAtom(comp));
+      mat->quantity(), cyclus::Composition::CreateFromAtom(comp));
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-cyclus::Material::Ptr Enrichment::Enrich_(
-    cyclus::Material::Ptr mat,
-    double qty) {
-
+cyclus::Material::Ptr Enrichment::Enrich_(cyclus::Material::Ptr mat,
+                                          double qty) {
   using cyclus::Material;
   using cyclus::ResCast;
   using cyclus::toolkit::Assays;
@@ -384,13 +367,13 @@ cyclus::Material::Ptr Enrichment::Enrich_(
   double pop_qty = inventory.quantity();
   Material::Ptr natu_matl = inventory.Pop(pop_qty, cyclus::eps_rsrc());
   inventory.Push(natu_matl);
-  
+
   cyclus::toolkit::MatQuery mq(natu_matl);
   std::set<cyclus::Nuc> nucs;
   nucs.insert(922350000);
   nucs.insert(922380000);
   double natu_frac = mq.mass_frac(nucs);
-  double feed_req = natu_req/natu_frac;
+  double feed_req = natu_req / natu_frac;
 
   // pop amount from inventory and blob it into one material
   Material::Ptr r;
@@ -404,8 +387,8 @@ cyclus::Material::Ptr Enrichment::Enrich_(
   } catch (cyclus::Error& e) {
     NatUConverter nc(FeedAssay(), tails_assay);
     std::stringstream ss;
-    ss << " tried to remove " << feed_req
-       << " from its inventory of size " << inventory.quantity()
+    ss << " tried to remove " << feed_req << " from its inventory of size "
+       << inventory.quantity()
        << " and the conversion of the material into natu is "
        << nc.convert(mat);
     throw cyclus::ValueError(Agent::InformErrorMsg(ss.str()));
@@ -414,7 +397,7 @@ cyclus::Material::Ptr Enrichment::Enrich_(
   // "enrich" it, but pull out the composition and quantity we require from the
   // blob
   cyclus::Composition::Ptr comp = mat->comp();
-  Material::Ptr response = r->ExtractComp(qty, comp); 
+  Material::Ptr response = r->ExtractComp(qty, comp);
   tails.Push(r);
 
   current_swu_capacity -= swu_req;
@@ -423,24 +406,21 @@ cyclus::Material::Ptr Enrichment::Enrich_(
   intra_timestep_feed_ += feed_req;
   RecordEnrichment_(feed_req, swu_req);
 
-  LOG(cyclus::LEV_INFO5, "EnrFac") << prototype() <<
-                                " has performed an enrichment: ";
-  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Feed Qty: "
-                                << feed_req;
+  LOG(cyclus::LEV_INFO5, "EnrFac") << prototype()
+                                   << " has performed an enrichment: ";
+  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Feed Qty: " << feed_req;
   LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Feed Assay: "
-                                << assays.Feed() * 100;
-  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Product Qty: "
-                                << qty;
+                                   << assays.Feed() * 100;
+  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Product Qty: " << qty;
   LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Product Assay: "
-                                << assays.Product() * 100;
+                                   << assays.Product() * 100;
   LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Tails Qty: "
-                                << TailsQty(qty, assays);
+                                   << TailsQty(qty, assays);
   LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Tails Assay: "
-                                << assays.Tails() * 100;
-  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * SWU: "
-                                << swu_req;
+                                   << assays.Tails() * 100;
+  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * SWU: " << swu_req;
   LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Current SWU capacity: "
-                                << current_swu_capacity;
+                                   << current_swu_capacity;
 
   return response;
 }
@@ -471,14 +451,15 @@ double Enrichment::FeedAssay() {
     return 0;
   }
   double pop_qty = inventory.quantity();
-  cyclus::Material::Ptr fission_matl = inventory.Pop(pop_qty, cyclus::eps_rsrc());
+  cyclus::Material::Ptr fission_matl =
+      inventory.Pop(pop_qty, cyclus::eps_rsrc());
   inventory.Push(fission_matl);
-  return cyclus::toolkit::UraniumAssay(fission_matl); 
+  return cyclus::toolkit::UraniumAssay(fission_matl);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 extern "C" cyclus::Agent* ConstructEnrichment(cyclus::Context* ctx) {
   return new Enrichment(ctx);
 }
-  
+
 }  // namespace cycamore

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -86,7 +86,7 @@ std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
   Material::Ptr mat = Request_();
   double amt = mat->quantity();
 
-  if (amt > cyclus::eps()) {
+  if (amt > cyclus::eps_rsrc()()) {
     port->AddRequest(mat, this, feed_commod);
     ports.insert(port);
   }
@@ -279,7 +279,7 @@ void Enrichment::GetMatlTrades(
 				       << " for " << it->amt
 				       << " of " << tails_commod;
       double pop_qty = std::min(qty, tails.quantity());
-      response = tails.Pop( pop_qty, cyclus::eps()*pop_qty );
+      response = tails.Pop( pop_qty, cyclus::eps_rsrc()()*pop_qty );
     } else {
       LOG(cyclus::LEV_INFO5, "EnrFac") << prototype()
 				       << " just received an order"
@@ -382,7 +382,7 @@ cyclus::Material::Ptr Enrichment::Enrich_(
   // Determine the composition of the natural uranium
   // (ie. U-235+U-238/TotalMass)
   double pop_qty = inventory.quantity();
-  Material::Ptr natu_matl = inventory.Pop(pop_qty, cyclus::eps()*pop_qty);
+  Material::Ptr natu_matl = inventory.Pop(pop_qty, cyclus::eps_rsrc()()*pop_qty);
   inventory.Push(natu_matl);
   
   cyclus::toolkit::MatQuery mq(natu_matl);
@@ -399,7 +399,7 @@ cyclus::Material::Ptr Enrichment::Enrich_(
     if (cyclus::AlmostEq(feed_req, inventory.quantity())) {
       r = cyclus::toolkit::Squash(inventory.PopN(inventory.count()));
     } else {
-      r = inventory.Pop(feed_req, cyclus::eps()*feed_req);
+      r = inventory.Pop(feed_req, cyclus::eps_rsrc()()*feed_req);
     }
   } catch (cyclus::Error& e) {
     NatUConverter nc(FeedAssay(), tails_assay);
@@ -471,7 +471,7 @@ double Enrichment::FeedAssay() {
     return 0;
   }
   double pop_qty = inventory.quantity();
-  cyclus::Material::Ptr fission_matl = inventory.Pop(pop_qty, cyclus::eps()*pop_qty);
+  cyclus::Material::Ptr fission_matl = inventory.Pop(pop_qty, cyclus::eps_rsrc()()*pop_qty);
   inventory.Push(fission_matl);
   return cyclus::toolkit::UraniumAssay(fission_matl); 
 }

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -278,7 +278,8 @@ void Enrichment::GetMatlTrades(
 				       << " just received an order"
 				       << " for " << it->amt
 				       << " of " << tails_commod;
-      response = tails.Pop(std::min(qty, tails.quantity()));    
+      double pop_qty = std::min(qty, tails.quantity());
+      response = tails.Pop( pop_qty, cyclus::eps()*pop_qty );
     } else {
       LOG(cyclus::LEV_INFO5, "EnrFac") << prototype()
 				       << " just received an order"
@@ -380,7 +381,8 @@ cyclus::Material::Ptr Enrichment::Enrich_(
 
   // Determine the composition of the natural uranium
   // (ie. U-235+U-238/TotalMass)
-  Material::Ptr natu_matl=inventory.Pop(inventory.quantity());
+  double pop_qty = inventory.quantity();
+  Material::Ptr natu_matl = inventory.Pop(pop_qty, cyclus::eps()*pop_qty);
   inventory.Push(natu_matl);
   
   cyclus::toolkit::MatQuery mq(natu_matl);
@@ -397,7 +399,7 @@ cyclus::Material::Ptr Enrichment::Enrich_(
     if (cyclus::AlmostEq(feed_req, inventory.quantity())) {
       r = cyclus::toolkit::Squash(inventory.PopN(inventory.count()));
     } else {
-      r = inventory.Pop(feed_req);
+      r = inventory.Pop(feed_req, cyclus::eps()*feed_req);
     }
   } catch (cyclus::Error& e) {
     NatUConverter nc(FeedAssay(), tails_assay);
@@ -468,7 +470,8 @@ double Enrichment::FeedAssay() {
   if (inventory.empty()) {
     return 0;
   }
-  cyclus::Material::Ptr fission_matl = inventory.Pop(inventory.quantity());
+  double pop_qty = inventory.quantity();
+  cyclus::Material::Ptr fission_matl = inventory.Pop(pop_qty, cyclus::eps()*pop_qty);
   inventory.Push(fission_matl);
   return cyclus::toolkit::UraniumAssay(fission_matl); 
 }

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -279,7 +279,7 @@ void Enrichment::GetMatlTrades(
 				       << " for " << it->amt
 				       << " of " << tails_commod;
       double pop_qty = std::min(qty, tails.quantity());
-      response = tails.Pop( pop_qty, cyclus::eps_rsrc()()*pop_qty );
+      response = tails.Pop( pop_qty, cyclus::eps_rsrc() );
     } else {
       LOG(cyclus::LEV_INFO5, "EnrFac") << prototype()
 				       << " just received an order"
@@ -382,7 +382,7 @@ cyclus::Material::Ptr Enrichment::Enrich_(
   // Determine the composition of the natural uranium
   // (ie. U-235+U-238/TotalMass)
   double pop_qty = inventory.quantity();
-  Material::Ptr natu_matl = inventory.Pop(pop_qty, cyclus::eps_rsrc()()*pop_qty);
+  Material::Ptr natu_matl = inventory.Pop(pop_qty, cyclus::eps_rsrc());
   inventory.Push(natu_matl);
   
   cyclus::toolkit::MatQuery mq(natu_matl);
@@ -399,7 +399,7 @@ cyclus::Material::Ptr Enrichment::Enrich_(
     if (cyclus::AlmostEq(feed_req, inventory.quantity())) {
       r = cyclus::toolkit::Squash(inventory.PopN(inventory.count()));
     } else {
-      r = inventory.Pop(feed_req, cyclus::eps_rsrc()()*feed_req);
+      r = inventory.Pop(feed_req, cyclus::eps_rsrc());
     }
   } catch (cyclus::Error& e) {
     NatUConverter nc(FeedAssay(), tails_assay);
@@ -471,7 +471,7 @@ double Enrichment::FeedAssay() {
     return 0;
   }
   double pop_qty = inventory.quantity();
-  cyclus::Material::Ptr fission_matl = inventory.Pop(pop_qty, cyclus::eps_rsrc()()*pop_qty);
+  cyclus::Material::Ptr fission_matl = inventory.Pop(pop_qty, cyclus::eps_rsrc());
   inventory.Push(fission_matl);
   return cyclus::toolkit::UraniumAssay(fission_matl); 
 }

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -86,7 +86,7 @@ std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
   Material::Ptr mat = Request_();
   double amt = mat->quantity();
 
-  if (amt > cyclus::eps_rsrc()()) {
+  if (amt > cyclus::eps_rsrc()) {
     port->AddRequest(mat, this, feed_commod);
     ports.insert(port);
   }

--- a/src/fuel_fab.cc
+++ b/src/fuel_fab.cc
@@ -390,9 +390,8 @@ void FuelFab::GetMatlTrades(
         responses) {
   using cyclus::Trade;
 
-  // guard against cases where a buffer is empty - this is okay because some
-  // trades
-  // may not need that particular buffer.
+  // guard against cases where a buffer is empty - this is okay because some 
+  // trades may not need that particular buffer.
   double w_fill = 0;
   if (fill.count() > 0) {
     w_fill = CosiWeight(fill.Peek()->comp(), spectrum);

--- a/src/fuel_fab.cc
+++ b/src/fuel_fab.cc
@@ -162,7 +162,7 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> FuelFab::GetMatlRequests() {
 
   bool exclusive = false;
 
-  if (fiss.space() > cyclus::eps()) {
+  if (fiss.space() > cyclus::eps_rsrc()()) {
     RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
 
     Material::Ptr m = cyclus::NewBlankMaterial(fiss.space());
@@ -182,7 +182,7 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> FuelFab::GetMatlRequests() {
     ports.insert(port);
   }
 
-  if (fill.space() > cyclus::eps()) {
+  if (fill.space() > cyclus::eps_rsrc()()) {
     RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
 
     Material::Ptr m = cyclus::NewBlankMaterial(fill.space());
@@ -202,7 +202,7 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> FuelFab::GetMatlRequests() {
     ports.insert(port);
   }
 
-  if (topup.space() > cyclus::eps()) {
+  if (topup.space() > cyclus::eps_rsrc()()) {
     RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
 
     Material::Ptr m = cyclus::NewBlankMaterial(topup.space());
@@ -409,7 +409,7 @@ void FuelFab::GetMatlTrades(
     double wfiss = w_fiss;
 
     tot += qty;
-    if (tot > throughput + cyclus::eps()) {
+    if (tot > throughput + cyclus::eps_rsrc()()) {
       std::stringstream ss;
       ss << "FuelFab was matched above throughput limit: " << tot << " > "
          << throughput;
@@ -419,17 +419,17 @@ void FuelFab::GetMatlTrades(
     if (fiss.count() == 0) {
       // use straight filler to satisfy this request
       double fillqty = qty;
-      if (std::abs(fillqty - fill.quantity()) < cyclus::eps()) {
+      if (std::abs(fillqty - fill.quantity()) < cyclus::eps_rsrc()()) {
         fillqty = std::min(fill.quantity(), qty);
       }
-      responses.push_back(std::make_pair(trades[i], fill.Pop(fillqty, cyclus::eps()*fillqty)));
+      responses.push_back(std::make_pair(trades[i], fill.Pop(fillqty, cyclus::eps_rsrc()()*fillqty)));
     } else if (fill.count() == 0 && ValidWeights(w_fill, w_tgt, w_fiss)) {
       // use straight fissile to satisfy this request
       double fissqty = qty;
-      if (std::abs(fissqty - fiss.quantity()) < cyclus::eps()) {
+      if (std::abs(fissqty - fiss.quantity()) < cyclus::eps_rsrc()()) {
         fissqty = std::min(fiss.quantity(), qty);
       }
-      responses.push_back(std::make_pair(trades[i], fiss.Pop(fissqty,cyclus::eps()*fissqty)));
+      responses.push_back(std::make_pair(trades[i], fiss.Pop(fissqty,cyclus::eps_rsrc()()*fissqty)));
     } else if (ValidWeights(w_fill, w_tgt, w_fiss)) {
       double fiss_frac = HighFrac(w_fill, w_tgt, w_fiss);
       double fill_frac = LowFrac(w_fill, w_tgt, w_fiss);
@@ -439,18 +439,18 @@ void FuelFab::GetMatlTrades(
           AtomToMassFrac(fill_frac, fill.Peek()->comp(), fiss.Peek()->comp());
 
       double fissqty = fiss_frac*qty;
-      if (std::abs(fissqty - fiss.quantity()) < cyclus::eps()) {
+      if (std::abs(fissqty - fiss.quantity()) < cyclus::eps_rsrc()()) {
         fissqty = std::min(fiss.quantity(), fiss_frac*qty);
       }
       double fillqty = fill_frac*qty;
-      if (std::abs(fillqty - fill.quantity()) < cyclus::eps()) {
+      if (std::abs(fillqty - fill.quantity()) < cyclus::eps_rsrc()()) {
         fillqty = std::min(fill.quantity(), fill_frac*qty);
       }
 
-      Material::Ptr m = fiss.Pop(fissqty,cyclus::eps()*fissqty);
+      Material::Ptr m = fiss.Pop(fissqty,cyclus::eps_rsrc()()*fissqty);
       // this if block prevents zero qty ResBuf pop exceptions
       if (fill_frac > 0) {
-        m->Absorb(fill.Pop(fillqty,cyclus::eps()*fillqty));
+        m->Absorb(fill.Pop(fillqty,cyclus::eps_rsrc()()*fillqty));
       }
       responses.push_back(std::make_pair(trades[i], m));
     } else {
@@ -462,18 +462,18 @@ void FuelFab::GetMatlTrades(
           AtomToMassFrac(fiss_frac, fiss.Peek()->comp(), topup.Peek()->comp());
 
       double fissqty = fiss_frac*qty;
-      if (std::abs(fissqty - fiss.quantity()) < cyclus::eps()) {
+      if (std::abs(fissqty - fiss.quantity()) < cyclus::eps_rsrc()()) {
         fissqty = std::min(fiss.quantity(), fiss_frac*qty);
       }
       double topupqty = topup_frac*qty;
-      if (std::abs(topupqty - topup.quantity()) < cyclus::eps()) {
+      if (std::abs(topupqty - topup.quantity()) < cyclus::eps_rsrc()()) {
         topupqty = std::min(topup.quantity(), topup_frac*qty);
       }
 
-      Material::Ptr m = fiss.Pop(fissqty,cyclus::eps()*fissqty);
+      Material::Ptr m = fiss.Pop(fissqty,cyclus::eps_rsrc()()*fissqty);
       // this if block prevents zero qty ResBuf pop exceptions
       if (topup_frac > 0) {
-        m->Absorb(topup.Pop(topupqty,cyclus::eps()*topupqty));
+        m->Absorb(topup.Pop(topupqty,cyclus::eps_rsrc()()*topupqty));
       }
       responses.push_back(std::make_pair(trades[i], m));
     }
@@ -690,23 +690,23 @@ double AtomToMassFrac(double atomfrac, Composition::Ptr c1,
   return mass1 / (mass1 + mass2);
 }
 
-double HighFrac(double w_low, double w_target, double w_high, double eps) {
+double HighFrac(double w_low, double w_target, double w_high, double eps_rsrc()) {
   if (!ValidWeights(w_low, w_target, w_high)) {
     throw cyclus::ValueError("low and high weights cannot meet target");
   } else if (w_low == w_high && w_target == w_low) {
     return 1;
   }
   double f = std::abs((w_target - w_low) / (w_high - w_low));
-  if (1 - f < eps) {
+  if (1 - f < eps_rsrc()) {
     return 1;
-  } else if (f < eps) {
+  } else if (f < eps_rsrc()) {
     return 0;
   }
   return f;
 }
 
-double LowFrac(double w_low, double w_target, double w_high, double eps) {
-  return 1 - HighFrac(w_low, w_target, w_high, eps);
+double LowFrac(double w_low, double w_target, double w_high, double eps_rsrc()) {
+  return 1 - HighFrac(w_low, w_target, w_high, eps_rsrc());
 }
 
 // Returns true if the given weights can be used to linearly interpolate valid

--- a/src/fuel_fab.cc
+++ b/src/fuel_fab.cc
@@ -1,4 +1,5 @@
 #include "fuel_fab.h"
+
 #include <sstream>
 
 using cyclus::Material;
@@ -23,9 +24,10 @@ class FissConverter : public cyclus::Converter<cyclus::Material> {
 
   virtual ~FissConverter() {}
 
-  virtual double convert(cyclus::Material::Ptr m, cyclus::Arc const* a = NULL,
-                         cyclus::ExchangeTranslationContext<
-                             cyclus::Material> const* ctx = NULL) const {
+  virtual double convert(
+      cyclus::Material::Ptr m, cyclus::Arc const* a = NULL,
+      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx =
+          NULL) const {
     double w_tgt = CosiWeight(m->comp(), spec_);
     if (ValidWeights(w_fill_, w_tgt, w_fiss_)) {
       double frac = HighFrac(w_fill_, w_tgt, w_fiss_);
@@ -62,9 +64,10 @@ class FillConverter : public cyclus::Converter<cyclus::Material> {
 
   virtual ~FillConverter() {}
 
-  virtual double convert(cyclus::Material::Ptr m, cyclus::Arc const* a = NULL,
-                         cyclus::ExchangeTranslationContext<
-                             cyclus::Material> const* ctx = NULL) const {
+  virtual double convert(
+      cyclus::Material::Ptr m, cyclus::Arc const* a = NULL,
+      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx =
+          NULL) const {
     double w_tgt = CosiWeight(m->comp(), spec_);
     if (ValidWeights(w_fill_, w_tgt, w_fiss_)) {
       double frac = LowFrac(w_fill_, w_tgt, w_fiss_);
@@ -100,9 +103,10 @@ class TopupConverter : public cyclus::Converter<cyclus::Material> {
 
   virtual ~TopupConverter() {}
 
-  virtual double convert(cyclus::Material::Ptr m, cyclus::Arc const* a = NULL,
-                         cyclus::ExchangeTranslationContext<
-                             cyclus::Material> const* ctx = NULL) const {
+  virtual double convert(
+      cyclus::Material::Ptr m, cyclus::Arc const* a = NULL,
+      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx =
+          NULL) const {
     double w_tgt = CosiWeight(m->comp(), spec_);
     if (ValidWeights(w_fill_, w_tgt, w_fiss_)) {
       return 0;
@@ -127,7 +131,7 @@ class TopupConverter : public cyclus::Converter<cyclus::Material> {
 };
 
 FuelFab::FuelFab(cyclus::Context* ctx)
-    : cyclus::Facility(ctx), fill_size(0), fiss_size(0), throughput(0) { }
+    : cyclus::Facility(ctx), fill_size(0), fiss_size(0), throughput(0) {}
 
 void FuelFab::EnterNotify() {
   cyclus::Facility::EnterNotify();
@@ -228,8 +232,9 @@ bool Contains(std::vector<std::string> vec, std::string s) {
   return false;
 }
 
-void FuelFab::AcceptMatlTrades(const std::vector<
-    std::pair<cyclus::Trade<Material>, Material::Ptr> >& responses) {
+void FuelFab::AcceptMatlTrades(
+    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
+        responses) {
   std::vector<std::pair<cyclus::Trade<cyclus::Material>,
                         cyclus::Material::Ptr> >::const_iterator trade;
 
@@ -342,7 +347,8 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> FuelFab::GetMatlBids(
 
       bool exclusive = false;
       port->AddBid(req, m1, this, exclusive);
-    } else if (fiss.count() > 0 && fill.count() > 0 || fiss.count() > 0 && topup.count() > 0) {
+    } else if (fiss.count() > 0 && fill.count() > 0 ||
+               fiss.count() > 0 && topup.count() > 0) {
       // else can't meet the target weight - don't bid.  Just a plain else
       // doesn't work because we set w_fiss = w_fill if we don't have any fiss
       // or fill inventory.
@@ -384,7 +390,8 @@ void FuelFab::GetMatlTrades(
         responses) {
   using cyclus::Trade;
 
-  // guard against cases where a buffer is empty - this is okay because some trades
+  // guard against cases where a buffer is empty - this is okay because some
+  // trades
   // may not need that particular buffer.
   double w_fill = 0;
   if (fill.count() > 0) {
@@ -422,14 +429,16 @@ void FuelFab::GetMatlTrades(
       if (std::abs(fillqty - fill.quantity()) < cyclus::eps_rsrc()) {
         fillqty = std::min(fill.quantity(), qty);
       }
-      responses.push_back(std::make_pair(trades[i], fill.Pop(fillqty, cyclus::eps_rsrc())));
+      responses.push_back(
+          std::make_pair(trades[i], fill.Pop(fillqty, cyclus::eps_rsrc())));
     } else if (fill.count() == 0 && ValidWeights(w_fill, w_tgt, w_fiss)) {
       // use straight fissile to satisfy this request
       double fissqty = qty;
       if (std::abs(fissqty - fiss.quantity()) < cyclus::eps_rsrc()) {
         fissqty = std::min(fiss.quantity(), qty);
       }
-      responses.push_back(std::make_pair(trades[i], fiss.Pop(fissqty,cyclus::eps_rsrc())));
+      responses.push_back(
+          std::make_pair(trades[i], fiss.Pop(fissqty, cyclus::eps_rsrc())));
     } else if (ValidWeights(w_fill, w_tgt, w_fiss)) {
       double fiss_frac = HighFrac(w_fill, w_tgt, w_fiss);
       double fill_frac = LowFrac(w_fill, w_tgt, w_fiss);
@@ -438,19 +447,19 @@ void FuelFab::GetMatlTrades(
       fill_frac =
           AtomToMassFrac(fill_frac, fill.Peek()->comp(), fiss.Peek()->comp());
 
-      double fissqty = fiss_frac*qty;
+      double fissqty = fiss_frac * qty;
       if (std::abs(fissqty - fiss.quantity()) < cyclus::eps_rsrc()) {
-        fissqty = std::min(fiss.quantity(), fiss_frac*qty);
+        fissqty = std::min(fiss.quantity(), fiss_frac * qty);
       }
-      double fillqty = fill_frac*qty;
+      double fillqty = fill_frac * qty;
       if (std::abs(fillqty - fill.quantity()) < cyclus::eps_rsrc()) {
-        fillqty = std::min(fill.quantity(), fill_frac*qty);
+        fillqty = std::min(fill.quantity(), fill_frac * qty);
       }
 
-      Material::Ptr m = fiss.Pop(fissqty,cyclus::eps_rsrc());
+      Material::Ptr m = fiss.Pop(fissqty, cyclus::eps_rsrc());
       // this if block prevents zero qty ResBuf pop exceptions
       if (fill_frac > 0) {
-        m->Absorb(fill.Pop(fillqty,cyclus::eps_rsrc()));
+        m->Absorb(fill.Pop(fillqty, cyclus::eps_rsrc()));
       }
       responses.push_back(std::make_pair(trades[i], m));
     } else {
@@ -461,19 +470,19 @@ void FuelFab::GetMatlTrades(
       fiss_frac =
           AtomToMassFrac(fiss_frac, fiss.Peek()->comp(), topup.Peek()->comp());
 
-      double fissqty = fiss_frac*qty;
+      double fissqty = fiss_frac * qty;
       if (std::abs(fissqty - fiss.quantity()) < cyclus::eps_rsrc()) {
-        fissqty = std::min(fiss.quantity(), fiss_frac*qty);
+        fissqty = std::min(fiss.quantity(), fiss_frac * qty);
       }
-      double topupqty = topup_frac*qty;
+      double topupqty = topup_frac * qty;
       if (std::abs(topupqty - topup.quantity()) < cyclus::eps_rsrc()) {
-        topupqty = std::min(topup.quantity(), topup_frac*qty);
+        topupqty = std::min(topup.quantity(), topup_frac * qty);
       }
 
-      Material::Ptr m = fiss.Pop(fissqty,cyclus::eps_rsrc());
+      Material::Ptr m = fiss.Pop(fissqty, cyclus::eps_rsrc());
       // this if block prevents zero qty ResBuf pop exceptions
       if (topup_frac > 0) {
-        m->Absorb(topup.Pop(topupqty,cyclus::eps_rsrc()));
+        m->Absorb(topup.Pop(topupqty, cyclus::eps_rsrc()));
       }
       responses.push_back(std::make_pair(trades[i], m));
     }

--- a/src/fuel_fab.cc
+++ b/src/fuel_fab.cc
@@ -422,14 +422,14 @@ void FuelFab::GetMatlTrades(
       if (std::abs(fillqty - fill.quantity()) < cyclus::eps()) {
         fillqty = std::min(fill.quantity(), qty);
       }
-      responses.push_back(std::make_pair(trades[i], fill.Pop(fillqty)));
+      responses.push_back(std::make_pair(trades[i], fill.Pop(fillqty, cyclus::eps()*fillqty)));
     } else if (fill.count() == 0 && ValidWeights(w_fill, w_tgt, w_fiss)) {
       // use straight fissile to satisfy this request
       double fissqty = qty;
       if (std::abs(fissqty - fiss.quantity()) < cyclus::eps()) {
         fissqty = std::min(fiss.quantity(), qty);
       }
-      responses.push_back(std::make_pair(trades[i], fiss.Pop(fissqty)));
+      responses.push_back(std::make_pair(trades[i], fiss.Pop(fissqty,cyclus::eps()*fissqty)));
     } else if (ValidWeights(w_fill, w_tgt, w_fiss)) {
       double fiss_frac = HighFrac(w_fill, w_tgt, w_fiss);
       double fill_frac = LowFrac(w_fill, w_tgt, w_fiss);
@@ -447,10 +447,10 @@ void FuelFab::GetMatlTrades(
         fillqty = std::min(fill.quantity(), fill_frac*qty);
       }
 
-      Material::Ptr m = fiss.Pop(fissqty);
+      Material::Ptr m = fiss.Pop(fissqty,cyclus::eps()*fissqty);
       // this if block prevents zero qty ResBuf pop exceptions
       if (fill_frac > 0) {
-        m->Absorb(fill.Pop(fillqty));
+        m->Absorb(fill.Pop(fillqty,cyclus::eps()*fillqty));
       }
       responses.push_back(std::make_pair(trades[i], m));
     } else {
@@ -470,10 +470,10 @@ void FuelFab::GetMatlTrades(
         topupqty = std::min(topup.quantity(), topup_frac*qty);
       }
 
-      Material::Ptr m = fiss.Pop(fissqty);
+      Material::Ptr m = fiss.Pop(fissqty,cyclus::eps()*fissqty);
       // this if block prevents zero qty ResBuf pop exceptions
       if (topup_frac > 0) {
-        m->Absorb(topup.Pop(topupqty));
+        m->Absorb(topup.Pop(topupqty,cyclus::eps()*topupqty));
       }
       responses.push_back(std::make_pair(trades[i], m));
     }

--- a/src/fuel_fab.cc
+++ b/src/fuel_fab.cc
@@ -422,14 +422,14 @@ void FuelFab::GetMatlTrades(
       if (std::abs(fillqty - fill.quantity()) < cyclus::eps_rsrc()()) {
         fillqty = std::min(fill.quantity(), qty);
       }
-      responses.push_back(std::make_pair(trades[i], fill.Pop(fillqty, cyclus::eps_rsrc()()*fillqty)));
+      responses.push_back(std::make_pair(trades[i], fill.Pop(fillqty, cyclus::eps_rsrc())));
     } else if (fill.count() == 0 && ValidWeights(w_fill, w_tgt, w_fiss)) {
       // use straight fissile to satisfy this request
       double fissqty = qty;
       if (std::abs(fissqty - fiss.quantity()) < cyclus::eps_rsrc()()) {
         fissqty = std::min(fiss.quantity(), qty);
       }
-      responses.push_back(std::make_pair(trades[i], fiss.Pop(fissqty,cyclus::eps_rsrc()()*fissqty)));
+      responses.push_back(std::make_pair(trades[i], fiss.Pop(fissqty,cyclus::eps_rsrc())));
     } else if (ValidWeights(w_fill, w_tgt, w_fiss)) {
       double fiss_frac = HighFrac(w_fill, w_tgt, w_fiss);
       double fill_frac = LowFrac(w_fill, w_tgt, w_fiss);
@@ -447,10 +447,10 @@ void FuelFab::GetMatlTrades(
         fillqty = std::min(fill.quantity(), fill_frac*qty);
       }
 
-      Material::Ptr m = fiss.Pop(fissqty,cyclus::eps_rsrc()()*fissqty);
+      Material::Ptr m = fiss.Pop(fissqty,cyclus::eps_rsrc());
       // this if block prevents zero qty ResBuf pop exceptions
       if (fill_frac > 0) {
-        m->Absorb(fill.Pop(fillqty,cyclus::eps_rsrc()()*fillqty));
+        m->Absorb(fill.Pop(fillqty,cyclus::eps_rsrc()));
       }
       responses.push_back(std::make_pair(trades[i], m));
     } else {
@@ -470,10 +470,10 @@ void FuelFab::GetMatlTrades(
         topupqty = std::min(topup.quantity(), topup_frac*qty);
       }
 
-      Material::Ptr m = fiss.Pop(fissqty,cyclus::eps_rsrc()()*fissqty);
+      Material::Ptr m = fiss.Pop(fissqty,cyclus::eps_rsrc());
       // this if block prevents zero qty ResBuf pop exceptions
       if (topup_frac > 0) {
-        m->Absorb(topup.Pop(topupqty,cyclus::eps_rsrc()()*topupqty));
+        m->Absorb(topup.Pop(topupqty,cyclus::eps_rsrc()));
       }
       responses.push_back(std::make_pair(trades[i], m));
     }

--- a/src/fuel_fab.cc
+++ b/src/fuel_fab.cc
@@ -162,7 +162,7 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> FuelFab::GetMatlRequests() {
 
   bool exclusive = false;
 
-  if (fiss.space() > cyclus::eps_rsrc()()) {
+  if (fiss.space() > cyclus::eps_rsrc()) {
     RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
 
     Material::Ptr m = cyclus::NewBlankMaterial(fiss.space());
@@ -182,7 +182,7 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> FuelFab::GetMatlRequests() {
     ports.insert(port);
   }
 
-  if (fill.space() > cyclus::eps_rsrc()()) {
+  if (fill.space() > cyclus::eps_rsrc()) {
     RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
 
     Material::Ptr m = cyclus::NewBlankMaterial(fill.space());
@@ -202,7 +202,7 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> FuelFab::GetMatlRequests() {
     ports.insert(port);
   }
 
-  if (topup.space() > cyclus::eps_rsrc()()) {
+  if (topup.space() > cyclus::eps_rsrc()) {
     RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
 
     Material::Ptr m = cyclus::NewBlankMaterial(topup.space());
@@ -409,7 +409,7 @@ void FuelFab::GetMatlTrades(
     double wfiss = w_fiss;
 
     tot += qty;
-    if (tot > throughput + cyclus::eps_rsrc()()) {
+    if (tot > throughput + cyclus::eps_rsrc()) {
       std::stringstream ss;
       ss << "FuelFab was matched above throughput limit: " << tot << " > "
          << throughput;
@@ -419,14 +419,14 @@ void FuelFab::GetMatlTrades(
     if (fiss.count() == 0) {
       // use straight filler to satisfy this request
       double fillqty = qty;
-      if (std::abs(fillqty - fill.quantity()) < cyclus::eps_rsrc()()) {
+      if (std::abs(fillqty - fill.quantity()) < cyclus::eps_rsrc()) {
         fillqty = std::min(fill.quantity(), qty);
       }
       responses.push_back(std::make_pair(trades[i], fill.Pop(fillqty, cyclus::eps_rsrc())));
     } else if (fill.count() == 0 && ValidWeights(w_fill, w_tgt, w_fiss)) {
       // use straight fissile to satisfy this request
       double fissqty = qty;
-      if (std::abs(fissqty - fiss.quantity()) < cyclus::eps_rsrc()()) {
+      if (std::abs(fissqty - fiss.quantity()) < cyclus::eps_rsrc()) {
         fissqty = std::min(fiss.quantity(), qty);
       }
       responses.push_back(std::make_pair(trades[i], fiss.Pop(fissqty,cyclus::eps_rsrc())));
@@ -439,11 +439,11 @@ void FuelFab::GetMatlTrades(
           AtomToMassFrac(fill_frac, fill.Peek()->comp(), fiss.Peek()->comp());
 
       double fissqty = fiss_frac*qty;
-      if (std::abs(fissqty - fiss.quantity()) < cyclus::eps_rsrc()()) {
+      if (std::abs(fissqty - fiss.quantity()) < cyclus::eps_rsrc()) {
         fissqty = std::min(fiss.quantity(), fiss_frac*qty);
       }
       double fillqty = fill_frac*qty;
-      if (std::abs(fillqty - fill.quantity()) < cyclus::eps_rsrc()()) {
+      if (std::abs(fillqty - fill.quantity()) < cyclus::eps_rsrc()) {
         fillqty = std::min(fill.quantity(), fill_frac*qty);
       }
 
@@ -462,11 +462,11 @@ void FuelFab::GetMatlTrades(
           AtomToMassFrac(fiss_frac, fiss.Peek()->comp(), topup.Peek()->comp());
 
       double fissqty = fiss_frac*qty;
-      if (std::abs(fissqty - fiss.quantity()) < cyclus::eps_rsrc()()) {
+      if (std::abs(fissqty - fiss.quantity()) < cyclus::eps_rsrc()) {
         fissqty = std::min(fiss.quantity(), fiss_frac*qty);
       }
       double topupqty = topup_frac*qty;
-      if (std::abs(topupqty - topup.quantity()) < cyclus::eps_rsrc()()) {
+      if (std::abs(topupqty - topup.quantity()) < cyclus::eps_rsrc()) {
         topupqty = std::min(topup.quantity(), topup_frac*qty);
       }
 
@@ -690,23 +690,23 @@ double AtomToMassFrac(double atomfrac, Composition::Ptr c1,
   return mass1 / (mass1 + mass2);
 }
 
-double HighFrac(double w_low, double w_target, double w_high, double eps_rsrc()) {
+double HighFrac(double w_low, double w_target, double w_high, double eps) {
   if (!ValidWeights(w_low, w_target, w_high)) {
     throw cyclus::ValueError("low and high weights cannot meet target");
   } else if (w_low == w_high && w_target == w_low) {
     return 1;
   }
   double f = std::abs((w_target - w_low) / (w_high - w_low));
-  if (1 - f < eps_rsrc()) {
+  if (1 - f < eps) {
     return 1;
-  } else if (f < eps_rsrc()) {
+  } else if (f < eps) {
     return 0;
   }
   return f;
 }
 
-double LowFrac(double w_low, double w_target, double w_high, double eps_rsrc()) {
-  return 1 - HighFrac(w_low, w_target, w_high, eps_rsrc());
+double LowFrac(double w_low, double w_target, double w_high, double eps) {
+  return 1 - HighFrac(w_low, w_target, w_high, eps);
 }
 
 // Returns true if the given weights can be used to linearly interpolate valid

--- a/src/mixer.cc
+++ b/src/mixer.cc
@@ -129,7 +129,7 @@ Mixer::GetMatlRequests() {
   for (int i = 0; i < in_commods.size(); i++) {
     std::string name = in_commods[i];
 
-    if (streambufs[name].space() > cyclus::eps_rsrc()()) {
+    if (streambufs[name].space() > cyclus::eps_rsrc()) {
       RequestPortfolio<cyclus::Material>::Ptr port(
           new RequestPortfolio<cyclus::Material>());
 

--- a/src/mixer.cc
+++ b/src/mixer.cc
@@ -105,17 +105,15 @@ void Mixer::Tick() {
       cyclus::Material::Ptr m;
       for (int i = 0; i < in_commods.size(); i++) {
         std::string name = in_commods[i];
+        double pop_qty = mixing_ratios[i] * tgt_qty;
         if (i == 0) {
-          double pop_qty = mixing_ratios[i] * tgt_qty;
           m = streambufs[name].Pop(pop_qty, cyclus::eps_rsrc());
         } else {
-          double pop_qty = mixing_ratios[i] * tgt_qty;
           cyclus::Material::Ptr m_ =
               streambufs[name].Pop(pop_qty, cyclus::eps_rsrc());
           m->Absorb(m_);
         }
       }
-
       output.Push(m);
     }
   }

--- a/src/mixer.cc
+++ b/src/mixer.cc
@@ -106,11 +106,11 @@ void Mixer::Tick() {
         std::string name = in_commods[i];
         if (i == 0) {
           double pop_qty = mixing_ratios[i] * tgt_qty; 
-          m = streambufs[name].Pop(pop_qty, cyclus::eps()*pop_qty);
+          m = streambufs[name].Pop(pop_qty, cyclus::eps_rsrc()()*pop_qty);
         } else {
           double pop_qty = mixing_ratios[i] * tgt_qty;
           cyclus::Material::Ptr m_ =
-              streambufs[name].Pop(pop_qty, cyclus::eps()*pop_qty);
+              streambufs[name].Pop(pop_qty, cyclus::eps_rsrc()()*pop_qty);
           m->Absorb(m_);
         }
       }
@@ -129,7 +129,7 @@ Mixer::GetMatlRequests() {
   for (int i = 0; i < in_commods.size(); i++) {
     std::string name = in_commods[i];
 
-    if (streambufs[name].space() > cyclus::eps()) {
+    if (streambufs[name].space() > cyclus::eps_rsrc()()) {
       RequestPortfolio<cyclus::Material>::Ptr port(
           new RequestPortfolio<cyclus::Material>());
 

--- a/src/mixer.cc
+++ b/src/mixer.cc
@@ -105,10 +105,12 @@ void Mixer::Tick() {
       for (int i = 0; i < in_commods.size(); i++) {
         std::string name = in_commods[i];
         if (i == 0) {
-          m = streambufs[name].Pop(mixing_ratios[i] * tgt_qty);
+          double pop_qty = mixing_ratios[i] * tgt_qty; 
+          m = streambufs[name].Pop(pop_qty, cyclus::eps()*pop_qty);
         } else {
+          double pop_qty = mixing_ratios[i] * tgt_qty;
           cyclus::Material::Ptr m_ =
-              streambufs[name].Pop(mixing_ratios[i] * tgt_qty);
+              streambufs[name].Pop(pop_qty, cyclus::eps()*pop_qty);
           m->Absorb(m_);
         }
       }

--- a/src/mixer.cc
+++ b/src/mixer.cc
@@ -106,11 +106,11 @@ void Mixer::Tick() {
         std::string name = in_commods[i];
         if (i == 0) {
           double pop_qty = mixing_ratios[i] * tgt_qty; 
-          m = streambufs[name].Pop(pop_qty, cyclus::eps_rsrc()()*pop_qty);
+          m = streambufs[name].Pop(pop_qty, cyclus::eps_rsrc());
         } else {
           double pop_qty = mixing_ratios[i] * tgt_qty;
           cyclus::Material::Ptr m_ =
-              streambufs[name].Pop(pop_qty, cyclus::eps_rsrc()()*pop_qty);
+              streambufs[name].Pop(pop_qty, cyclus::eps_rsrc());
           m->Absorb(m_);
         }
       }

--- a/src/mixer.cc
+++ b/src/mixer.cc
@@ -1,4 +1,5 @@
 #include <sstream>
+
 #include "mixer.h"
 
 namespace cycamore {
@@ -105,7 +106,7 @@ void Mixer::Tick() {
       for (int i = 0; i < in_commods.size(); i++) {
         std::string name = in_commods[i];
         if (i == 0) {
-          double pop_qty = mixing_ratios[i] * tgt_qty; 
+          double pop_qty = mixing_ratios[i] * tgt_qty;
           m = streambufs[name].Pop(pop_qty, cyclus::eps_rsrc());
         } else {
           double pop_qty = mixing_ratios[i] * tgt_qty;

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -104,7 +104,7 @@ void Separations::Tick() {
     return;
   }
   double pop_qty = std::min(throughput, feed.quantity());
-  Material::Ptr mat = feed.Pop(pop_qty,cyclus::eps()*pop_qty);
+  Material::Ptr mat = feed.Pop(pop_qty,cyclus::eps_rsrc()()*pop_qty);
   double orig_qty = mat->quantity();
 
   StreamSet::iterator it;
@@ -185,7 +185,7 @@ Separations::GetMatlRequests() {
   int t_exit = exit_time();
   if (t_exit >= 0 && (feed.quantity() >= (t_exit - t) * throughput)) {
     return ports; // already have enough feed for remainder of life
-  } else if (feed.space() < cyclus::eps()) {
+  } else if (feed.space() < cyclus::eps_rsrc()()) {
     return ports;
   }
 
@@ -221,11 +221,11 @@ void Separations::GetMatlTrades(
     std::string commod = trades[i].request->commodity();
     if (commod == leftover_commod) {
       double amt = std::min(leftover.quantity(), trades[i].amt);
-      Material::Ptr m = leftover.Pop(amt, cyclus::eps()*amt);
+      Material::Ptr m = leftover.Pop(amt, cyclus::eps_rsrc()()*amt);
       responses.push_back(std::make_pair(trades[i], m));
     } else if (streambufs.count(commod) > 0) {
       double amt = std::min(streambufs[commod].quantity(), trades[i].amt);
-      Material::Ptr m = streambufs[commod].Pop(amt,cyclus::eps()*amt);
+      Material::Ptr m = streambufs[commod].Pop(amt,cyclus::eps_rsrc()()*amt);
       responses.push_back(std::make_pair(trades[i], m));
     } else {
       throw ValueError("invalid commodity " + commod +
@@ -258,7 +258,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
     std::vector<Request<Material>*>& reqs = commod_requests[commod];
     if (reqs.size() == 0) {
       continue;
-    } else if (streambufs[commod].quantity() < cyclus::eps()) {
+    } else if (streambufs[commod].quantity() < cyclus::eps_rsrc()()) {
       continue;
     }
 
@@ -275,7 +275,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
         tot_bid += m->quantity();
 
         // this fix the problem of the cyclus exchange manager which crashes when a bid with a quantity <=0 is offered.
-        if(m->quantity() > cyclus::eps()){
+        if(m->quantity() > cyclus::eps_rsrc()()){
           port->AddBid(req, m, this, exclusive);
         }
 
@@ -293,7 +293,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
 
   // bid leftovers
   std::vector<Request<Material>*>& reqs = commod_requests[leftover_commod];
-  if (reqs.size() > 0 && leftover.quantity() >= cyclus::eps()) {
+  if (reqs.size() > 0 && leftover.quantity() >= cyclus::eps_rsrc()()) {
     MatVec mats = leftover.PopN(leftover.count());
     leftover.Push(mats);
 
@@ -307,7 +307,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
         tot_bid += m->quantity();
 
         // this fix the problem of the cyclus exchange manager which crashes when a bid with a quantity <=0 is offered.
-        if(m->quantity() > cyclus::eps()){
+        if(m->quantity() > cyclus::eps_rsrc()()){
           port->AddBid(req, m, this, exclusive);
         }
 

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -185,7 +185,7 @@ Separations::GetMatlRequests() {
   int t_exit = exit_time();
   if (t_exit >= 0 && (feed.quantity() >= (t_exit - t) * throughput)) {
     return ports; // already have enough feed for remainder of life
-  } else if (feed.space() < cyclus::eps_rsrc()()) {
+  } else if (feed.space() < cyclus::eps_rsrc()) {
     return ports;
   }
 
@@ -258,7 +258,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
     std::vector<Request<Material>*>& reqs = commod_requests[commod];
     if (reqs.size() == 0) {
       continue;
-    } else if (streambufs[commod].quantity() < cyclus::eps_rsrc()()) {
+    } else if (streambufs[commod].quantity() < cyclus::eps_rsrc()) {
       continue;
     }
 
@@ -275,7 +275,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
         tot_bid += m->quantity();
 
         // this fix the problem of the cyclus exchange manager which crashes when a bid with a quantity <=0 is offered.
-        if(m->quantity() > cyclus::eps_rsrc()()){
+        if(m->quantity() > cyclus::eps_rsrc()){
           port->AddBid(req, m, this, exclusive);
         }
 
@@ -293,7 +293,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
 
   // bid leftovers
   std::vector<Request<Material>*>& reqs = commod_requests[leftover_commod];
-  if (reqs.size() > 0 && leftover.quantity() >= cyclus::eps_rsrc()()) {
+  if (reqs.size() > 0 && leftover.quantity() >= cyclus::eps_rsrc()) {
     MatVec mats = leftover.PopN(leftover.count());
     leftover.Push(mats);
 
@@ -307,7 +307,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
         tot_bid += m->quantity();
 
         // this fix the problem of the cyclus exchange manager which crashes when a bid with a quantity <=0 is offered.
-        if(m->quantity() > cyclus::eps_rsrc()()){
+        if(m->quantity() > cyclus::eps_rsrc()){
           port->AddBid(req, m, this, exclusive);
         }
 

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -103,8 +103,8 @@ void Separations::Tick() {
   if (feed.count() == 0) {
     return;
   }
-
-  Material::Ptr mat = feed.Pop(std::min(throughput, feed.quantity()));
+  double pop_qty = std::min(throughput, feed.quantity());
+  Material::Ptr mat = feed.Pop(pop_qty,cyclus::eps()*pop_qty);
   double orig_qty = mat->quantity();
 
   StreamSet::iterator it;
@@ -221,11 +221,11 @@ void Separations::GetMatlTrades(
     std::string commod = trades[i].request->commodity();
     if (commod == leftover_commod) {
       double amt = std::min(leftover.quantity(), trades[i].amt);
-      Material::Ptr m = leftover.Pop(amt);
+      Material::Ptr m = leftover.Pop(amt, cyclus::eps()*amt);
       responses.push_back(std::make_pair(trades[i], m));
     } else if (streambufs.count(commod) > 0) {
       double amt = std::min(streambufs[commod].quantity(), trades[i].amt);
-      Material::Ptr m = streambufs[commod].Pop(amt);
+      Material::Ptr m = streambufs[commod].Pop(amt,cyclus::eps()*amt);
       responses.push_back(std::make_pair(trades[i], m));
     } else {
       throw ValueError("invalid commodity " + commod +

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -104,7 +104,7 @@ void Separations::Tick() {
     return;
   }
   double pop_qty = std::min(throughput, feed.quantity());
-  Material::Ptr mat = feed.Pop(pop_qty,cyclus::eps_rsrc()()*pop_qty);
+  Material::Ptr mat = feed.Pop(pop_qty,cyclus::eps_rsrc());
   double orig_qty = mat->quantity();
 
   StreamSet::iterator it;
@@ -221,11 +221,11 @@ void Separations::GetMatlTrades(
     std::string commod = trades[i].request->commodity();
     if (commod == leftover_commod) {
       double amt = std::min(leftover.quantity(), trades[i].amt);
-      Material::Ptr m = leftover.Pop(amt, cyclus::eps_rsrc()()*amt);
+      Material::Ptr m = leftover.Pop(amt, cyclus::eps_rsrc());
       responses.push_back(std::make_pair(trades[i], m));
     } else if (streambufs.count(commod) > 0) {
       double amt = std::min(streambufs[commod].quantity(), trades[i].amt);
-      Material::Ptr m = streambufs[commod].Pop(amt,cyclus::eps_rsrc()()*amt);
+      Material::Ptr m = streambufs[commod].Pop(amt,cyclus::eps_rsrc());
       responses.push_back(std::make_pair(trades[i], m));
     } else {
       throw ValueError("invalid commodity " + commod +

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -11,7 +11,7 @@ using cyclus::CompMap;
 
 namespace cycamore {
 
-Separations::Separations(cyclus::Context* ctx) : cyclus::Facility(ctx) { }
+Separations::Separations(cyclus::Context* ctx) : cyclus::Facility(ctx) {}
 
 cyclus::Inventories Separations::SnapshotInv() {
   cyclus::Inventories invs;
@@ -51,8 +51,7 @@ void Separations::EnterNotify() {
   std::map<int, double> efficiency_;
 
   StreamSet::iterator it;
-  std::map< int, double>::iterator it2;
-
+  std::map<int, double>::iterator it2;
 
   for (it = streams_.begin(); it != streams_.end(); ++it) {
     std::string name = it->first;
@@ -61,36 +60,35 @@ void Separations::EnterNotify() {
     if (cap >= 0) {
       streambufs[name].capacity(cap);
     }
-    
-    for( it2 = stream.second.begin(); it2 != stream.second.end(); it2++  ){
+
+    for (it2 = stream.second.begin(); it2 != stream.second.end(); it2++) {
       efficiency_[it2->first] += it2->second;
     }
-    
   }
-  
+
   std::vector<int> eff_pb_;
-  for( it2 = efficiency_.begin(); it2 != efficiency_.end(); it2++  ){
-    if( it2->second > 1){
+  for (it2 = efficiency_.begin(); it2 != efficiency_.end(); it2++) {
+    if (it2->second > 1) {
       eff_pb_.push_back(it2->first);
     }
   }
-  
-  if(eff_pb_.size() > 0){
+
+  if (eff_pb_.size() > 0) {
     std::stringstream ss;
     ss << "In " << prototype() << ", ";
-    ss << "the following nuclide(s) have a cumulative separation efficiency greater than 1:";
-    for(int i = 0; i < eff_pb_.size(); i++){
+    ss << "the following nuclide(s) have a cumulative separation efficiency "
+          "greater than 1:";
+    for (int i = 0; i < eff_pb_.size(); i++) {
       ss << "\n    " << eff_pb_[i];
-      if( i < eff_pb_.size()-1 ){
+      if (i < eff_pb_.size() - 1) {
         ss << ",";
-      } else{
+      } else {
         ss << ".";
       }
     }
-    
+
     throw cyclus::ValueError(ss.str());
   }
-
 
   if (feed_commod_prefs.size() == 0) {
     for (int i = 0; i < feed_commods.size(); i++) {
@@ -104,7 +102,7 @@ void Separations::Tick() {
     return;
   }
   double pop_qty = std::min(throughput, feed.quantity());
-  Material::Ptr mat = feed.Pop(pop_qty,cyclus::eps_rsrc());
+  Material::Ptr mat = feed.Pop(pop_qty, cyclus::eps_rsrc());
   double orig_qty = mat->quantity();
 
   StreamSet::iterator it;
@@ -184,7 +182,7 @@ Separations::GetMatlRequests() {
   int t = context()->time();
   int t_exit = exit_time();
   if (t_exit >= 0 && (feed.quantity() >= (t_exit - t) * throughput)) {
-    return ports; // already have enough feed for remainder of life
+    return ports;  // already have enough feed for remainder of life
   } else if (feed.space() < cyclus::eps_rsrc()) {
     return ports;
   }
@@ -225,7 +223,7 @@ void Separations::GetMatlTrades(
       responses.push_back(std::make_pair(trades[i], m));
     } else if (streambufs.count(commod) > 0) {
       double amt = std::min(streambufs[commod].quantity(), trades[i].amt);
-      Material::Ptr m = streambufs[commod].Pop(amt,cyclus::eps_rsrc());
+      Material::Ptr m = streambufs[commod].Pop(amt, cyclus::eps_rsrc());
       responses.push_back(std::make_pair(trades[i], m));
     } else {
       throw ValueError("invalid commodity " + commod +
@@ -234,8 +232,9 @@ void Separations::GetMatlTrades(
   }
 }
 
-void Separations::AcceptMatlTrades(const std::vector<
-    std::pair<cyclus::Trade<Material>, Material::Ptr> >& responses) {
+void Separations::AcceptMatlTrades(
+    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
+        responses) {
   std::vector<std::pair<cyclus::Trade<cyclus::Material>,
                         cyclus::Material::Ptr> >::const_iterator trade;
 
@@ -274,8 +273,9 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
         Material::Ptr m = mats[k];
         tot_bid += m->quantity();
 
-        // this fix the problem of the cyclus exchange manager which crashes when a bid with a quantity <=0 is offered.
-        if(m->quantity() > cyclus::eps_rsrc()){
+        // this fix the problem of the cyclus exchange manager which crashes
+        // when a bid with a quantity <=0 is offered.
+        if (m->quantity() > cyclus::eps_rsrc()) {
           port->AddBid(req, m, this, exclusive);
         }
 
@@ -306,8 +306,9 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
         Material::Ptr m = mats[k];
         tot_bid += m->quantity();
 
-        // this fix the problem of the cyclus exchange manager which crashes when a bid with a quantity <=0 is offered.
-        if(m->quantity() > cyclus::eps_rsrc()){
+        // this fix the problem of the cyclus exchange manager which crashes
+        // when a bid with a quantity <=0 is offered.
+        if (m->quantity() > cyclus::eps_rsrc()) {
           port->AddBid(req, m, this, exclusive);
         }
 

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -119,7 +119,7 @@ void Storage::Tick() {
 
   LOG(cyclus::LEV_INFO3, "ComCnv") << prototype() << " is ticking {";
 
-  if (current_capacity() > cyclus::eps()) {
+  if (current_capacity() > cyclus::eps_rsrc()()) {
     LOG(cyclus::LEV_INFO4, "ComCnv") << " has capacity for " << current_capacity()
                                        << " kg of material.";
   }
@@ -202,7 +202,7 @@ void Storage::ProcessMat_(double cap){
         }
       }
       else {
-        stocks.Push(ready.Pop(max_pop,cyclus::eps()*max_pop));
+        stocks.Push(ready.Pop(max_pop,cyclus::eps_rsrc()()*max_pop));
       }
 
       LOG(cyclus::LEV_INFO1, "ComCnv") << "Storage " << prototype() 

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -5,10 +5,10 @@
 namespace storage {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Storage::Storage(cyclus::Context* ctx)
-    : cyclus::Facility(ctx) {
-  cyclus::Warn<cyclus::EXPERIMENTAL_WARNING>("The Storage Facility is experimental.");
-    };
+Storage::Storage(cyclus::Context* ctx) : cyclus::Facility(ctx) {
+  cyclus::Warn<cyclus::EXPERIMENTAL_WARNING>(
+      "The Storage Facility is experimental.");
+};
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // pragmas
@@ -29,15 +29,13 @@ Storage::Storage(cyclus::Context* ctx)
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Storage::InitFrom(Storage* m) {
-
-  #pragma cyclus impl initfromcopy storage::Storage
+#pragma cyclus impl initfromcopy storage::Storage
   cyclus::toolkit::CommodityProducer::Copy(m);
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-void Storage::InitFrom(cyclus::QueryableBackend* b){
-
-  #pragma cyclus impl initfromdb storage::Storage
+void Storage::InitFrom(cyclus::QueryableBackend* b) {
+#pragma cyclus impl initfromdb storage::Storage
 
   using cyclus::toolkit::Commodity;
   Commodity commod = Commodity(out_commods.front());
@@ -50,39 +48,38 @@ void Storage::EnterNotify() {
   cyclus::Facility::EnterNotify();
   buy_policy.Init(this, &inventory, std::string("inventory"));
 
-  //dummy comp, use in_recipe if provided
+  // dummy comp, use in_recipe if provided
   cyclus::CompMap v;
   cyclus::Composition::Ptr comp = cyclus::Composition::CreateFromAtom(v);
   if (in_recipe != "") {
     comp = context()->GetRecipe(in_recipe);
   }
 
-  if (in_commod_prefs.size() == 0){
-    for (int i=0; i < in_commods.size(); ++i){
+  if (in_commod_prefs.size() == 0) {
+    for (int i = 0; i < in_commods.size(); ++i) {
       in_commod_prefs.push_back(1);
     }
-  }
-  else if (in_commod_prefs.size() != in_commods.size()) {
+  } else if (in_commod_prefs.size() != in_commods.size()) {
     std::stringstream ss;
-    ss << "in_commod_prefs has " << in_commod_prefs.size() << " values, expected "
-       << in_commods.size();
+    ss << "in_commod_prefs has " << in_commod_prefs.size()
+       << " values, expected " << in_commods.size();
     throw cyclus::ValueError(ss.str());
   }
 
-  for(int i=0; i!=in_commods.size(); ++i) {
-    buy_policy.Set(in_commods[i],comp,in_commod_prefs[i]);
+  for (int i = 0; i != in_commods.size(); ++i) {
+    buy_policy.Set(in_commods[i], comp, in_commod_prefs[i]);
   }
   buy_policy.Start();
 
   if (out_commods.size() == 1) {
-  sell_policy.Init(this, &stocks, std::string("stocks")).Set(out_commods.front()).Start();
-  }
-  else {
+    sell_policy.Init(this, &stocks, std::string("stocks"))
+        .Set(out_commods.front())
+        .Start();
+  } else {
     std::stringstream ss;
     ss << "out_commods has " << out_commods.size() << " values, expected 1.";
     throw cyclus::ValueError(ss.str());
   }
-
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -91,37 +88,36 @@ std::string Storage::str() {
   std::string ans, out_str;
   if (out_commods.size() == 1) {
     out_str = out_commods.front();
-  }
-  else {
+  } else {
     out_str = "";
   }
-  if (cyclus::toolkit::CommodityProducer::
-      Produces(cyclus::toolkit::Commodity(out_str))){
+  if (cyclus::toolkit::CommodityProducer::Produces(
+          cyclus::toolkit::Commodity(out_str))) {
     ans = "yes";
   } else {
     ans = "no";
   }
   ss << cyclus::Facility::str();
-  ss << " has facility parameters {" << "\n"
+  ss << " has facility parameters {"
+     << "\n"
      << "     Output Commodity = " << out_str << ",\n"
      << "     Residence Time = " << residence_time << ",\n"
      << "     Throughput = " << throughput << ",\n"
-     << " commod producer members: " << " produces "
-     << out_str << "?:" << ans
-     << "'}";
+     << " commod producer members: "
+     << " produces " << out_str << "?:" << ans << "'}";
   return ss.str();
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-void Storage::Tick() { 
+void Storage::Tick() {
   // Set available capacity for Buy Policy
   inventory.capacity(current_capacity());
 
   LOG(cyclus::LEV_INFO3, "ComCnv") << prototype() << " is ticking {";
 
   if (current_capacity() > cyclus::eps_rsrc()) {
-    LOG(cyclus::LEV_INFO4, "ComCnv") << " has capacity for " << current_capacity()
-                                       << " kg of material.";
+    LOG(cyclus::LEV_INFO4, "ComCnv")
+        << " has capacity for " << current_capacity() << " kg of material.";
   }
   LOG(cyclus::LEV_INFO3, "ComCnv") << "}";
 }
@@ -130,22 +126,21 @@ void Storage::Tick() {
 void Storage::Tock() {
   LOG(cyclus::LEV_INFO3, "ComCnv") << prototype() << " is tocking {";
 
-  BeginProcessing_(); // place unprocessed inventory into processing
+  BeginProcessing_();  // place unprocessed inventory into processing
 
-  if( ready_time() >= 0 || residence_time == 0  && !inventory.empty() ) {
+  if (ready_time() >= 0 || residence_time == 0 && !inventory.empty()) {
     ReadyMatl_(ready_time());  // place processing into ready
   }
 
-  ProcessMat_(throughput); // place ready into stocks
+  ProcessMat_(throughput);  // place ready into stocks
 
   LOG(cyclus::LEV_INFO3, "ComCnv") << "}";
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Storage::AddMat_(cyclus::Material::Ptr mat) {
-
   LOG(cyclus::LEV_INFO5, "ComCnv") << prototype() << " is initially holding "
-                                << inventory.quantity() << " total.";
+                                   << inventory.quantity() << " total.";
 
   try {
     inventory.Push(mat);
@@ -154,22 +149,22 @@ void Storage::AddMat_(cyclus::Material::Ptr mat) {
     throw e;
   }
 
-  LOG(cyclus::LEV_INFO5, "ComCnv") << prototype() << " added " << mat->quantity()
-                                << " of material to its inventory, which is holding "
-                                << inventory.quantity() << " total.";
-
+  LOG(cyclus::LEV_INFO5, "ComCnv")
+      << prototype() << " added " << mat->quantity()
+      << " of material to its inventory, which is holding "
+      << inventory.quantity() << " total.";
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-void Storage::BeginProcessing_(){
-  while( inventory.count() > 0 ){
+void Storage::BeginProcessing_() {
+  while (inventory.count() > 0) {
     try {
       processing.Push(inventory.Pop());
       entry_times.push_back(context()->time());
 
-      LOG(cyclus::LEV_DEBUG2, "ComCnv") << "Storage " << prototype() 
-                                      << " added resources to processing at t= "
-                                      << context()->time();
+      LOG(cyclus::LEV_DEBUG2, "ComCnv")
+          << "Storage " << prototype()
+          << " added resources to processing at t= " << context()->time();
     } catch (cyclus::Error& e) {
       e.msg(Agent::InformErrorMsg(e.msg()));
       throw e;
@@ -178,37 +173,34 @@ void Storage::BeginProcessing_(){
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-void Storage::ProcessMat_(double cap){
+void Storage::ProcessMat_(double cap) {
   using cyclus::Material;
   using cyclus::ResCast;
   using cyclus::toolkit::ResBuf;
   using cyclus::toolkit::Manifest;
 
-  if ( !ready.empty() ){
-    try { 
-
+  if (!ready.empty()) {
+    try {
       double max_pop = std::min(cap, ready.quantity());
 
-      if ( discrete_handling ) {
+      if (discrete_handling) {
         if (max_pop == ready.quantity()) {
           stocks.Push(ready.PopN(ready.count()));
-        }
-        else {
+        } else {
           double cap_pop = ready.Peek()->quantity();
-          while(cap_pop<=max_pop && !ready.empty() ){
+          while (cap_pop <= max_pop && !ready.empty()) {
             stocks.Push(ready.Pop());
             cap_pop += ready.empty() ? 0 : ready.Peek()->quantity();
           }
         }
-      }
-      else {
-        stocks.Push(ready.Pop(max_pop,cyclus::eps_rsrc()));
+      } else {
+        stocks.Push(ready.Pop(max_pop, cyclus::eps_rsrc()));
       }
 
-      LOG(cyclus::LEV_INFO1, "ComCnv") << "Storage " << prototype() 
-                                        << " moved resources" 
-                                        << " from ready to stocks" 
-                                        << " at t= " << context()->time();
+      LOG(cyclus::LEV_INFO1, "ComCnv") << "Storage " << prototype()
+                                       << " moved resources"
+                                       << " from ready to stocks"
+                                       << " at t= " << context()->time();
     } catch (cyclus::Error& e) {
       e.msg(Agent::InformErrorMsg(e.msg()));
       throw e;
@@ -222,7 +214,7 @@ void Storage::ReadyMatl_(int time) {
 
   int to_ready = 0;
 
-  while(!entry_times.empty() && entry_times.front()<=time){
+  while (!entry_times.empty() && entry_times.front() <= time) {
     entry_times.pop_front();
     ++to_ready;
   }
@@ -235,4 +227,4 @@ extern "C" cyclus::Agent* ConstructStorage(cyclus::Context* ctx) {
   return new Storage(ctx);
 }
 
-} // namespace storage
+}  // namespace storage

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -202,7 +202,7 @@ void Storage::ProcessMat_(double cap){
         }
       }
       else {
-        stocks.Push(ready.Pop(max_pop));
+        stocks.Push(ready.Pop(max_pop,cyclus::eps()*max_pop));
       }
 
       LOG(cyclus::LEV_INFO1, "ComCnv") << "Storage " << prototype() 

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -119,7 +119,7 @@ void Storage::Tick() {
 
   LOG(cyclus::LEV_INFO3, "ComCnv") << prototype() << " is ticking {";
 
-  if (current_capacity() > cyclus::eps_rsrc()()) {
+  if (current_capacity() > cyclus::eps_rsrc()) {
     LOG(cyclus::LEV_INFO4, "ComCnv") << " has capacity for " << current_capacity()
                                        << " kg of material.";
   }

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -202,7 +202,7 @@ void Storage::ProcessMat_(double cap){
         }
       }
       else {
-        stocks.Push(ready.Pop(max_pop,cyclus::eps_rsrc()()*max_pop));
+        stocks.Push(ready.Pop(max_pop,cyclus::eps_rsrc()));
       }
 
       LOG(cyclus::LEV_INFO1, "ComCnv") << "Storage " << prototype() 


### PR DESCRIPTION
According to [the discussion about floating point issues](https://groups.google.com/forum/#!topic/cyclus-dev/d25nGI9dYH0):

changing all `Pop` call in Cycamore to `Pop(qty, eps)`.

The eps used is the `cyclus::eps_rsrc()`, and is by default 1e-6.
