### PR TITLE
reactor recordtimeseries supply of spent fuel

### DIFF
--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -404,7 +404,6 @@ std::map<std::string, MatVec> Reactor::PeekSpent() {
 }
 
 bool Reactor::Discharge() {
-  
   int npop = std::min(n_assem_batch, core.count());
   if (n_assem_spent - spent.count() < npop) {
     Record("DISCHARGE", "failed");

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -254,7 +254,6 @@ void Reactor::GetMatlTrades(
     std::string commod = trades[i].request->commodity();
     Material::Ptr m = mats[commod].back();
     mats[commod].pop_back();
-    //cyclus::toolkit::RecordTimeSeries<double>("supply"+commod, this, m->quantity());
     responses.push_back(std::make_pair(trades[i], m));
     res_indexes.erase(m->obj_id());
   }

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -288,7 +288,6 @@ void Reactor::AcceptMatlTrades(const std::vector<
 std::set<cyclus::BidPortfolio<Material>::Ptr> Reactor::GetMatlBids(
     cyclus::CommodMap<Material>::type& commod_requests) {
   using cyclus::BidPortfolio;
-
   std::set<BidPortfolio<Material>::Ptr> ports;
 
   bool gotmats = false;
@@ -335,7 +334,6 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Reactor::GetMatlBids(
       tot_qty += mats[j]->quantity();
     }
 
-    cyclus::toolkit::RecordTimeSeries<double>("supply"+*it, this, tot_qty);
     cyclus::CapacityConstraint<Material> cc(tot_qty);
     port->AddConstraint(cc);
     ports.insert(port);
@@ -416,6 +414,18 @@ bool Reactor::Discharge() {
   ss << npop << " assemblies";
   Record("DISCHARGE", ss.str());  
   spent.Push(core.PopN(npop));
+
+  double fuel_pref_prev = 0; 
+  int pref_element = 0; 
+
+  for (int i = 0; i < fuel_prefs.size(); i++) {
+    if (fuel_prefs[i] > fuel_pref_prev) {
+      pref_element = i;
+    }
+    fuel_pref_prev = fuel_prefs[i];
+  }
+
+  cyclus::toolkit::RecordTimeSeries<double>("supply"+fuel_outcommods[pref_element], this, spent.quantity());
   return true;
 }
 

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -241,7 +241,7 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> Reactor::GetMatlRequests() {
     int max_index = std::distance(fuel_prefs.begin(), result);
 
     cyclus::toolkit::RecordTimeSeries<double>("demand"+fuel_incommods[max_index], this, 
-                                          assem_size);
+                                          assem_size * n_assem_order) ;
 
     port->AddMutualReqs(mreqs);
     ports.insert(port);

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -236,16 +236,11 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> Reactor::GetMatlRequests() {
       mreqs.push_back(r);
     }
 
-    double fuel_pref_prev = 0; 
-    int pref_element = 0; 
-    for (int k = 0; k < fuel_prefs.size(); k++) {
-        if (fuel_prefs[k] > fuel_pref_prev) {
-          pref_element = k;
-        }
-        fuel_pref_prev = fuel_prefs[k];
-      }
+    std::vector<double>::iterator result;
+    result = std::max_element(fuel_prefs.begin(), fuel_prefs.end());
+    int max_index = std::distance(fuel_prefs.begin(), result);
 
-    cyclus::toolkit::RecordTimeSeries<double>("demand"+fuel_incommods[pref_element], this, 
+    cyclus::toolkit::RecordTimeSeries<double>("demand"+fuel_incommods[max_index], this, 
                                           assem_size);
 
     port->AddMutualReqs(mreqs);

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -134,7 +134,7 @@ void Reactor::Tick() {
       }
     }
     while (core.count() > 0) {
-      if (!Discharge()) {
+      if (!Discharge(fuel_outcommods)) {
         break;
       }
     }
@@ -153,7 +153,7 @@ void Reactor::Tick() {
   }
 
   if (cycle_step >= cycle_time && !discharged) {
-    discharged = Discharge();
+    discharged = Discharge(fuel_outcommods);
   }
   if (cycle_step >= cycle_time) {
     Load();
@@ -254,7 +254,7 @@ void Reactor::GetMatlTrades(
     std::string commod = trades[i].request->commodity();
     Material::Ptr m = mats[commod].back();
     mats[commod].pop_back();
-    cyclus::toolkit::RecordTimeSeries<double>("supply"+commod, this, m->quantity());
+    //cyclus::toolkit::RecordTimeSeries<double>("supply"+commod, this, m->quantity());
     responses.push_back(std::make_pair(trades[i], m));
     res_indexes.erase(m->obj_id());
   }
@@ -404,7 +404,8 @@ std::map<std::string, MatVec> Reactor::PeekSpent() {
   return mapped;
 }
 
-bool Reactor::Discharge() {
+bool Reactor::Discharge(fuel_outcommods) {
+  std::cout << fuel_outcommods << std:endl; 
   int npop = std::min(n_assem_batch, core.count());
   int cap_pop = 0; 
   double assem_quantity = 0; 

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -334,6 +334,8 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Reactor::GetMatlBids(
     for (int j = 0; j < mats.size(); j++) {
       tot_qty += mats[j]->quantity();
     }
+
+    cyclus::toolkit::RecordTimeSeries<double>("supply"+*it, this, tot_qty);
     cyclus::CapacityConstraint<Material> cc(tot_qty);
     port->AddConstraint(cc);
     ports.insert(port);
@@ -414,7 +416,6 @@ bool Reactor::Discharge() {
   ss << npop << " assemblies";
   Record("DISCHARGE", ss.str());  
   spent.Push(core.PopN(npop));
-  cyclus::toolkit::RecordTimeSeries<double>("supply"+fuel_outcommods[0], this, spent.quantity());
   return true;
 }
 

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -134,7 +134,7 @@ void Reactor::Tick() {
       }
     }
     while (core.count() > 0) {
-      if (!Discharge(fuel_outcommods)) {
+      if (!Discharge()) {
         break;
       }
     }
@@ -153,7 +153,7 @@ void Reactor::Tick() {
   }
 
   if (cycle_step >= cycle_time && !discharged) {
-    discharged = Discharge(fuel_outcommods);
+    discharged = Discharge();
   }
   if (cycle_step >= cycle_time) {
     Load();
@@ -404,8 +404,8 @@ std::map<std::string, MatVec> Reactor::PeekSpent() {
   return mapped;
 }
 
-bool Reactor::Discharge(fuel_outcommods) {
-  std::cout << fuel_outcommods << std:endl; 
+bool Reactor::Discharge() {
+  
   int npop = std::min(n_assem_batch, core.count());
   int cap_pop = 0; 
   double assem_quantity = 0; 
@@ -418,7 +418,7 @@ bool Reactor::Discharge(fuel_outcommods) {
   ss << npop << " assemblies";
   Record("DISCHARGE", ss.str());  
   spent.Push(core.PopN(npop));
-  cyclus::toolkit::RecordTimeSeries<double>("supplyspentfuel", this, spent.quantity());
+  cyclus::toolkit::RecordTimeSeries<double>("supply"+fuel_outcommods[0], this, spent.quantity());
   return true;
 }
 

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -406,6 +406,8 @@ std::map<std::string, MatVec> Reactor::PeekSpent() {
 
 bool Reactor::Discharge() {
   int npop = std::min(n_assem_batch, core.count());
+  int cap_pop = 0; 
+  double assem_quantity = 0; 
   if (n_assem_spent - spent.count() < npop) {
     Record("DISCHARGE", "failed");
     return false;  // not enough room in spent buffer
@@ -413,9 +415,9 @@ bool Reactor::Discharge() {
 
   std::stringstream ss;
   ss << npop << " assemblies";
-  Record("DISCHARGE", ss.str());
-
+  Record("DISCHARGE", ss.str());  
   spent.Push(core.PopN(npop));
+  cyclus::toolkit::RecordTimeSeries<double>("supplyspentfuel", this, spent.quantity());
   return true;
 }
 

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -406,8 +406,6 @@ std::map<std::string, MatVec> Reactor::PeekSpent() {
 bool Reactor::Discharge() {
   
   int npop = std::min(n_assem_batch, core.count());
-  int cap_pop = 0; 
-  double assem_quantity = 0; 
   if (n_assem_spent - spent.count() < npop) {
     Record("DISCHARGE", "failed");
     return false;  // not enough room in spent buffer

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -128,6 +128,7 @@ void Storage::Tick() {
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Storage::Tock() {
+  using cyclus::toolkit::RecordTimeSeries;
   LOG(cyclus::LEV_INFO3, "ComCnv") << prototype() << " is tocking {";
 
   BeginProcessing_();  // place unprocessed inventory into processing
@@ -138,6 +139,16 @@ void Storage::Tock() {
 
   ProcessMat_(throughput);  // place ready into stocks
 
+
+  std::vector<double>::iterator result;
+  result = std::max_element(in_commod_prefs.begin(), in_commod_prefs.end());
+  int maxindx = std::distance(in_commod_prefs.begin(), result);
+  cyclus::toolkit::RecordTimeSeries<double>("demand"+in_commods[maxindx], this,
+                                            current_capacity());
+  // Multiple commodity tracking is not supported, user can only
+  // provide one value for out_commods, despite it being a vector of strings.
+  cyclus::toolkit::RecordTimeSeries<double>("supply"+out_commods[0], this,
+                                            stocks.quantity());
   LOG(cyclus::LEV_INFO3, "ComCnv") << "}";
 }
 


### PR DESCRIPTION
In this PR: 
Recordtimeseries of supply of spent fuel is moved from `Reactor::GetMatlTrades()` to `Reactor::Discharge()`. This was done because the `timeseriessupplyspentfuel` table currently only shows up in the output database if the commodity is traded. However, we need to know how much of that commodity is in the spent buffer and available for trade. 

This is used in d3ploy so that it can know how many of the other facilities need to be deployed to receive the commodity. 