### PR TITLE
Update mixer API

### DIFF
--- a/src/mixer.cc
+++ b/src/mixer.cc
@@ -54,12 +54,7 @@ void Mixer::EnterNotify() {
     if (cap >= 0) {
       streambufs[name].capacity(cap);
     }
-
-    std::vector<std::pair<std::string, double> > stream_commods_;
-    for (int j = 0; j < streams_[i].second.size(); j++) {
-      stream_commods_.push_back(streams_[i].second[j]);
-    }
-    in_commods.push_back(stream_commods_);
+    in_commods.push_back(streams_[i].second);
   }
 
   // ratio normalisation
@@ -140,10 +135,12 @@ Mixer::GetMatlRequests() {
       cyclus::Material::Ptr m;
       m = cyclus::NewBlankMaterial(streambufs[name].space());
 
-      std::vector<cyclus::Request<cyclus::Material>*> reqs;      
-      for (int j = 0; j < in_commods[i].size(); j++) {
-        std::string commod = in_commods[i][j].first;
-        double pref = in_commods[i][j].second;
+      std::vector<cyclus::Request<cyclus::Material>*> reqs;
+      
+      std::map<std::string, double>::iterator it;
+      for (it = in_commods[i].begin() ; it != in_commods[i].end(); it++) {
+        std::string commod = it->first;
+        double pref = it->second;
         reqs.push_back(port->AddRequest(m, this, commod , pref, false));
         req_inventories_[reqs.back()] = name;
       }

--- a/src/mixer.cc
+++ b/src/mixer.cc
@@ -81,7 +81,7 @@ void Mixer::EnterNotify() {
       }
     } else {
       for (int i = 0; i < mixing_ratios.size(); i++) {
-        mixing_ratios[i] = 1.0 / (mixing_ratios.size() - 1);
+        mixing_ratios[i] = 1.0 / (mixing_ratios.size());
       }
     }
   }

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -39,13 +39,13 @@ class Mixer : public cyclus::Facility {
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
   GetMatlRequests();
 
-  #pragma cyclus clone
-  #pragma cyclus initfromcopy
-  #pragma cyclus infiletodb
-  #pragma cyclus initfromdb
-  #pragma cyclus schema
-  #pragma cyclus annotations
-  #pragma cyclus snapshot
+#pragma cyclus clone
+#pragma cyclus initfromcopy
+#pragma cyclus infiletodb
+#pragma cyclus initfromdb
+#pragma cyclus schema
+#pragma cyclus annotations
+#pragma cyclus snapshot
   // the following pragmas are ommitted and the functions are written
   // manually in order to handle the vector of resource buffers:
   //
@@ -56,51 +56,30 @@ class Mixer : public cyclus::Facility {
   virtual void InitInv(cyclus::Inventories& inv);
 
  protected:
-  #pragma cyclus var { \
-    "doc": "Ordered list of commodities on which to request material stream" \
-    " material, each commodity corresponds to an input stream.", \
-    "uilabel": "Input Commodities", \
-    "uitype": ["oneormore", "incommodity"], \
+#pragma cyclus var { \
+    "alias": ["in_streams", [ "stream", [ "info", "mixing_ratio", "buf_size"], [ "commodities", "commodity", "pref"]]], \
+    "uitype": ["oneormore", [ "pair", ["pair", "double", "double"],  ["oneormore", "incommod", "double"]]], \
+    "uilabel": "", \
+    "doc": "", \
   }
-  std::vector<std::string> in_commods;
+  std::vector<std::pair<std::pair<std::double, double>, std::vector<std::pair<std::string, double> > > > > streams_;
 
-  #pragma cyclus var { \
-    "default": [], \
-    "uilabel": "Input Preferences", \
-    "doc": "Stream commodity request preferences for each of the given" \
-           "commodities (same order)." \
-           " If unspecified, default is 1.0 for all preferences.", \
-  }
-  std::vector<double> in_commod_prefs;
-
-  #pragma cyclus var { \
-    "doc": "Size of input material stream inventory - i.e. the quantity of each" \
-           " stream type to keep on-hand)", \
-    "uilabel": "Input Inventory Capacity", \
-    "units": [ "", "kg"],                  \
-  }
+  // internal storage of the fraction values
+  std::vector<std::vector<pair<string, pref> > > in_commods;
   std::vector<double> in_buf_sizes;
