### PR TITLE
updated metadata

### DIFF
--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -299,7 +299,9 @@ class Enrichment : public cyclus::Facility {
 
   #pragma cyclus var {							\
     "default": 0.003, "tooltip": "tails assay",				\
-    "uilabel": "Tails Assay",                               \
+    "uilabel": "Tails Assay",                             \
+    "uitype": "range"                               \
+    "range": [0.0, 0.003],                              \
     "doc": "tails assay from the enrichment process",       \
   }
   double tails_assay;
@@ -327,6 +329,8 @@ class Enrichment : public cyclus::Facility {
     "tooltip": "maximum allowed enrichment fraction",		\
     "doc": "maximum allowed weight fraction of U235 in product", \
     "uilabel": "Maximum Allowed Enrichment", \
+    "uitype": "range", \
+    "range": [0.0,1.0], \
     "schema": '<optional>'				     	   \
         '          <element name="max_enrich">'			   \
         '              <data type="double">'			   \

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -330,7 +330,7 @@ class Reactor : public cyclus::Facility,
            "normally.", \
     "uilabel": "Nominal Reactor Power", \
     "uitype": "range", \
-    "range": [0.0, 10,000.00],  \
+    "range": [0.0, 2000.00],  \
     "units": "MWe", \
   }
   double power_cap;

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -270,12 +270,13 @@ class Reactor : public cyclus::Facility,
   }
   int n_assem_batch;
   #pragma cyclus var { \
+    "default": 3, \
     "uilabel": "Number of Assemblies in Core", \
     "doc": "Number of assemblies that constitute a full core.", \
   }
   int n_assem_core;
   #pragma cyclus var { \
-    "default": 0, \
+    "default": 3, \
     "uilabel": "Minimum Fresh Fuel Inventory", \
     "units": "assemblies", \
     "doc": "Number of fresh fuel assemblies to keep on-hand if possible.", \
@@ -292,6 +293,7 @@ class Reactor : public cyclus::Facility,
 
    ///////// cycle params ///////////
   #pragma cyclus var { \
+    "default": 18, \
     "doc": "The duration of a full operational cycle (excluding refueling " \
            "time) in time steps.", \
     "uilabel": "Cycle Length", \
@@ -299,6 +301,7 @@ class Reactor : public cyclus::Facility,
   }
   int cycle_time;
   #pragma cyclus var { \
+    "default": 1, \
     "doc": "The duration of a full refueling period - the minimum time between"\
            " the end of a cycle and the start of the next cycle.", \
     "uilabel": "Refueling Outage Duration", \

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -272,16 +272,16 @@ class Reactor : public cyclus::Facility,
   #pragma cyclus var { \
     "default": 3, \
     "uilabel": "Number of Assemblies in Core", \
-    "uitype": "Range", \
-    "Range": [1,3], \
+    "uitype": "range", \
+    "range": [1,3], \
     "doc": "Number of assemblies that constitute a full core.", \
   }
   int n_assem_core;
   #pragma cyclus var { \
     "default": 3, \
     "uilabel": "Minimum Fresh Fuel Inventory", \
-    "uitype": "Range", \
-    "Range": [1,3], \
+    "uitype": "range", \
+    "range": [1,3], \
     "units": "assemblies", \
     "doc": "Number of fresh fuel assemblies to keep on-hand if possible.", \
   }
@@ -289,8 +289,8 @@ class Reactor : public cyclus::Facility,
   #pragma cyclus var { \
     "default": 1000000000, \
     "uilabel": "Maximum Spent Fuel Inventory", \
-    "uitype": "Range", \
-    "Range": [0, 1000000000], \
+    "uitype": "range", \
+    "range": [0, 1000000000], \
     "units": "assemblies", \
     "doc": "Number of spent fuel assemblies that can be stored on-site before" \
            " reactor operation stalls.", \
@@ -329,8 +329,8 @@ class Reactor : public cyclus::Facility,
     "doc": "Amount of electrical power the facility produces when operating " \
            "normally.", \
     "uilabel": "Nominal Reactor Power", \
-    "uitype": "Range", \
-    "Range": [0.0, 10,000.00],  \
+    "uitype": "range", \
+    "range": [0.0, 10,000.00],  \
     "units": "MWe", \
   }
   double power_cap;

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -272,12 +272,16 @@ class Reactor : public cyclus::Facility,
   #pragma cyclus var { \
     "default": 3, \
     "uilabel": "Number of Assemblies in Core", \
+    "uitype": "Range", \
+    "Range": [1,3], \
     "doc": "Number of assemblies that constitute a full core.", \
   }
   int n_assem_core;
   #pragma cyclus var { \
     "default": 3, \
     "uilabel": "Minimum Fresh Fuel Inventory", \
+    "uitype": "Range", \
+    "Range": [1,3], \
     "units": "assemblies", \
     "doc": "Number of fresh fuel assemblies to keep on-hand if possible.", \
   }
@@ -285,6 +289,8 @@ class Reactor : public cyclus::Facility,
   #pragma cyclus var { \
     "default": 1000000000, \
     "uilabel": "Maximum Spent Fuel Inventory", \
+    "uitype": "Range", \
+    "Range": [0, 1000000000], \
     "units": "assemblies", \
     "doc": "Number of spent fuel assemblies that can be stored on-site before" \
            " reactor operation stalls.", \
@@ -323,6 +329,8 @@ class Reactor : public cyclus::Facility,
     "doc": "Amount of electrical power the facility produces when operating " \
            "normally.", \
     "uilabel": "Nominal Reactor Power", \
+    "uitype": "Range", \
+    "Range": [0.0, 10,000.00],  \
     "units": "MWe", \
   }
   double power_cap;


### PR DESCRIPTION
Updated metadata for enrichment.h and reactor.h:
Enrichment: added range to max_enrich [0.0, 1.0] and to tails_assay [0.0,0.003]
Reactor: added default values to cycle_time, n_assem_core, n_assem_fresh, and refuel_time these are subject to change in later updates.