### PR TITLE
Optional decom behavior and separations data record

### DIFF
--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -125,7 +125,12 @@ void Reactor::Tick() {
     Record("RETIRED", "");
 
     if (context()->time() == exit_time() + 1) { // only need to transmute once
-      Transmute(ceil(static_cast<double>(n_assem_core) / 2.0));
+      if (decom_transmute_all == true) {
+        Transmute(ceil(static_cast<double>(n_assem_core)));
+      }
+      else {
+        Transmute(ceil(static_cast<double>(n_assem_core) / 2.0));
+      }
     }
     while (core.count() > 0) {
       if (!Discharge()) {

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -372,6 +372,15 @@ class Reactor : public cyclus::Facility,
   bool hybrid_;
 
 
+  /////////// Decommission transmutation behavior ///////////
+  #pragma cyclus var {"default": 0, \
+                      "uilabel": "Boolean for transmutation behavior upon decommissioning.", \
+                      "doc": "If true, the archetype transmutes all assemblies upon decommissioning " \
+                             "If false, the archetype only transmutes half.", \
+  }
+  bool decom_transmute_all;
+
+
   /////////// preference changes ///////////
   #pragma cyclus var { \
     "default": [], \

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -129,8 +129,6 @@ void Separations::Tick() {
     std::string name = itf->first;
     Material::Ptr m = itf->second;
     if (m->quantity() > 0) {
-      std::cout << "m quantity: " << m->quantity() << "\n";
-      std::cout << "mat quantity: " << mat->quantity() << "\n";
       double qty = m->quantity();
       if (m->quantity() > mat->quantity()) {
         qty = mat->quantity();
@@ -149,8 +147,6 @@ void Separations::Tick() {
   } else {  // maxfrac is < 1
     // push back any leftover feed due to separated stream inv size constraints
 
-    std::cout << "(1- maxfrac) * orig_ qty: " << ((1 - maxfrac) * orig_qty) << "\n";
-    std::cout << "mat quantity: " << mat->quantity() << "\n";
     feed.Push(mat->ExtractQty((1 - maxfrac) * orig_qty));
     if (mat->quantity() > 0) {
       // unspecified separations fractions go to leftovers

--- a/src/separations.h
+++ b/src/separations.h
@@ -226,6 +226,7 @@ class Separations
 
   /// Records an agent's latitude and longitude to the output db
   void RecordPosition();
+  void Record(std::string name, double val, std::string type);
 };
 
 }  // namespace cycamore


### PR DESCRIPTION
This PR adds two backwards-compatible functions:
1. Cycamore::Reactor has an additional boolean - if true, the reactor will transmute all its assemblies to the depleted recipe upon decommission
2. Cycamore:Separations will write to the output its throughput and the streams it created.