### PR TITLE
an empty file is created in cycamore when cyclus is built, git should…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tests/run_inputs.py
 cyclus.sqlite
 cycamore_version.h
 *.sqlite
+src/version.cc.in


### PR DESCRIPTION
… not track it.

A better solution would be (eventually) to prevent the generation of this file.