### PR TITLE
fixes unit test segfault

### DIFF
--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -680,7 +680,6 @@ TEST(ReactorTests, ByProduct) {
   conds.push_back(Cond("Value", "==", 0));
   qr = sim.db().Query("ReactorSideProducts", &conds);
   EXPECT_EQ(5, qr.rows.size());
-
 }
 
 TEST(ReactorTests, MultipleByProduct) {
@@ -706,25 +705,26 @@ TEST(ReactorTests, MultipleByProduct) {
   sim.AddRecipe("spentuox", c_spentuox());
   int id = sim.Run();
 
-  std::vector<Cond> conds;
+
+  std::vector<Cond> conds_2;
   // test if it produces heat when reactor is running
   int quantity = 10;
-  conds.push_back(Cond("Product", "==", "process_heat"));
-  conds.push_back(Cond("Value", "==", quantity));
-  QueryResult qr = sim.db().Query("ReactorSideProducts", &conds);
+  conds_2.push_back(Cond("Product", "==", std::string("process_heat")));
+  conds_2.push_back(Cond("Value", "==", quantity));
+  QueryResult qr = sim.db().Query("ReactorSideProducts", &conds_2);
   EXPECT_EQ(5, qr.rows.size());
 
   // test if it produces water when reactor is running
-  conds.clear();
+  conds_2.clear();
   quantity = 100;
-  conds.push_back(Cond("Product", "==", "water"));
-  conds.push_back(Cond("Value", "==", quantity));
-  qr = sim.db().Query("ReactorSideProducts", &conds);
+  conds_2.push_back(Cond("Product", "==", std::string("water")));
+  conds_2.push_back(Cond("Value", "==", quantity));
+  qr = sim.db().Query("ReactorSideProducts", &conds_2);
   EXPECT_EQ(5, qr.rows.size());
 
-  conds.clear();
-  conds.push_back(Cond("Value", "==", 0));
-  qr = sim.db().Query("ReactorSideProducts", &conds);
+  conds_2.clear();
+  conds_2.push_back(Cond("Value", "==", 0));
+  qr = sim.db().Query("ReactorSideProducts", &conds_2);
   EXPECT_EQ(10, qr.rows.size());
 
 }

--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -706,25 +706,25 @@ TEST(ReactorTests, MultipleByProduct) {
   int id = sim.Run();
 
 
-  std::vector<Cond> conds_2;
+  std::vector<Cond> conds;
   // test if it produces heat when reactor is running
   int quantity = 10;
-  conds_2.push_back(Cond("Product", "==", std::string("process_heat")));
-  conds_2.push_back(Cond("Value", "==", quantity));
-  QueryResult qr = sim.db().Query("ReactorSideProducts", &conds_2);
+  conds.push_back(Cond("Product", "==", std::string("process_heat")));
+  conds.push_back(Cond("Value", "==", quantity));
+  QueryResult qr = sim.db().Query("ReactorSideProducts", &conds);
   EXPECT_EQ(5, qr.rows.size());
 
   // test if it produces water when reactor is running
-  conds_2.clear();
+  conds.clear();
   quantity = 100;
-  conds_2.push_back(Cond("Product", "==", std::string("water")));
-  conds_2.push_back(Cond("Value", "==", quantity));
-  qr = sim.db().Query("ReactorSideProducts", &conds_2);
+  conds.push_back(Cond("Product", "==", std::string("water")));
+  conds.push_back(Cond("Value", "==", quantity));
+  qr = sim.db().Query("ReactorSideProducts", &conds);
   EXPECT_EQ(5, qr.rows.size());
 
-  conds_2.clear();
-  conds_2.push_back(Cond("Value", "==", 0));
-  qr = sim.db().Query("ReactorSideProducts", &conds_2);
+  conds.clear();
+  conds.push_back(Cond("Value", "==", 0));
+  qr = sim.db().Query("ReactorSideProducts", &conds);
   EXPECT_EQ(10, qr.rows.size());
 
 }


### PR DESCRIPTION
resolves issue #488 unit test segfault by using "std::string" in a Cond function call within the MultipleByProduct reactor test. probably something to do with boost.