### PR TITLE
fix sink default pref

### DIFF
--- a/src/sink.cc
+++ b/src/sink.cc
@@ -37,6 +37,23 @@ Sink::~Sink() {}
 #pragma cyclus def initfromcopy cycamore::Sink
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void Sink::EnterNotify() {
+  cyclus::Facility::EnterNotify();
+
+  if (in_commod_prefs.size() == 0) {
+    for (int i = 0; i < in_commods.size(); ++i) {
+      in_commod_prefs.push_back(1);
+    }
+  } else if (in_commod_prefs.size() != in_commods.size()) {
+    std::stringstream ss;
+    ss << "in_commod_prefs has " << in_commod_prefs.size()
+       << " values, expected " << in_commods.size();
+    throw cyclus::ValueError(ss.str());
+  }
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::string Sink::str() {
   using std::string;
   using std::vector;
@@ -77,10 +94,9 @@ Sink::GetMatlRequests() {
   } 
 
   if (amt > cyclus::eps()) {
-    std::vector<std::string>::const_iterator it;
     std::vector<Request<Material>*> mutuals;
-    for (it = in_commods.begin(); it != in_commods.end(); ++it) {
-      mutuals.push_back(port->AddRequest(mat, this, *it));
+    for (int i = 0; i < in_commods.size(); i++) {
+      mutuals.push_back(port->AddRequest(mat, this, in_commods[i], in_commod_prefs[i]));
     }
     port->AddMutualReqs(mutuals);
     ports.insert(port);

--- a/src/sink.cc
+++ b/src/sink.cc
@@ -42,7 +42,7 @@ void Sink::EnterNotify() {
 
   if (in_commod_prefs.size() == 0) {
     for (int i = 0; i < in_commods.size(); ++i) {
-      in_commod_prefs.push_back(1);
+      in_commod_prefs.push_back(cyclus::kDefaultPref);
     }
   } else if (in_commod_prefs.size() != in_commods.size()) {
     std::stringstream ss;

--- a/src/sink.h
+++ b/src/sink.h
@@ -40,6 +40,8 @@ class Sink : public cyclus::Facility  {
 
   virtual std::string str();
 
+  virtual void EnterNotify();
+  
   virtual void Tick();
 
   virtual void Tock();
@@ -105,6 +107,14 @@ class Sink : public cyclus::Facility  {
                       "uilabel": "List of Input Commodities", \
                       "uitype": ["oneormore", "incommodity"]}
   std::vector<std::string> in_commods;
+
+  #pragma cyclus var {"default": [],\
+                      "doc":"preferences for each of the given commodities, in the same order."\
+                      "Defauts to 1 if unspecified",\
+                      "uilabel":"In Commody Preferences", \
+                      "range": [None, [1e-299, 1e299]], \
+                      "uitype":["oneormore", "range"]}
+  std::vector<double> in_commod_prefs;
 
   #pragma cyclus var {"default": "", \
                       "tooltip": "requested composition", \

--- a/src/sink.h
+++ b/src/sink.h
@@ -100,6 +100,10 @@ class Sink : public cyclus::Facility  {
   inline const std::vector<std::string>&
       input_commodities() const { return in_commods; }
 
+  /// @return the input commodities preferences
+  inline const std::vector<double>&
+      input_commodity_preferences() const { return in_commod_prefs; }
+
  private:
   /// all facilities must have at least one input commodity
   #pragma cyclus var {"tooltip": "input commodities", \

--- a/src/sink_tests.cc
+++ b/src/sink_tests.cc
@@ -50,6 +50,11 @@ TEST_F(SinkTest, InitialState) {
   std::string arr[] = {commod1_, commod2_};
   std::vector<std::string> vexp (arr, arr + sizeof(arr) / sizeof(arr[0]) );
   EXPECT_EQ(vexp, src_facility->input_commodities());
+
+  src_facility->EnterNotify();
+  double pref[] = {cyclus::kDefaultPref, cyclus::kDefaultPref};
+  std::vector<double> vpref (pref, pref + sizeof(pref) / sizeof(pref[0]) );
+  EXPECT_EQ(vpref, src_facility->input_commodity_preferences());
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/sink_tests.cc
+++ b/src/sink_tests.cc
@@ -218,6 +218,52 @@ TEST_F(SinkTest, InRecipe){
   EXPECT_EQ(req->commodity(),"some_u");
 }
 
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(SinkTest, BidPrefs) {
+  using cyclus::QueryResult;
+  using cyclus::Cond;
+
+  std::string config = 
+    "   <in_commods>"
+    "     <val>commods_1</val>"
+    "     <val>commods_2</val>"
+    "   </in_commods>"
+    "   <in_commod_prefs>"
+    "     <val>10</val> "
+    "     <val>1</val> "
+    "   </in_commod_prefs>"
+    "   <capacity>1</capacity>"
+    "   <input_capacity>1.0</input_capacity> ";
+
+  int simdur = 1;
+  cyclus::MockSim sim(cyclus::AgentSpec
+		      (":cycamore:Sink"), config, simdur);
+
+  sim.AddSource("commods_1")
+    .capacity(1)
+    .Finalize();
+
+  sim.AddSource("commods_2")
+    .capacity(1)
+    .Finalize();
+  
+  int id = sim.Run();
+
+  std::vector<Cond> conds;
+  conds.push_back(Cond("Commodity", "==", std::string("commods_1")));
+  QueryResult qr = sim.db().Query("Transactions", &conds);
+
+  // should trade only with #1 since it has highier priority
+  EXPECT_EQ(1, qr.rows.size());
+  
+  std::vector<Cond> conds2;
+  conds2.push_back(Cond("Commodity", "==", std::string("commods_2")));
+  QueryResult qr2 = sim.db().Query("Transactions", &conds2);
+
+  // should trade only with #1 since it has highier priority
+  EXPECT_EQ(0, qr2.rows.size());
+  
+}
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(SinkTest, Print) {
   EXPECT_NO_THROW(std::string s = src_facility->str());

--- a/src/sink_tests.cc
+++ b/src/sink_tests.cc
@@ -113,6 +113,7 @@ TEST_F(SinkTest, Requests) {
   std::string arr[] = {commod1_, commod2_};
   std::vector<std::string> commods (arr, arr + sizeof(arr) / sizeof(arr[0]) );
 
+  src_facility->EnterNotify();
   std::set<RequestPortfolio<Material>::Ptr> ports =
       src_facility->GetMatlRequests();
 
@@ -197,7 +198,8 @@ TEST_F(SinkTest, InRecipe){
   // create a sink facility to interact with the DRE
   cycamore::Sink* snk = new cycamore::Sink(&ctx);
   snk->AddCommodity("some_u");
-
+  snk->EnterNotify();
+  
   std::set<RequestPortfolio<Material>::Ptr> ports =
     snk->GetMatlRequests();
   ASSERT_EQ(ports.size(), 1);

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -57,7 +57,7 @@ void Storage::EnterNotify() {
 
   if (in_commod_prefs.size() == 0) {
     for (int i = 0; i < in_commods.size(); ++i) {
-      in_commod_prefs.push_back(1);
+      in_commod_prefs.push_back(cyclus::kDefaultPref);
     }
   } else if (in_commod_prefs.size() != in_commods.size()) {
     std::stringstream ss;


### PR DESCRIPTION
the release v1.4.0 is not tolerant to pref 0. 
Apparently sink use to do 0 preference request (by default), which stop the simulation...

this should fix it and put everything back to normal.

If you could review it quickly, I think it should go in the 1.4.2 release.... :(
@scopatz @gonuke @FlanFlanagan 