### PR TITLE
Add Sell quantity to storage

### DIFF
--- a/src/storage.cc
+++ b/src/storage.cc
@@ -78,8 +78,7 @@ void Storage::EnterNotify() {
     sell_policy.Init(this, &stocks, std::string("stocks"), 1e+299, false, sell_quantity)
       .Set(out_commods.front())
       .Start();
-    }
-    
+
   } else {
     std::stringstream ss;
     ss << "out_commods has " << out_commods.size() << " values, expected 1.";

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -74,9 +74,12 @@ void Storage::EnterNotify() {
   }
   buy_policy.Start();
 
-  if (out_commods.size() == 1) {
+  if (out_commods.size() == 1 && stocks.quantity() > min_sell_inv) {
     sell_policy.Init(this, &stocks, std::string("stocks"))
         .Set(out_commods.front())
+        .Start();
+  } else if (out_commods.size() == 1) {
+    sell_policy.Init(this, 0, std::string("stocks"))
         .Start();
   } else {
     std::stringstream ss;

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -74,13 +74,17 @@ void Storage::EnterNotify() {
   }
   buy_policy.Start();
 
-  if (out_commods.size() == 1 && stocks.quantity() > min_sell_inv) {
-    sell_policy.Init(this, &stocks, std::string("stocks"))
+  if (out_commods.size() == 1) {
+    if (sell_quantity != 0) {
+      sell_policy.Init(this, &stocks, std::string("stocks"), 1e+299, false, sell_quantity)
         .Set(out_commods.front())
         .Start();
-  } else if (out_commods.size() == 1) {
-    sell_policy.Init(this, 0, std::string("stocks"))
+    } else {
+      sell_policy.Init(this, &stocks, std::string("stocks"))
+        .Set(out_commods.front())
         .Start();
+    }
+    
   } else {
     std::stringstream ss;
     ss << "out_commods has " << out_commods.size() << " values, expected 1.";

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -75,14 +75,9 @@ void Storage::EnterNotify() {
   buy_policy.Start();
 
   if (out_commods.size() == 1) {
-    if (sell_quantity != 0) {
-      sell_policy.Init(this, &stocks, std::string("stocks"), 1e+299, false, sell_quantity)
-        .Set(out_commods.front())
-        .Start();
-    } else {
-      sell_policy.Init(this, &stocks, std::string("stocks"))
-        .Set(out_commods.front())
-        .Start();
+    sell_policy.Init(this, &stocks, std::string("stocks"), 1e+299, false, sell_quantity)
+      .Set(out_commods.front())
+      .Start();
     }
     
   } else {

--- a/src/storage.h
+++ b/src/storage.h
@@ -32,7 +32,7 @@ namespace cycamore {
 /// in_recipe (optional) describes the incoming resource by recipe
 ///
 /// @section optionalparams Optional Parameters
-/// min_sell_inv is the minimum inventory required to start selling material
+/// sell_quantity restricts selling to only integer multiples of this value
 /// max_inv_size is the maximum capacity of the inventory storage
 /// throughput is the maximum processing capacity per timestep
 ///

--- a/src/storage.h
+++ b/src/storage.h
@@ -164,13 +164,15 @@ class Storage
   int residence_time;
 
   #pragma cyclus var {"default": 0,\
-                      "tooltip":"minimum sell inventory (kg)",\
-                      "doc":"minimum inventory required before commodity is released",\
-                      "uilabel":"Minimum Sell Inventory",\
+                      "tooltip":"sell quantity (kg)",\
+                      "doc":"material will be sold in integer multiples of this quantity. If"\
+                      " the buffer contains less than the sell quantity, no material will be"\
+                      " offered", \
+                      "uilabel":"Sell Quantity",\
                       "uitype": "range", \
                       "range": [0.0, 1e299], \
                       "units": "kg"}
-  double min_sell_inv;
+  double sell_quantity;
 
   #pragma cyclus var {"default": 1e299,\
                      "tooltip":"throughput per timestep (kg)",\

--- a/src/storage.h
+++ b/src/storage.h
@@ -32,6 +32,7 @@ namespace cycamore {
 /// in_recipe (optional) describes the incoming resource by recipe
 ///
 /// @section optionalparams Optional Parameters
+/// min_sell_inv is the minimum inventory required to start selling material
 /// max_inv_size is the maximum capacity of the inventory storage
 /// throughput is the maximum processing capacity per timestep
 ///
@@ -161,6 +162,15 @@ class Storage
                       "uitype": "range", \
                       "range": [0, 12000]}
   int residence_time;
+
+  #pragma cyclus var {"default": 0,\
+                      "tooltip":"minimum sell inventory (kg)",\
+                      "doc":"minimum inventory required before commodity is released",\
+                      "uilabel":"Minimum Sell Inventory",\
+                      "uitype": "range", \
+                      "range": [0.0, 1e299], \
+                      "units": "kg"}
+  double min_sell_inv;
 
   #pragma cyclus var {"default": 1e299,\
                      "tooltip":"throughput per timestep (kg)",\


### PR DESCRIPTION
Adds optional variable `sell_quantity` to Storage archetype. Facility must have >= `sell_quantity` in the buffer to sell material, and only trades in integer multiples of `sell_quantity`

Requires [Cyclus PR #1552](https://github.com/cyclus/cyclus/pull/1552) to work as intended.

cc @bam241 