### PR TITLE
timeseriessupplypower does not record until the reactor produces power.

### DIFF
--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -370,6 +370,7 @@ void Reactor::Tock() {
     RecordSideProduct(true);
   } else {
     cyclus::toolkit::RecordTimeSeries<cyclus::toolkit::POWER>(this, 0);
+    cyclus::toolkit::RecordTimeSeries<double>("supplyPOWER", this, 0);
     RecordSideProduct(false);
   }
 


### PR DESCRIPTION
This pr addresses https://github.com/arfc/d3ploy/issues/196

