### PR TITLE
Fix cycamore_unit_test

### DIFF
--- a/src/reactor.h
+++ b/src/reactor.h
@@ -281,7 +281,7 @@ class Reactor : public cyclus::Facility,
     "default": 0, \
     "uilabel": "Minimum Fresh Fuel Inventory", \
     "uitype": "range", \
-    "range": [1,3], \
+    "range": [0,3], \
     "units": "assemblies", \
     "doc": "Number of fresh fuel assemblies to keep on-hand if possible.", \
   }

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -278,7 +278,7 @@ class Reactor : public cyclus::Facility,
   }
   int n_assem_core;
   #pragma cyclus var { \
-    "default": 3, \
+    "default": 0, \
     "uilabel": "Minimum Fresh Fuel Inventory", \
     "uitype": "range", \
     "range": [1,3], \


### PR DESCRIPTION
@scopatz @aglenn2 :
I fix the cycamore unit test by re-setting the minimum fresh assembly to 0

the change from 0 to 3 definitely change the behavior of the reactor... and as most of the cycamore user don't specify it... I think this is better to actually keep it that way...

