### PR TITLE
fix enrichement calculation

### DIFF
--- a/input/enrichment/1_src_enr_rxtr_sink.xml
+++ b/input/enrichment/1_src_enr_rxtr_sink.xml
@@ -100,7 +100,7 @@
 
   <recipe>
     <name>natl_u</name>
-    <basis>atom</basis>
+    <basis>mass</basis>
     <nuclide>
       <id>922350000</id>
       <comp>0.7</comp>
@@ -113,7 +113,7 @@
 
   <recipe>
     <name>fuel_recipe</name>
-    <basis>atom</basis>
+    <basis>mass</basis>
     <nuclide>
       <id>922350000</id>
       <comp>4.5</comp>

--- a/input/enrichment/linear_src_enr_rxtr_sink.xml
+++ b/input/enrichment/linear_src_enr_rxtr_sink.xml
@@ -125,7 +125,7 @@
 
   <recipe>
     <name>natl_u</name>
-    <basis>atom</basis>
+    <basis>mass</basis>
     <nuclide>
       <id>922350000</id>
       <comp>0.7</comp>
@@ -138,7 +138,7 @@
 
   <recipe>
     <name>fuel_recipe</name>
-    <basis>atom</basis>
+    <basis>mass</basis>
     <nuclide>
       <id>922350000</id>
       <comp>4.5</comp>

--- a/input/enrichment/natu_capacitated.xml
+++ b/input/enrichment/natu_capacitated.xml
@@ -125,7 +125,7 @@
 
   <recipe>
     <name>natl_u</name>
-    <basis>atom</basis>
+    <basis>mass</basis>
     <nuclide>
       <id>922350000</id>
       <comp>0.7</comp>
@@ -138,7 +138,7 @@
 
   <recipe>
     <name>fuel_recipe</name>
-    <basis>atom</basis>
+    <basis>mass</basis>
     <nuclide>
       <id>922350000</id>
       <comp>4.5</comp>

--- a/input/enrichment/swu_capacitated.xml
+++ b/input/enrichment/swu_capacitated.xml
@@ -126,7 +126,7 @@
 
   <recipe>
     <name>natl_u</name>
-    <basis>atom</basis>
+    <basis>mass</basis>
     <nuclide>
       <id>922350000</id>
       <comp>0.7</comp>
@@ -139,7 +139,7 @@
 
   <recipe>
     <name>fuel_recipe</name>
