### PR TITLE
Prevent incorrect start of a new fuel cycle in Reactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ cycamore_version.h
 src/version.cc.in
 # Rever
 rever/
+commitMessage.md
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,3 @@ cycamore_version.h
 src/version.cc.in
 # Rever
 rever/
-commitMessage.md
-*.DS_Store

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -356,7 +356,10 @@ void Reactor::Tock() {
   if (retired()) {
     return;
   }
-
+  
+  // Check that irradiation and refueling periods are over, that 
+  // the core is full and that it has previously been discharged.
+  // If this is the case, then a new cycle will be initiated.
   if (cycle_step >= cycle_time + refuel_time && core.count() == n_assem_core && discharged == true) {
     discharged = false;
     cycle_step = 0;

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -358,7 +358,7 @@ void Reactor::Tock() {
   }
   
   // Check that irradiation and refueling periods are over, that 
-  // the core is full and that it has previously been discharged.
+  // the core is full and that fuel was successfully discharged in this refueling time.
   // If this is the case, then a new cycle will be initiated.
   if (cycle_step >= cycle_time + refuel_time && core.count() == n_assem_core && discharged == true) {
     discharged = false;

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -357,7 +357,7 @@ void Reactor::Tock() {
     return;
   }
 
-  if (cycle_step >= cycle_time + refuel_time && core.count() == n_assem_core) {
+  if (cycle_step >= cycle_time + refuel_time && core.count() == n_assem_core && discharged == true) {
     discharged = false;
     cycle_step = 0;
   }


### PR DESCRIPTION
This fix prevents that a new fuel cycle wrongfully starts in cycamore::Reactor.

Consider a reactor whose core cannot be discharged due to a full spent
fuel inventory. The if-statement that checks whether or not a new
fuel cycle is about to be initiated does not take into account if the 
core has been discharged: it only considers if the core is full.
Hence, it is possible that power is generated despite the core being
composed (partially or entirely) of spent fuel.

This behaviour has been explained further in 9c3e52468b6c59db4793c8e630317c04063ce6a9 and it has been fixed
by explicitly checking if the core has been discharged.
Moreover, b9935ff0b4eccaee31c33c8fc7c3e6c1a2d59cec adds a test to check this.