+  std::vector<double> mixing_ratios;
 
   // custom SnapshotInv and InitInv and EnterNotify are used to persist this
   // state var.
   std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material> > streambufs;
 
-  #pragma cyclus var { \
-    "default": [], \
-    "uilabel": "Commodities Mass Fraction", \
-    "doc": "Mass mixing ratio of each input commodity requested (same order)." \
-           " If unspecified, default is to use 1/N for each fraction." \
-           " Stream ratios can total to any arbitrary value" \
-           " and will be automatically normalized internally." \
-  }
-  std::vector<double> mixing_ratios;
 
-  #pragma cyclus var {                                                 \
-    "doc" : "Commodity on which to offer/supply mixed fuel material.", \
-    "uilabel" : "Output Commodity", "uitype" : "outcommodity", }
+#pragma cyclus var {                                                 \
+  "doc" : "Commodity on which to offer/supply mixed fuel material.", \
+  "uilabel" : "Output Commodity", "uitype" : "outcommodity", }
   std::string out_commod;
 
-  #pragma cyclus var { \
+#pragma cyclus var { \
     "doc" : "Maximum amount of mixed material that can be stored." \
             " If full, the facility halts operation until space becomes" \
             " available.", \
@@ -110,10 +89,10 @@ class Mixer : public cyclus::Facility {
   }
   double out_buf_size;
 
-  #pragma cyclus var { "capacity" : "out_buf_size", }
+#pragma cyclus var { "capacity" : "out_buf_size", }
   cyclus::toolkit::ResBuf<cyclus::Material> output;
 
-  #pragma cyclus var { \
+#pragma cyclus var { \
     "default": 1e299, \
     "doc": "Maximum number of kg of fuel material that can be mixed per time step.", \
     "uilabel": "Maximum Throughput", \

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -62,10 +62,9 @@ class Mixer : public cyclus::Facility {
     "uilabel": "", \
     "doc": "", \
   }
-  std::vector<std::pair<std::pair<std::double, double>, std::vector<std::pair<std::string, double> > > > > streams_;
+  std::vector<std::pair<std::pair<double, double>, std::vector<std::pair<std::string, double> > > > streams_;
 
-  // internal storage of the fraction values
-  std::vector<std::vector<pair<string, pref> > > in_commods;
+  std::vector<std::vector<std::pair<std::string, double> > > in_commods;
   std::vector<double> in_buf_sizes;
   std::vector<double> mixing_ratios;
 

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -58,13 +58,13 @@ class Mixer : public cyclus::Facility {
  protected:
 #pragma cyclus var { \
     "alias": ["in_streams", [ "stream", [ "info", "mixing_ratio", "buf_size"], [ "commodities", "commodity", "pref"]]], \
-    "uitype": ["oneormore", [ "pair", ["pair", "double", "double"],  ["oneormore", "incommod", "double"]]], \
+    "uitype": ["oneormore", [ "pair", ["pair", "double", "double"], ["oneormore", "incommodity", "double"]]], \
     "uilabel": "", \
     "doc": "", \
   }
-  std::vector<std::pair<std::pair<double, double>, std::vector<std::pair<std::string, double> > > > streams_;
+  std::vector<std::pair<std::pair<double, double>, std::map<std::string, double> > > streams_;
 
-  std::vector<std::vector<std::pair<std::string, double> > > in_commods;
+  std::vector<std::map<std::string, double> > in_commods;
   std::vector<double> in_buf_sizes;
   std::vector<double> mixing_ratios;
 

