### PR TITLE
Source buffer

### DIFF
--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -668,9 +668,19 @@ TEST(ReactorTests, ByProduct) {
   sim.AddRecipe("spentuox", c_spentuox());
   int id = sim.Run();
 
-  QueryResult qr = sim.db().Query("ReactorSideProducts", NULL);
-  // 7 for initial core, 3 per time step for each new batch for remainder
+  std::vector<Cond> conds;
+  // test if it produces side products only when reactor is running
+  int quantity = 10;
+  conds.push_back(Cond("Value", "==", quantity));
+  QueryResult qr = sim.db().Query("ReactorSideProducts", &conds);
   EXPECT_EQ(5, qr.rows.size());
+
+  // test if it doesn't produce side products when reactor is refueling
+  conds.clear();
+  conds.push_back(Cond("Value", "==", 0));
+  qr = sim.db().Query("ReactorSideProducts", &conds);
+  EXPECT_EQ(5, qr.rows.size());
+
 }
 
 TEST(ReactorTests, MultipleByProduct) {
@@ -696,9 +706,27 @@ TEST(ReactorTests, MultipleByProduct) {
   sim.AddRecipe("spentuox", c_spentuox());
   int id = sim.Run();
 
-  QueryResult qr = sim.db().Query("ReactorSideProducts", NULL);
-  // 7 for initial core, 3 per time step for each new batch for remainder
+  std::vector<Cond> conds;
+  // test if it produces heat when reactor is running
+  int quantity = 10;
+  conds.push_back(Cond("Product", "==", "process_heat"));
+  conds.push_back(Cond("Value", "==", quantity));
+  QueryResult qr = sim.db().Query("ReactorSideProducts", &conds);
+  EXPECT_EQ(5, qr.rows.size());
+
+  // test if it produces water when reactor is running
+  conds.clear();
+  quantity = 100;
+  conds.push_back(Cond("Product", "==", "water"));
+  conds.push_back(Cond("Value", "==", quantity));
+  qr = sim.db().Query("ReactorSideProducts", &conds);
+  EXPECT_EQ(5, qr.rows.size());
+
+  conds.clear();
+  conds.push_back(Cond("Value", "==", 0));
+  qr = sim.db().Query("ReactorSideProducts", &conds);
   EXPECT_EQ(10, qr.rows.size());
+
 }
 
 } // namespace reactortests

--- a/src/source.cc
+++ b/src/source.cc
@@ -44,6 +44,9 @@ void Source::Tick() {
   double qty = std::min(throughput, inventory_size);
   Material::Ptr m = Material::Create(this, qty, comp);
   inventory_size -= qty;
+  if (buffer == false && !ready.empty()){
+    ready.Pop();
+  }
   ready.Push(m);
 }
 

--- a/src/source.cc
+++ b/src/source.cc
@@ -44,9 +44,6 @@ void Source::Tick() {
   double qty = std::min(throughput, inventory_size);
   Material::Ptr m = Material::Create(this, qty, comp);
   inventory_size -= qty;
-  if (buffer == false && !ready.empty()){
-    ready.Pop();
-  }
   ready.Push(m);
 }
 
@@ -79,7 +76,11 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
   using cyclus::Request;
   using cyclus::toolkit::ResBuf;
 
-  double max_qty = ready.quantity();
+  double max_qty = std::min(ready.quantity(), throughput);
+  if (buffer == true) {
+    max_qty = ready.quantity();
+  }
+
   cyclus::toolkit::RecordTimeSeries<double>("supply"+outcommod, this, 
                                             max_qty);
   LOG(cyclus::LEV_INFO3, "Source") << prototype() << " is bidding up to "

--- a/src/source.cc
+++ b/src/source.cc
@@ -67,8 +67,6 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
     max_qty = std::min(inventory_size + buffer_qty, throughput + buffer_qty);
   }
 
-  std::cout << "buff quantity at time " << context()->time() << "is : " << buffer_qty << "\n";
-
 
   LOG(cyclus::LEV_INFO3, "Source") << prototype() << " is bidding up to "
                                    << max_qty << " kg of " << outcommod;
@@ -79,8 +77,10 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
     return ports;
   } else if (commod_requests.count(outcommod) == 0) {
     // if there is no demand for commodity, source dumps all throughput to buffer.
-    inventory_size -= throughput;
-    buffer_qty += throughput;
+    if (buffer == true){
+        inventory_size -= throughput;
+        buffer_qty += throughput;
+    }
     return ports;
   }
 