-    <basis>atom</basis>
+    <basis>mass</basis>
     <nuclide>
       <id>922350000</id>
       <comp>4.5</comp>

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -209,7 +209,7 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Enrichment::GetMatlBids(
     for (it = commod_requests.begin(); it != commod_requests.end(); ++it) {
       Request<Material>* req = *it;
       Material::Ptr mat = req->target();
-      double request_enrich = cyclus::toolkit::UraniumAssay(mat);
+      double request_enrich = cyclus::toolkit::UraniumAssayMass(mat);
       if (ValidReq(req->target()) &&
           ((request_enrich < max_enrich) ||
            (cyclus::AlmostEq(request_enrich, max_enrich)))) {
@@ -352,13 +352,13 @@ cyclus::Material::Ptr Enrichment::Enrich_(cyclus::Material::Ptr mat,
   using cyclus::Material;
   using cyclus::ResCast;
   using cyclus::toolkit::Assays;
-  using cyclus::toolkit::UraniumAssay;
+  using cyclus::toolkit::UraniumAssayMass;
   using cyclus::toolkit::SwuRequired;
   using cyclus::toolkit::FeedQty;
   using cyclus::toolkit::TailsQty;
 
   // get enrichment parameters
-  Assays assays(FeedAssay(), UraniumAssay(mat), tails_assay);
+  Assays assays(FeedAssay(), UraniumAssayMass(mat), tails_assay);
   double swu_req = SwuRequired(qty, assays);
   double natu_req = FeedQty(qty, assays);
 
@@ -454,7 +454,7 @@ double Enrichment::FeedAssay() {
   cyclus::Material::Ptr fission_matl =
       inventory.Pop(pop_qty, cyclus::eps_rsrc());
   inventory.Push(fission_matl);
-  return cyclus::toolkit::UraniumAssay(fission_matl);
+  return cyclus::toolkit::UraniumAssayMass(fission_matl);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -24,7 +24,7 @@ class SWUConverter : public cyclus::Converter<cyclus::Material> {
       cyclus::Arc const * a = NULL,
       cyclus::ExchangeTranslationContext<cyclus::Material>
           const * ctx = NULL) const {
-    cyclus::toolkit::Assays assays(feed_, cyclus::toolkit::UraniumAssay(m),
+    cyclus::toolkit::Assays assays(feed_, cyclus::toolkit::UraniumAssayMass(m),
                                    tails_);
     return cyclus::toolkit::SwuRequired(m->quantity(), assays);
   }
@@ -60,7 +60,7 @@ class NatUConverter : public cyclus::Converter<cyclus::Material> {
       cyclus::Arc const * a = NULL,
       cyclus::ExchangeTranslationContext<cyclus::Material>
           const * ctx = NULL) const {
-    cyclus::toolkit::Assays assays(feed_, cyclus::toolkit::UraniumAssay(m),
+    cyclus::toolkit::Assays assays(feed_, cyclus::toolkit::UraniumAssayMass(m),
                                    tails_);
     cyclus::toolkit::MatQuery mq(m);
     std::set<cyclus::Nuc> nucs;

--- a/src/enrichment_tests.cc
+++ b/src/enrichment_tests.cc
@@ -162,7 +162,7 @@ TEST_F(EnrichmentTest, CheckCapConstraint) {
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
   EXPECT_EQ(1.0, qr.rows.size());
-  EXPECT_NEAR(5.0, m->quantity(), 0.01) <<
+  EXPECT_LE(5.0, m->quantity()) << 
     "traded quantity exceeds capacity constraint";
 }
 
@@ -299,7 +299,8 @@ TEST_F(EnrichmentTest, TradeTails) {
   QueryResult qr = sim.db().Query("Transactions", &conds);
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
   
-  // Should be 2 tails transactions, one from each LEU sink, each 4.084kg.
+  // Should be 2 tails transactions, one from each LEU sink, each 4.125kg.
+  // Q * (e_p - e_f)/(e_f - e_t) = 0.5 * (0.04 - 0.007)/(0.007 - 0.003) = 4.125 
   EXPECT_EQ(2, qr.rows.size());
 
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
@@ -310,7 +311,7 @@ TEST_F(EnrichmentTest, TradeTails) {
 
   stmt->BindText(1, "tails");
   stmt->Step();
-  EXPECT_NEAR(8.168,stmt->GetDouble(0), 0.01) <<
+  EXPECT_NEAR(8.25,stmt->GetDouble(0), 0.01) <<
     "Not providing the requested quantity" ;
 }
 
@@ -579,7 +580,7 @@ TEST_F(EnrichmentTest, ValidReq) {
   using cyclus::toolkit::MatQuery;
   using cyclus::Composition;
   using cyclus::toolkit::Assays;
-  using cyclus::toolkit::UraniumAssay;
+  using cyclus::toolkit::UraniumAssayMass;
   using cyclus::toolkit::SwuRequired;
   using cyclus::toolkit::FeedQty;
   using cyclus::toolkit::MatQuery;
@@ -621,7 +622,7 @@ TEST_F(EnrichmentTest, Enrich) {
   using cyclus::toolkit::MatQuery;
   using cyclus::Composition;
   using cyclus::toolkit::Assays;
-  using cyclus::toolkit::UraniumAssay;
+  using cyclus::toolkit::UraniumAssayMass;
   using cyclus::toolkit::SwuRequired;
   using cyclus::toolkit::FeedQty;
 
@@ -634,7 +635,7 @@ TEST_F(EnrichmentTest, Enrich) {
   Material::Ptr target = cyclus::Material::CreateUntracked(
       qty + 10, cyclus::Composition::CreateFromMass(v));
 
-  Assays assays(feed_assay, UraniumAssay(target), tails_assay);
+  Assays assays(feed_assay, UraniumAssayMass(target), tails_assay);
   double swu_req = SwuRequired(qty, assays);
   double natu_req = FeedQty(qty, assays);
   double tails_qty = TailsQty(qty, assays);
@@ -676,7 +677,7 @@ TEST_F(EnrichmentTest, Response) {
   using cyclus::toolkit::Assays; 
   using cyclus::toolkit::FeedQty; 
   using cyclus::toolkit::SwuRequired;
-  using cyclus::toolkit::UraniumAssay;
+  using cyclus::toolkit::UraniumAssayMass;
 
   // problem set up
   std::vector< cyclus::Trade<cyclus::Material> > trades;
@@ -694,7 +695,7 @@ TEST_F(EnrichmentTest, Response) {
   Material::Ptr target = cyclus::Material::CreateUntracked(
       qty + 10, cyclus::Composition::CreateFromMass(v));
 
-  Assays assays(feed_assay, UraniumAssay(target), tails_assay);
+  Assays assays(feed_assay, UraniumAssayMass(target), tails_assay);
   double swu_req = SwuRequired(qty, assays);
   double natu_req = FeedQty(qty, assays);
   

--- a/src/enrichment_tests.cc
+++ b/src/enrichment_tests.cc
@@ -162,7 +162,7 @@ TEST_F(EnrichmentTest, CheckCapConstraint) {
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
   EXPECT_EQ(1.0, qr.rows.size());
-  EXPECT_LE(5.0, m->quantity()) << 
+  EXPECT_LE(m->quantity(), 5.0) << 
     "traded quantity exceeds capacity constraint";
 }
 
@@ -177,7 +177,7 @@ TEST_F(EnrichmentTest, RequestEnrich) {
     "   <product_commod>enr_u</product_commod> "
     "   <tails_commod>tails</tails_commod> "
     "   <tails_assay>0.003</tails_assay> "
-    "   <max_enrich>0.20</max_enrich> ";
+    "   <max_enrich>0.19</max_enrich> ";
 
   int simdur = 2;
   cyclus::MockSim sim(cyclus::AgentSpec
@@ -467,7 +467,7 @@ void EnrichmentTest::InitParameters() {
   cyclus::CompMap v;
   v[922350000] = feed_assay;
   v[922380000] = 1 - feed_assay;
-  recipe = cyclus::Composition::CreateFromAtom(v);
+  recipe = cyclus::Composition::CreateFromMass(v);
   ctx->AddRecipe(feed_recipe, recipe);
 
   tails_assay = 0.002;

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -113,7 +113,7 @@ class _PhysorEnrichment(TestRegression):
         # this can be updated if/when we can call into the cyclus::toolkit's
         # enrichment module from python
         # with old BatchReactor: exp = [6.9, 10, 4.14, 6.9]
-        exp = [6.9, 10., 4.14, 6.9]
+        exp = [6.85, 9.94, 4.11, 6.85]
         obs = [np.sum(self.to_ary(enr, "SWU")[
                     self.to_ary(enr, "Time") == t]) for t in range(4)]
         assert_array_almost_equal(exp, obs, decimal=2)
@@ -124,7 +124,7 @@ class _PhysorEnrichment(TestRegression):
         # enrichment module from python
 
         # with old BatchReactor: exp = [13.03, 16.54, 7.83, 13.03]
-        exp = [13.03, 16.55, 7.82, 13.03]
+        exp = [13.14, 16.69, 7.88, 13.14]
         obs = [np.sum(self.to_ary(enr, "Natural_Uranium")[
                     self.to_ary(enr, "Time") == t]) for t in range(4)]
         assert_array_almost_equal(exp, obs, decimal=2)


### PR DESCRIPTION
this PR fix the calculation of the enrichment:
this now requires the proper amount of feed material and calculate the proper enrichment of the tails.

the unit test have been updated accordingly.

the precedent issue was a confusion when calculating the feed quantity required using the mass quantity and the atom enrichment fraction. 
this now use mass enrichment fraction for everything.