--- a/src/mixer_tests.cc
+++ b/src/mixer_tests.cc
@@ -363,10 +363,8 @@ TEST(MixerTests, MultipleFissStreams) {
       "<out_commod>mixedstream</out_commod>"
       "<outputbuf_size>0</outputbuf_size>"
       "<throughput>0</throughput>";
-  std::cout << "1" << std::endl;
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Mixer"), config, simdur);
-  std::cout << "2" << std::endl;
   sim.AddSource("stream1").recipe("unatstream").capacity(1).Finalize();
   sim.AddSource("stream2").recipe("uoxstream").capacity(1).Finalize();
   sim.AddSource("stream3").recipe("pustream").capacity(1).Finalize();
@@ -375,28 +373,23 @@ TEST(MixerTests, MultipleFissStreams) {
   sim.AddRecipe("pustream", c_uox());
   int id = sim.Run();
 
-  std::cout << "3" << std::endl;
   // Checking the number of transaction is as expected 3.
   cyclus::QueryResult qr = sim.db().Query("Transactions", NULL);
   EXPECT_EQ(3, qr.rows.size());
 
-  std::cout << "4" << std::endl;
   // Checking that all input stream get one transaction each.
   std::vector<cyclus::Cond> conds;
   conds.push_back(cyclus::Cond("Commodity", "==", std::string("stream1")));
   qr = sim.db().Query("Transactions", &conds);
   EXPECT_EQ(1, qr.rows.size());
 
-  std::cout << "5" << std::endl;
   conds[0] = cyclus::Cond("Commodity", "==", std::string("stream2"));
   qr = sim.db().Query("Transactions", &conds);
   EXPECT_EQ(1, qr.rows.size());
 
-  std::cout << "6" << std::endl;
   conds[0] = cyclus::Cond("Commodity", "==", std::string("stream3"));
   qr = sim.db().Query("Transactions", &conds);
   EXPECT_EQ(1, qr.rows.size());
-  std::cout << "7" << std::endl;
 }
 
 // multiple input streams can be correctly requested and used as

--- a/src/mixer_tests.cc
+++ b/src/mixer_tests.cc
@@ -12,6 +12,10 @@ namespace cycamore {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+typedef std::vector<std::pair<std::pair<double, double>,
+                              std::vector<std::pair<std::string, double>>>>
+    t_instream;
+
 cyclus::Composition::Ptr c_pustream() {
   using pyne::nucname::id;
 
@@ -51,17 +55,23 @@ class MixerTest : public ::testing::Test {
   virtual void SetUp() {
     mf_facility_ = new Mixer(tc_.get());
 
-    std::vector<std::string> in_com_ = {"in_c1", "in_c2", "in_c3"};
-    SetStream_comds(in_com_);
-
-    std::vector<double> in_cap_ = {30, 20, 10};
-    SetStream_capacity(in_cap_);
-
+    std::vector<std::vector<std::pair<std::string, double> >> in_commods;
+    std::vector<std::pair<std::string, double> > in_com = {std::pair<std::string, double>("in_c1",1)};
+    in_commods.push_back(in_com);
+    in_com = {std::pair<std::string, double>("in_c2",1)};
+    in_commods.push_back(in_com);
+    in_com = {std::pair<std::string, double>("in_c3",1)};
+    in_commods.push_back(in_com);
+    
+    std::vector<double> in_ratios = {1, 1, 1};
+    std::vector<double> in_caps = {30, 20, 10};
+    SetIn_stream(in_commods, in_ratios,  in_caps);
+  
     SetOutStream_comds("out_com");
   }
   virtual void TearDown() { delete mf_facility_; }
 
-  std::vector<std::string> in_com;
+  std::vector<std::vector<std::pair<std::string, double> >> in_coms;
   std::vector<double> in_frac;
   std::vector<double> in_cap;
 
@@ -75,19 +85,46 @@ class MixerTest : public ::testing::Test {
     mf_facility_->throughput = thpt;
   }
 
-  void SetStream_comds(std::vector<std::string> comds) {
-    in_com = comds;
-    mf_facility_->in_commods = comds;
+  void SetIn_stream(t_instream streams) {
+    mf_facility_->streams_ = streams;
+    
+    in_frac.clear();
+    in_cap.clear();
+    for (int i = 0; i < streams.size(); i++) {
+      in_frac.push_back(streams[i].first.first);
+      in_cap.push_back(streams[i].first.second);
+    }
+  }
+  
+  void SetIn_stream(
+      std::vector<std::vector<std::pair<std::string, double> > > in_stream,
+      std::vector<double> ratios, std::vector<double> caps) {
+    t_instream instream_tmp;
+    for (int i = 0; i < in_stream.size(); i++) {
+      std::pair<double, double> info_mtp =
+          std::pair<double, double>(ratios[i], caps[i]);
+      instream_tmp.push_back(
+          std::pair<std::pair<double, double>,
+                    std::vector<std::pair<std::string, double> > >(info_mtp,
+                                                              in_stream[i]));
+    }
+    SetIn_stream(instream_tmp);
   }
 
-  void SetStream_ratio(std::vector<double> ratio) {
-    in_frac = ratio;
-    mf_facility_->mixing_ratios = ratio;
+  void SetStream_ratio(std::vector<double> new_ratios) {
+    for (int i = 0; i < new_ratios.size(); i++) {
+      mf_facility_->streams_[i].first.first = new_ratios[i];
+    }
+
+    mf_facility_->mixing_ratios = new_ratios;
   }
 
-  void SetStream_capacity(std::vector<double> cap) {
-    in_cap = cap;
-    mf_facility_->in_buf_sizes = cap;
+  void SetStream_capacity(std::vector<double> new_caps) {
+    for (int i = 0; i < new_caps.size(); i++) {
+      mf_facility_->streams_[i].first.second = new_caps[i];
+    }
+
+    mf_facility_->in_buf_sizes = new_caps;
   }
 
   void SetOutStream_comds(std::string com) {
@@ -101,13 +138,10 @@ class MixerTest : public ::testing::Test {
   }
 
   void SetInputInv(std::vector<cyclus::Material::Ptr> mat) {
-    for (int i = 0; i < in_com.size(); i++) {
-      mf_facility_->streambufs[in_com[i]].Push(mat[i]);
+    for (int i = 0; i < mat.size(); i++) {
+      std::string name = "in_stream_" + std::to_string(i);
+      mf_facility_->streambufs[name].Push(mat[i]);
     }
-  }
-
-  std::vector<std::string> GetStream_comds() {
-    return mf_facility_->in_commods;
   }
 
   std::vector<double> GetStream_ratio() { return mf_facility_->mixing_ratios; }
@@ -133,18 +167,18 @@ class MixerTest : public ::testing::Test {
 // Checking that ratios correctly default to 1/N.
 TEST_F(MixerTest, StreamDefaultRatio) {
   SetOutStream_capacity(50);
-
   SetThroughput(1e200);
-
   mf_facility_->EnterNotify();
+
   double ext_val = 1.0 / 3.0;
   std::vector<double> strm_ratio_ = GetStream_ratio();
 
   //
-  for (int i = 0; i < in_com.size(); i++) {
+  for (int i = 0; i < in_coms.size(); i++) {
     EXPECT_DOUBLE_EQ(ext_val, strm_ratio_[i]);
   }
 }
+
 // Test things about the mixing ratio normalisation.
 TEST_F(MixerTest, StreamRatio) {
   // Checking renormalisation when sum of ratio is grester tham 1.
@@ -154,16 +188,13 @@ TEST_F(MixerTest, StreamRatio) {
 
   SetStream_ratio(in_frac_);
   SetStream_capacity(in_cap_);
-
   SetOutStream_capacity(50);
-
   SetThroughput(1e200);
-
   mf_facility_->EnterNotify();
 
   std::vector<double> strm_ratio_ = GetStream_ratio();
   double sum = 0.0;
-  for (int i = 0; i < in_com.size(); i++) {
+  for (int i = 0; i < strm_ratio_.size(); i++) {
     sum += strm_ratio_[i];
   }
 
@@ -172,18 +203,15 @@ TEST_F(MixerTest, StreamRatio) {
 
   // Checking renormalisation when sum of ratio is smaller tham 1.
   in_frac_ = {0.1, 0.2, 0.5};
-
-  SetStream_ratio(in_frac_);
-
   SetOutStream_capacity(50);
-
   SetThroughput(1e200);
 
+  SetStream_ratio(in_frac_);
   mf_facility_->EnterNotify();
-
   strm_ratio_ = GetStream_ratio();
+
   sum = 0;
-  for (int i = 0; i < in_com.size(); i++) {
+  for (int i = 0; i < strm_ratio_.size(); i++) {
     sum += strm_ratio_[i];
   }
 
@@ -196,7 +224,6 @@ TEST_F(MixerTest, MixingComposition) {
   using cyclus::Material;
 
   std::vector<double> in_frac_ = {0.80, 0.15, 0.05};
-
   SetStream_ratio(in_frac_);
 
   SetOutStream_capacity(50);
@@ -212,11 +239,11 @@ TEST_F(MixerTest, MixingComposition) {
   mf_facility_->Tick();
 
   cyclus::CompMap v_0 = c_natu()->mass();
-  cyclus::compmath::Normalize(&v_0, in_frac[0]);
+  cyclus::compmath::Normalize(&v_0, in_frac_[0]);
   cyclus::CompMap v_1 = c_pustream()->mass();
-  cyclus::compmath::Normalize(&v_1, in_frac[1]);
+  cyclus::compmath::Normalize(&v_1, in_frac_[1]);
   cyclus::CompMap v_2 = c_uox()->mass();
-  cyclus::compmath::Normalize(&v_2, in_frac[2]);
+  cyclus::compmath::Normalize(&v_2, in_frac_[2]);
   cyclus::CompMap v = v_0;
   v = cyclus::compmath::Add(v, v_1);
   v = cyclus::compmath::Add(v, v_2);
@@ -224,6 +251,7 @@ TEST_F(MixerTest, MixingComposition) {
   InvBuffer* buffer = GetOutPutBuffer();
   Material::Ptr final_mat = cyclus::ResCast<Material>(buffer->PopBack());
   cyclus::CompMap final_comp = final_mat->comp()->mass();
+
 
   cyclus::compmath::Normalize(&v, 1);
   cyclus::compmath::Normalize(&final_comp, 1);
@@ -258,17 +286,17 @@ TEST_F(MixerTest, Throughput) {
   mf_facility_->Tick();
 
   std::vector<double> cap;
-  for (int i = 0; i < in_com.size(); i++) {
+  for (int i = 0; i < in_coms.size(); i++) {
     cap.push_back(in_cap[i] - 0.5 * in_frac[i]);
   }
 
   std::map<std::string, InvBuffer> streambuf = GetStreamBuffer();
 
-  for (int i = 0; i < in_com.size(); i++) {
-    std::string buf_com = in_com[i];
+  for (int i = 0; i < in_coms.size(); i++) {
+    std::string name = "in_stream_" + std::to_string(i);
     double buf_size = in_cap[i];
     double buf_ratio = in_frac[i];
-    double buf_inv = streambuf[buf_com].quantity();
+    double buf_inv = streambuf[name].quantity();
 
     // checking that each input buf was reduce of the correct amount
     // (constrained by the throughput"
@@ -287,27 +315,45 @@ TEST_F(MixerTest, Throughput) {
 //  material inventory.
 TEST(MixerTests, MultipleFissStreams) {
   std::string config =
-      "<in_commods>"
-      "<val>stream1</val>"
-      "<val>stream2</val>"
-      "<val>stream3</val>"
-      "</in_commods>"
-      "<in_buf_sizes>"
-      "<val>2.5</val>"
-      "<val>3</val>"
-      "<val>5</val>"
-      "</in_buf_sizes>"
-      "<mixing_ratios>"
-      "<val>0.8</val>"
-      "<val>0.15</val>"
-      "<val>0.05</val>"
-      "</mixing_ratios>"
-      "<out_commod>dummyout</out_commod>"
+      "<in_streams>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.8</mixing_ratio>"
+      "<buf_size>2.5</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<commodity>stream1</commodity>"
+      "<pref>1</pref>"
+      "</commodities>"
+      "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.15</mixing_ratio>"
+      "<buf_size>3</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<commodity>stream2</commodity>"
+      "<pref>1</pref>"
+      "</commodities>"
+      "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.05</mixing_ratio>"
+      "<buf_size>5</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<commodity>stream3</commodity>"
+      "<pref>1</pref>"
+      "</commodities>"
+      "</stream>"
+      "</in_streams>"
+      "<out_commod>mixedstream</out_commod>"
       "<outputbuf_size>0</outputbuf_size>"
       "<throughput>0</throughput>";
-
+  std::cout << "1" << std::endl;
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Mixer"), config, simdur);
+  std::cout << "2" << std::endl;
   sim.AddSource("stream1").recipe("unatstream").capacity(1).Finalize();
   sim.AddSource("stream2").recipe("uoxstream").capacity(1).Finalize();
   sim.AddSource("stream3").recipe("pustream").capacity(1).Finalize();
@@ -316,44 +362,66 @@ TEST(MixerTests, MultipleFissStreams) {
   sim.AddRecipe("pustream", c_uox());
   int id = sim.Run();
 
+  std::cout << "3" << std::endl;
   // Checking the number of transaction is as expected 3.
   cyclus::QueryResult qr = sim.db().Query("Transactions", NULL);
   EXPECT_EQ(3, qr.rows.size());
 
+  std::cout << "4" << std::endl;
   // Checking that all input stream get one transaction each.
   std::vector<cyclus::Cond> conds;
   conds.push_back(cyclus::Cond("Commodity", "==", std::string("stream1")));
   qr = sim.db().Query("Transactions", &conds);
   EXPECT_EQ(1, qr.rows.size());
 
+  std::cout << "5" << std::endl;
   conds[0] = cyclus::Cond("Commodity", "==", std::string("stream2"));
   qr = sim.db().Query("Transactions", &conds);
   EXPECT_EQ(1, qr.rows.size());
 
+  std::cout << "6" << std::endl;
   conds[0] = cyclus::Cond("Commodity", "==", std::string("stream3"));
   qr = sim.db().Query("Transactions", &conds);
   EXPECT_EQ(1, qr.rows.size());
+  std::cout << "7" << std::endl;
 }
 
 // multiple input streams can be correctly requested and used as
 //  material inventory.
 TEST(MixerTests, CompleteMixingProcess) {
   std::string config =
-      "<in_commods>"
-      "<val>stream1</val>"
-      "<val>stream2</val>"
-      "<val>stream3</val>"
-      "</in_commods>"
-      "<in_buf_sizes>"
-      "<val>2.5</val>"
-      "<val>3</val>"
-      "<val>5</val>"
-      "</in_buf_sizes>"
-      "<mixing_ratios>"
-      "<val>0.8</val>"
-      "<val>0.15</val>"
-      "<val>0.05</val>"
-      "</mixing_ratios>"
+      "<in_streams>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.8</mixing_ratio>"
+            "<buf_size>2.5</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<commodity>stream1<commodity>"
+            "<pref>1</pref>"
+          "</commodities>"
+        "</stream>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.15</mixing_ratio>"
+            "<buf_size>3</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<commodity>stream2<commodity>"
+            "<pref>1</pref>"
+          "</commodities>"
+        "</stream>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.05</mixing_ratio>"
+            "<buf_size>5</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<commodity>stream3<commodity>"
+            "<pref>1</pref>"
+          "</commodities>"
+        "</stream>"
+      "</in_streams>"
       "<out_commod>mixedstream</out_commod>"
       "<outputbuf_size>10</outputbuf_size>"
       "<throughput>1</throughput>";

--- a/src/mixer_tests.cc
+++ b/src/mixer_tests.cc
@@ -12,8 +12,8 @@ namespace cycamore {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-typedef std::vector<std::pair<std::pair<double, double>,
-                              std::vector<std::pair<std::string, double>>>>
+typedef std::vector<
+    std::pair<std::pair<double, double>, std::map<std::string, double> > >
     t_instream;
 
 cyclus::Composition::Ptr c_pustream() {
@@ -55,13 +55,22 @@ class MixerTest : public ::testing::Test {
   virtual void SetUp() {
     mf_facility_ = new Mixer(tc_.get());
 
-    std::vector<std::vector<std::pair<std::string, double> >> in_commods;
-    std::vector<std::pair<std::string, double> > in_com = {std::pair<std::string, double>("in_c1",1)};
-    in_commods.push_back(in_com);
-    in_com = {std::pair<std::string, double>("in_c2",1)};
-    in_commods.push_back(in_com);
-    in_com = {std::pair<std::string, double>("in_c3",1)};
-    in_commods.push_back(in_com);
+    std::vector<std::map<std::string, double> > in_commods;
+    {
+      std::map<std::string, double> in_com;
+      in_com.insert(std::pair<std::string, double>("in_c1", 1));
+      in_commods.push_back(in_com);
+    }
+    {
+      std::map<std::string, double> in_com;
+      in_com.insert(std::pair<std::string, double>("in_c2", 1));
+      in_commods.push_back(in_com);
+    }
+    {
+      std::map<std::string, double> in_com;
+      in_com.insert(std::pair<std::string, double>("in_c3", 1));
+      in_commods.push_back(in_com);
+    }
     
     std::vector<double> in_ratios = {1, 1, 1};
     std::vector<double> in_caps = {30, 20, 10};
@@ -71,7 +80,7 @@ class MixerTest : public ::testing::Test {
   }
   virtual void TearDown() { delete mf_facility_; }
 
-  std::vector<std::vector<std::pair<std::string, double> >> in_coms;
+  std::vector<std::map<std::string, double> > in_coms;
   std::vector<double> in_frac;
   std::vector<double> in_cap;
 
@@ -95,18 +104,16 @@ class MixerTest : public ::testing::Test {
       in_cap.push_back(streams[i].first.second);
     }
   }
-  
-  void SetIn_stream(
-      std::vector<std::vector<std::pair<std::string, double> > > in_stream,
-      std::vector<double> ratios, std::vector<double> caps) {
+
+  void SetIn_stream(std::vector<std::map<std::string, double> > in_stream,
+                    std::vector<double> ratios, std::vector<double> caps) {
     t_instream instream_tmp;
     for (int i = 0; i < in_stream.size(); i++) {
       std::pair<double, double> info_mtp =
           std::pair<double, double>(ratios[i], caps[i]);
       instream_tmp.push_back(
-          std::pair<std::pair<double, double>,
-                    std::vector<std::pair<std::string, double> > >(info_mtp,
-                                                              in_stream[i]));
+          std::pair<std::pair<double, double>, std::map<std::string, double> >(
+              info_mtp, in_stream[i]));
     }
     SetIn_stream(instream_tmp);
   }
@@ -316,36 +323,42 @@ TEST_F(MixerTest, Throughput) {
 TEST(MixerTests, MultipleFissStreams) {
   std::string config =
       "<in_streams>"
-      "<stream>"
-      "<info>"
-      "<mixing_ratio>0.8</mixing_ratio>"
-      "<buf_size>2.5</buf_size>"
-      "</info>"
-      "<commodities>"
-      "<commodity>stream1</commodity>"
-      "<pref>1</pref>"
-      "</commodities>"
-      "</stream>"
-      "<stream>"
-      "<info>"
-      "<mixing_ratio>0.15</mixing_ratio>"
-      "<buf_size>3</buf_size>"
-      "</info>"
-      "<commodities>"
-      "<commodity>stream2</commodity>"
-      "<pref>1</pref>"
-      "</commodities>"
-      "</stream>"
-      "<stream>"
-      "<info>"
-      "<mixing_ratio>0.05</mixing_ratio>"
-      "<buf_size>5</buf_size>"
-      "</info>"
-      "<commodities>"
-      "<commodity>stream3</commodity>"
-      "<pref>1</pref>"
-      "</commodities>"
-      "</stream>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.8</mixing_ratio>"
+            "<buf_size>2.5</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<item>"
+              "<commodity>stream1</commodity>"
+              "<pref>1</pref>"
+            "</item>"
+          "</commodities>"
+        "</stream>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.15</mixing_ratio>"
+            "<buf_size>3</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<item>"
+              "<commodity>stream2</commodity>"
+              "<pref>1</pref>"
+            "</item>"
+          "</commodities>"
+        "</stream>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.05</mixing_ratio>"
+            "<buf_size>5</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<item>"
+              "<commodity>stream3</commodity>"
+              "<pref>1</pref>"
+            "</item>"
+          "</commodities>"
+        "</stream>"
       "</in_streams>"
       "<out_commod>mixedstream</out_commod>"
       "<outputbuf_size>0</outputbuf_size>"
@@ -397,8 +410,10 @@ TEST(MixerTests, CompleteMixingProcess) {
             "<buf_size>2.5</buf_size>"
           "</info>"
           "<commodities>"
-            "<commodity>stream1<commodity>"
-            "<pref>1</pref>"
+            "<item>"
+              "<commodity>stream1</commodity>"
+              "<pref>1</pref>"
+            "</item>"
           "</commodities>"
         "</stream>"
         "<stream>"
@@ -407,8 +422,10 @@ TEST(MixerTests, CompleteMixingProcess) {
             "<buf_size>3</buf_size>"
           "</info>"
           "<commodities>"
-            "<commodity>stream2<commodity>"
-            "<pref>1</pref>"
+            "<item>"
+              "<commodity>stream2</commodity>"
+              "<pref>1</pref>"
+            "</item>"
           "</commodities>"
         "</stream>"
         "<stream>"
@@ -417,15 +434,16 @@ TEST(MixerTests, CompleteMixingProcess) {
             "<buf_size>5</buf_size>"
           "</info>"
           "<commodities>"
-            "<commodity>stream3<commodity>"
-            "<pref>1</pref>"
+            "<item>"
+              "<commodity>stream3</commodity>"
+              "<pref>1</pref>"
+            "</item>"
           "</commodities>"
         "</stream>"
       "</in_streams>"
       "<out_commod>mixedstream</out_commod>"
       "<outputbuf_size>10</outputbuf_size>"
       "<throughput>1</throughput>";
-
   int simdur = 2;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Mixer"), config, simdur);
   sim.AddSource("stream1").recipe("unatstream").capacity(1).Finalize();


### PR DESCRIPTION
This update the mixer API solving #421 issue.

This is a join PR with cyclus PR [#1271](https://github.com/cyclus/cyclus/pull/1271)

this update mixer API, to allows multiple commodity requests (with different preferences) for each streams that will be mixed i the facility.

The previous API did not deal multiple commodity requests for a single stream. And the previous API would have make it very difficult.

This need a new type: 
`std::vector<std::pair<std::pair<double, double>, std::map<std::string, double> > >`
which has been added in CYCLUS (see cyclus PR [#1271](https://github.com/cyclus/cyclus/pull/1271))
cycamore::mixer unit test have been updated as well.

The implement might not the best: I try to update the API as quick as possible, but the API is fine I think, allowing changing the inside implementation later...

BaM