@@ -118,7 +118,6 @@ void Source::GetMatlTrades(
   double throughput_diff = throughput;
   for (it = trades.begin(); it != trades.end(); ++it) {
     double qty = it->amt;
-    std::cout << context()->time() << "DEMAND QUANTITY :" << qty << "\n";
     if (buffer == true){
         throughput_diff -= qty;
     }

--- a/src/source.cc
+++ b/src/source.cc
@@ -63,10 +63,9 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
 
   double max_qty = std::min(throughput, inventory_size);
 
-  if (buffer == true){
+  if (buffer == true) {
     max_qty = std::min(inventory_size + buffer_qty, throughput + buffer_qty);
   }
-
 
   LOG(cyclus::LEV_INFO3, "Source") << prototype() << " is bidding up to "
                                    << max_qty << " kg of " << outcommod;
@@ -77,9 +76,9 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
     return ports;
   } else if (commod_requests.count(outcommod) == 0) {
     // if there is no demand for commodity, source dumps all throughput to buffer.
-    if (buffer == true){
-        inventory_size -= throughput;
-        buffer_qty += throughput;
+    if (buffer == true) {
+      inventory_size -= throughput;
+      buffer_qty += throughput;
     }
     return ports;
   }
@@ -98,7 +97,6 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
     port->AddBid(req, m, this);
   }
 
-
   CapacityConstraint<Material> cc(max_qty);
   port->AddConstraint(cc);
   ports.insert(port);
@@ -115,14 +113,18 @@ void Source::GetMatlTrades(
 
   std::vector<cyclus::Trade<cyclus::Material> >::const_iterator it;
 
-  double throughput_diff = throughput;
+  if (buffer == true) {
+    double throughput_diff = throughput;
+  } else {
+    double throughput_diff = 0;
+  }
+
   for (it = trades.begin(); it != trades.end(); ++it) {
     double qty = it->amt;
     if (buffer == true){
-        throughput_diff -= qty;
-    }
-    else{
-    inventory_size -= qty;
+      throughput_diff -= qty;
+    } else {
+      inventory_size -= qty;
     }
 
     Material::Ptr response;

--- a/src/source.h
+++ b/src/source.h
@@ -132,6 +132,19 @@ class Source : public cyclus::Facility,
   }
   double longitude;
 
+  #pragma cyclus var { \
+    "default": -1, \
+    "uilabel": "Option to have source inventory buffer.", \
+    "doc": "The user can set this variable to true to have the source " \
+           "save its maximum throughput for later demand." \
+  }
+  bool buffer;
+
+
+  #pragma cyclus var {"tooltip":"Buffer for material held for future demand"}
+  cyclus::toolkit::ResBuf<cyclus::Material> stock;
+
+
   cyclus::toolkit::Position coordinates;
 
   void RecordPosition();

--- a/src/source.h
+++ b/src/source.h
@@ -133,7 +133,7 @@ class Source : public cyclus::Facility,
   double longitude;
 
   #pragma cyclus var { \
-    "default": -1, \
+    "default": 0, \
     "uilabel": "Boolean to have source inventory buffer.", \
     "doc": "The user can set this variable to true to have the source " \
            "save its maximum throughput for later demand." \

--- a/src/source.h
+++ b/src/source.h
@@ -57,7 +57,7 @@ class Source : public cyclus::Facility,
 
   virtual void InitFrom(cyclus::QueryableBackend* b);
 
-  virtual void Tick() {};
+  virtual void Tick();
 
   virtual void Tock() {};
 
@@ -140,15 +140,12 @@ class Source : public cyclus::Facility,
   }
   bool buffer;
 
-  #pragma cyclus var { \
-    "doc": "Variable for keeping count of the stock the source keeps " \
-           " when throughput is larger than demand. ", \
-    "default": 0, \
-    "units": "kg", \
-  }
-  double buffer_qty;
+  #pragma cyclus var {"tooltip" : "Material ready to be sent out"}
+  cyclus::toolkit::ResBuf<cyclus::Material> ready;
 
   cyclus::toolkit::Position coordinates;
+
+  
 
   void RecordPosition();
 };

--- a/src/source.h
+++ b/src/source.h
@@ -148,9 +148,6 @@ class Source : public cyclus::Facility,
   }
   double buffer_qty;
 
-
-
-
   cyclus::toolkit::Position coordinates;
 
   void RecordPosition();

--- a/src/source.h
+++ b/src/source.h
@@ -134,9 +134,9 @@ class Source : public cyclus::Facility,
 
   #pragma cyclus var { \
     "default": 0, \
-    "uilabel": "Boolean to have source inventory buffer.", \
-    "doc": "The user can set this variable to true to have the source " \
-           "save its maximum throughput for later demand." \
+    "uilabel": "Boolean to stockpile throughput.", \
+    "doc": "If true, the facility will stockpile its maximum throughput at " \
+           "each timestep. If false, the facility will not store inventory." \
   }
   bool buffer;
 

--- a/src/source.h
+++ b/src/source.h
@@ -134,15 +134,21 @@ class Source : public cyclus::Facility,
 
   #pragma cyclus var { \
     "default": -1, \
-    "uilabel": "Option to have source inventory buffer.", \
+    "uilabel": "Boolean to have source inventory buffer.", \
     "doc": "The user can set this variable to true to have the source " \
            "save its maximum throughput for later demand." \
   }
   bool buffer;
 
+  #pragma cyclus var { \
+    "doc": "Variable for keeping count of the stock the source keeps " \
+           " when throughput is larger than demand. ", \
+    "default": 0, \
+    "units": "kg", \
+  }
+  double buffer_qty;
 
-  #pragma cyclus var {"tooltip":"Buffer for material held for future demand"}
-  cyclus::toolkit::ResBuf<cyclus::Material> stock;
+
 
 
   cyclus::toolkit::Position coordinates;


### PR DESCRIPTION
As requested, the user can now choose to have a `buffer ` for the source.

If the boolean `buffer` is set to true in the input file, the source will 'save' its unused commodity into this buffer, allowing the source to have a larger throughput at a given timestep if it 'saved-up' unused commodity in previous timesteps.

The benefit/efficiency of this ability can be demonstrated [with this input file](https://gist.github.com/jbae11/85d346cc205c2295e8ef162bc42caac2). Without the buffer, the reactor would start generating power at timestep 16. However, with the buffer, the source can provide the reactor with fuel immediately.

Note that implementation-wise, the source buffer is not actually a `ResBuf`, but rather a simple double-type variable, that keeps track of the surplus inventory. 

I have attempted to make unit tests for this capability, but it requires be to define two prototypes at once (`DeployInst` and `Source`). I have not been able to figure out how, please let me know.