### PR TITLE
Reactor by-product

### DIFF
--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -23,9 +23,10 @@ Reactor::Reactor(cyclus::Context* ctx)
       power_cap(0),
       power_name("power"),
       discharged(false),
-      latitude(0,0),
-      longitude(0,0),
-      coordinates(latitude, longitude) { }
+      latitude(0.0),
+      longitude(0.0),
+      coordinates(latitude, longitude) {}
+
 
 #pragma cyclus def clone cycamore::Reactor
 
@@ -126,7 +127,7 @@ void Reactor::Tick() {
     // record the last time series entry if the reactor was operating at the
     // time of retirement.
 
-    if (context()->time() == exit_time()) { // only need to transmute once
+    if (context()->time() == exit_time() + 1) { // only need to transmute once
       Transmute(ceil(static_cast<double>(n_assem_core) / 2.0));
     }
     while (core.count() > 0) {
@@ -537,13 +538,13 @@ void Reactor::RecordPosition() {
   std::string specification = this->spec();
   context()
       ->NewDatum("AgentPosition")
+      ->AddVal("Spec", specification)
       ->AddVal("Prototype", this->prototype())
       ->AddVal("AgentId", id())
       ->AddVal("Latitude", latitude)
       ->AddVal("Longitude", longitude)
       ->Record();
 }
-
 
 extern "C" cyclus::Agent* ConstructReactor(cyclus::Context* ctx) {
   return new Reactor(ctx);

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -22,11 +22,7 @@ Reactor::Reactor(cyclus::Context* ctx)
       cycle_step(0),
       power_cap(0),
       power_name("power"),
-      discharged(false),
-      latitude(0.0),
-      longitude(0.0),
-      coordinates(latitude, longitude) {}
-
+      discharged(false) { }
 
 #pragma cyclus def clone cycamore::Reactor
 
@@ -53,8 +49,13 @@ void Reactor::InitFrom(cyclus::QueryableBackend* b) {
   namespace tk = cyclus::toolkit;
   tk::CommodityProducer::Add(tk::Commodity(power_name),
                              tk::CommodInfo(power_cap, power_cap));
-}
 
+  for (int i = 0; i < side_products.size(); i++) {
+    tk::CommodityProducer::Add(tk::Commodity(side_products[i]),
+                               tk::CommodInfo(side_product_quantity[i],
+                                                 side_product_quantity[i]));
+  }
+}
 void Reactor::EnterNotify() {
   cyclus::Facility::EnterNotify();
 
@@ -64,6 +65,11 @@ void Reactor::EnterNotify() {
     for (int i = 0; i < fuel_outcommods.size(); i++) {
       fuel_prefs.push_back(cyclus::kDefaultPref);
     }
+  }
+
+  // Test if any side products have been defined.
+  if (side_products.size() == 0){
+    bool hybrid = false;
   }
 
   // input consistency checking:
@@ -96,7 +102,6 @@ void Reactor::EnterNotify() {
   if (ss.str().size() > 0) {
     throw cyclus::ValueError(ss.str());
   }
-  RecordPosition();
 }
 
 bool Reactor::CheckDecommissionCondition() {
@@ -114,7 +119,33 @@ void Reactor::Tick() {
   if (retired()) {
     Record("RETIRED", "");
 
-    if (context()->time() == exit_time() + 1) { // only need to transmute once
+    // record the last time series entry if the reactor was operating at the
+    // time of retirement.
+    if (exit_time() == context()->time()) {
+      if (refuel_time == 0){
+        if (cycle_step > 0 && cycle_step <= cycle_time &&
+          core.count() == n_assem_core) {
+        cyclus::toolkit::RecordTimeSeries<cyclus::toolkit::POWER>(this, power_cap);
+        RecordSideProduct(true);
+      } else {
+        cyclus::toolkit::RecordTimeSeries<cyclus::toolkit::POWER>(this, 0);
+        RecordSideProduct(false);
+      }
+      } else{
+        if (cycle_step > 0 && cycle_step < cycle_time &&
+          core.count() == n_assem_core) {
+        cyclus::toolkit::RecordTimeSeries<cyclus::toolkit::POWER>(this, power_cap);
+        RecordSideProduct(true);
+      } 
+        else {
+        cyclus::toolkit::RecordTimeSeries<cyclus::toolkit::POWER>(this, 0);
+        RecordSideProduct(false);
+      }  
+      }
+      
+    }
+
+    if (context()->time() == exit_time()) { // only need to transmute once
       Transmute(ceil(static_cast<double>(n_assem_core) / 2.0));
     }
     while (core.count() > 0) {
@@ -236,7 +267,6 @@ void Reactor::GetMatlTrades(
     std::string commod = trades[i].request->commodity();
     Material::Ptr m = mats[commod].back();
     mats[commod].pop_back();
-    cyclus::toolkit::RecordTimeSeries<double>("UsedFuel", this, m->quantity());
     responses.push_back(std::make_pair(trades[i], m));
     res_indexes.erase(m->obj_id());
   }
@@ -342,8 +372,10 @@ void Reactor::Tock() {
   if (cycle_step >= 0 && cycle_step < cycle_time &&
       core.count() == n_assem_core) {
     cyclus::toolkit::RecordTimeSeries<cyclus::toolkit::POWER>(this, power_cap);
+    RecordSideProduct(true);
   } else {
     cyclus::toolkit::RecordTimeSeries<cyclus::toolkit::POWER>(this, 0);
+    RecordSideProduct(false);
   }
 
   // "if" prevents starting cycle after initial deployment until core is full
@@ -487,6 +519,28 @@ void Reactor::PushSpent(std::map<std::string, MatVec> leftover) {
   }
 }
 
+void Reactor::RecordSideProduct(bool produce){
+  if (hybrid){
+    double value;
+    for (int i = 0; i < side_products.size(); i++) {
+      if (produce){
+          value = side_product_quantity[i];
+      }
+      else {
+          value = 0;
+      }
+
+      context()
+          ->NewDatum("ReactorSideProducts")
+          ->AddVal("AgentId", id())
+          ->AddVal("Time", context()->time())
+          ->AddVal("Product", side_products[i])
+          ->AddVal("Value", value)
+          ->Record();
+    }
+  }
+}
+
 void Reactor::Record(std::string name, std::string val) {
   context()
       ->NewDatum("ReactorEvents")
@@ -494,18 +548,6 @@ void Reactor::Record(std::string name, std::string val) {
       ->AddVal("Time", context()->time())
       ->AddVal("Event", name)
       ->AddVal("Value", val)
-      ->Record();
-}
-
-void Reactor::RecordPosition() {
-  std::string specification = this->spec();
-  context()
-      ->NewDatum("AgentPosition")
-      ->AddVal("Spec", specification)
-      ->AddVal("Prototype", this->prototype())
-      ->AddVal("AgentId", id())
-      ->AddVal("Latitude", latitude)
-      ->AddVal("Longitude", longitude)
       ->Record();
 }
 

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -57,7 +57,7 @@ void Reactor::InitFrom(cyclus::QueryableBackend* b) {
   for (int i = 0; i < side_products.size(); i++) {
     tk::CommodityProducer::Add(tk::Commodity(side_products[i]),
                                tk::CommodInfo(side_product_quantity[i],
-                                                 side_product_quantity[i]));
+                                              side_product_quantity[i]));
   }
 }
 void Reactor::EnterNotify() {
@@ -73,7 +73,7 @@ void Reactor::EnterNotify() {
 
   // Test if any side products have been defined.
   if (side_products.size() == 0){
-    bool hybrid = false;
+    hybrid_ = false;
   }
 
   // input consistency checking:
@@ -500,7 +500,7 @@ void Reactor::PushSpent(std::map<std::string, MatVec> leftover) {
 }
 
 void Reactor::RecordSideProduct(bool produce){
-  if (hybrid){
+  if (hybrid_){
     double value;
     for (int i = 0; i < side_products.size(); i++) {
       if (produce){

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -124,9 +124,6 @@ void Reactor::Tick() {
   if (retired()) {
     Record("RETIRED", "");
 
-    // record the last time series entry if the reactor was operating at the
-    // time of retirement.
-
     if (context()->time() == exit_time() + 1) { // only need to transmute once
       Transmute(ceil(static_cast<double>(n_assem_core) / 2.0));
     }

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -53,7 +53,8 @@ namespace cycamore {
 /// compositions.
 
 class Reactor : public cyclus::Facility,
-  public cyclus::toolkit::CommodityProducer {
+  public cyclus::toolkit::CommodityProducer,
+  public cyclus::toolkit::Position {
 #pragma cyclus note { \
 "niche": "reactor", \
 "doc": \
@@ -140,7 +141,7 @@ class Reactor : public cyclus::Facility,
   double fuel_pref(cyclus::Material::Ptr m);
 
   bool retired() {
-    return exit_time() != -1 && context()->time() >= exit_time();
+    return exit_time() != -1 && context()->time() > exit_time();
   }
 
   /// Store fuel info index for the given resource received on incommod.
@@ -352,12 +353,14 @@ class Reactor : public cyclus::Facility,
 
   #pragma cyclus var { \
     "uilabel": "Side Product from Reactor Plant", \
+    "default": [], \
     "doc": "Ordered list of side product the reactor produces with power", \
   }
   std::vector<std::string> side_products;
 
   #pragma cyclus var { \
     "uilabel": "Quantity of Side Product from Reactor Plant", \
+    "default": [], \
     "doc": "Ordered list of the quantity of side product the reactor produces with power", \
   }
   std::vector<double> side_product_quantity;
@@ -420,6 +423,27 @@ class Reactor : public cyclus::Facility,
 
   // populated lazily and no need to persist.
   std::set<std::string> uniq_outcommods_;
+
+  #pragma cyclus var { \
+    "default": 0.0, \
+    "uilabel": "Geographical latitude in degrees as a double", \
+    "doc": "Latitude of the agent's geographical position. The value should " \
+           "be expressed in degrees as a double." \
+  }
+  double latitude;
+
+  #pragma cyclus var { \
+    "default": 0.0, \
+    "uilabel": "Geographical longitude in degrees as a double", \
+    "doc": "Longitude of the agent's geographical position. The value should " \
+           "be expressed in degrees as a double." \
+  }
+  double longitude;
+
+  cyclus::toolkit::Position coordinates;
+
+  /// Records an agent's latitude and longitude to the output db
+  void RecordPosition();
 };
 
 } // namespace cycamore

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -365,7 +365,7 @@ class Reactor : public cyclus::Facility,
   }
   std::vector<double> side_product_quantity;
 
-  #pragma cyclus var {"default": 1, "doc": "This should NEVER be set manually",\
+  #pragma cyclus var {"default": 1,\
                       "internal": True,\
                       "doc": "True if reactor is a hybrid system (produces side products)", \
   }

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -354,21 +354,22 @@ class Reactor : public cyclus::Facility,
   #pragma cyclus var { \
     "uilabel": "Side Product from Reactor Plant", \
     "default": [], \
-    "doc": "Ordered list of side product the reactor produces with power", \
+    "doc": "Ordered vector of side product the reactor produces with power", \
   }
   std::vector<std::string> side_products;
 
   #pragma cyclus var { \
     "uilabel": "Quantity of Side Product from Reactor Plant", \
     "default": [], \
-    "doc": "Ordered list of the quantity of side product the reactor produces with power", \
+    "doc": "Ordered vector of the quantity of side product the reactor produces with power", \
   }
   std::vector<double> side_product_quantity;
 
   #pragma cyclus var {"default": 1, "doc": "This should NEVER be set manually",\
-                      "internal": True \
+                      "internal": True,\
+                      "doc": "True if reactor is a hybrid system (produces side products)", \
   }
-  bool hybrid;
+  bool hybrid_;
 
 
   /////////// preference changes ///////////

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -53,8 +53,7 @@ namespace cycamore {
 /// compositions.
 
 class Reactor : public cyclus::Facility,
-  public cyclus::toolkit::CommodityProducer,
-  public cyclus::toolkit::Position {
+  public cyclus::toolkit::CommodityProducer {
 #pragma cyclus note { \
 "niche": "reactor", \
 "doc": \
@@ -141,7 +140,7 @@ class Reactor : public cyclus::Facility,
   double fuel_pref(cyclus::Material::Ptr m);
 
   bool retired() {
-    return exit_time() != -1 && context()->time() > exit_time();
+    return exit_time() != -1 && context()->time() >= exit_time();
   }
 
   /// Store fuel info index for the given resource received on incommod.
@@ -157,6 +156,9 @@ class Reactor : public cyclus::Facility,
   /// Transmute the batch that is about to be discharged from the core to its
   /// fully burnt state as defined by its outrecipe.
   void Transmute();
+
+  /// Records production of side products from the reactor
+  void RecordSideProduct(bool produce);
 
   /// Transmute the specified number of assemblies in the core to their
   /// fully burnt state as defined by their outrecipe.
@@ -208,7 +210,7 @@ class Reactor : public cyclus::Facility,
            "received as each particular input commodity (same order)." \
   }
   std::vector<std::string> fuel_outcommods;
-  #pragma cyclus var {		       \
+  #pragma cyclus var {           \
     "uitype": ["oneormore", "outrecipe"], \
     "uilabel": "Spent Fuel Recipe List", \
     "doc": "Spent fuel recipes corresponding to the given fuel input " \
@@ -256,7 +258,7 @@ class Reactor : public cyclus::Facility,
 
  //////////// inventory and core params ////////////
   #pragma cyclus var { \
-    "doc": "Mass (kg) of a single assembly.",	\
+    "doc": "Mass (kg) of a single assembly.", \
     "uilabel": "Assembly Mass", \
     "uitype": "range", \
     "range": [1.0, 1e5], \
@@ -268,7 +270,7 @@ class Reactor : public cyclus::Facility,
     "uilabel": "Number of Assemblies per Batch", \
     "doc": "Number of assemblies that constitute a single batch.  " \
            "This is the number of assemblies discharged from the core fully " \
-           "burned each cycle."						\
+           "burned each cycle."           \
            "Batch size is equivalent to ``n_assem_batch / n_assem_core``.", \
   }
   int n_assem_batch;
@@ -346,6 +348,26 @@ class Reactor : public cyclus::Facility,
   }
   std::string power_name;
 
+  /////////// hybrid params ///////////
+
+  #pragma cyclus var { \
+    "uilabel": "Side Product from Reactor Plant", \
+    "doc": "Ordered list of side product the reactor produces with power", \
+  }
+  std::vector<std::string> side_products;
+
+  #pragma cyclus var { \
+    "uilabel": "Quantity of Side Product from Reactor Plant", \
+    "doc": "Ordered list of the quantity of side product the reactor produces with power", \
+  }
+  std::vector<double> side_product_quantity;
+
+  #pragma cyclus var {"default": 1, "doc": "This should NEVER be set manually",\
+                      "internal": True \
+  }
+  bool hybrid;
+
+
   /////////// preference changes ///////////
   #pragma cyclus var { \
     "default": [], \
@@ -398,27 +420,6 @@ class Reactor : public cyclus::Facility,
 
   // populated lazily and no need to persist.
   std::set<std::string> uniq_outcommods_;
-
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double latitude;
-
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double longitude;
-
-  cyclus::toolkit::Position coordinates;
-
-  /// Records an agent's latitude and longitude to the output db
-  void RecordPosition();
 };
 
 } // namespace cycamore

--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -668,9 +668,19 @@ TEST(ReactorTests, ByProduct) {
   sim.AddRecipe("spentuox", c_spentuox());
   int id = sim.Run();
 
-  QueryResult qr = sim.db().Query("ReactorSideProducts", NULL);
-  // 7 for initial core, 3 per time step for each new batch for remainder
+  std::vector<Cond> conds;
+  // test if it produces side products only when reactor is running
+  int quantity = 10;
+  conds.push_back(Cond("Value", "==", quantity));
+  QueryResult qr = sim.db().Query("ReactorSideProducts", &conds);
   EXPECT_EQ(5, qr.rows.size());
+
+  // test if it doesn't produce side products when reactor is refueling
+  conds.clear();
+  conds.push_back(Cond("Value", "==", 0));
+  qr = sim.db().Query("ReactorSideProducts", &conds);
+  EXPECT_EQ(5, qr.rows.size());
+
 }
 
 TEST(ReactorTests, MultipleByProduct) {
@@ -696,9 +706,27 @@ TEST(ReactorTests, MultipleByProduct) {
   sim.AddRecipe("spentuox", c_spentuox());
   int id = sim.Run();
 
-  QueryResult qr = sim.db().Query("ReactorSideProducts", NULL);
-  // 7 for initial core, 3 per time step for each new batch for remainder
+  std::vector<Cond> conds;
+  // test if it produces heat when reactor is running
+  int quantity = 10;
+  conds.push_back(Cond("Product", "==", "process_heat"));
+  conds.push_back(Cond("Value", "==", quantity));
+  QueryResult qr = sim.db().Query("ReactorSideProducts", &conds);
+  EXPECT_EQ(5, qr.rows.size());
+
+  // test if it produces water when reactor is running
+  conds.clear();
+  quantity = 100;
+  conds.push_back(Cond("Product", "==", "water"));
+  conds.push_back(Cond("Value", "==", quantity));
+  qr = sim.db().Query("ReactorSideProducts", &conds);
+  EXPECT_EQ(5, qr.rows.size());
+
+  conds.clear();
+  conds.push_back(Cond("Value", "==", 0));
+  qr = sim.db().Query("ReactorSideProducts", &conds);
   EXPECT_EQ(10, qr.rows.size());
+
 }
 
 } // namespace reactortests

--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -668,7 +668,7 @@ TEST(ReactorTests, ByProduct) {
   sim.AddRecipe("spentuox", c_spentuox());
   int id = sim.Run();
 
-  QueryResult qr = sim.db().Query("reactorsideproducts", NULL);
+  QueryResult qr = sim.db().Query("ReactorSideProducts", NULL);
   // 7 for initial core, 3 per time step for each new batch for remainder
   EXPECT_EQ(5, qr.rows.size());
 }
@@ -696,7 +696,7 @@ TEST(ReactorTests, MultipleByProduct) {
   sim.AddRecipe("spentuox", c_spentuox());
   int id = sim.Run();
 
-  QueryResult qr = sim.db().Query("reactorsideproducts", NULL);
+  QueryResult qr = sim.db().Query("ReactorSideProducts", NULL);
   // 7 for initial core, 3 per time step for each new batch for remainder
   EXPECT_EQ(10, qr.rows.size());
 }

--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -645,6 +645,62 @@ TEST(ReactorTests, PositionInitialize2) {
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 30.0);
 }
 
+TEST(ReactorTests, ByProduct) {
+  std::string config = 
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>1</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>7</n_assem_core>  "
+     "  <n_assem_batch>3</n_assem_batch>  "
+     ""
+     "  <side_products> <val>process_heat</val> </side_products>"
+     "  <side_product_quantity> <val>10</val> </side_product_quantity>";
+
+  int simdur = 10;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
+  sim.AddSource("uox").Finalize();
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  int id = sim.Run();
+
+  QueryResult qr = sim.db().Query("reactorsideproducts", NULL);
+  // 7 for initial core, 3 per time step for each new batch for remainder
+  EXPECT_EQ(5, qr.rows.size());
+}
+
+TEST(ReactorTests, MultipleByProduct) {
+  std::string config = 
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>1</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>7</n_assem_core>  "
+     "  <n_assem_batch>3</n_assem_batch>  "
+     ""
+     "  <side_products> <val>process_heat</val> <val>water</val> </side_products>"
+     "  <side_product_quantity> <val>10</val> <val>100</val> </side_product_quantity>";
+
+  int simdur = 10;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
+  sim.AddSource("uox").Finalize();
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  int id = sim.Run();
+
+  QueryResult qr = sim.db().Query("reactorsideproducts", NULL);
+  // 7 for initial core, 3 per time step for each new batch for remainder
+  EXPECT_EQ(10, qr.rows.size());
+}
+
 } // namespace reactortests
 } // namespace cycamore
 


### PR DESCRIPTION
I have added additions to the `cycamore::Reactor` so that it can also produce side products (e.g. steam, process heat, etc) when it produces power.

This is a completely optional parameter and won't cause errors to current users if they do not use this. But it gives the users ability to model hybrid nuclear reactor systems that do desalination or have other by-products. 