### PR TITLE
fix header collision when installing cycamore

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,4 +33,3 @@ SET(TestSource ${cycamore_TEST_CC} PARENT_SCOPE)
 
 # install header files
 FILE(GLOB h_files "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
-INSTALL(FILES ${h_files} DESTINATION include/cycamore COMPONENT cycamore)


### PR DESCRIPTION
this is linked to cyclus PR [#1270](https://github.com/cyclus/cyclus/pull/1270), and to solve cycamore issue #419.


This solution prevent header file from cycamore to be installed (theoretically only cyclus header file should be require by developers...)

(Alternatively on can argues that Cycamore header file could be useful for developers, to develop news modules against Cycamore.)

