### PR TITLE
[WIP tests needed] Preference change timestep comparison update

### DIFF
--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -167,7 +167,7 @@ void Reactor::Tick() {
   // update preferences
   for (int i = 0; i < pref_change_times.size(); i++) {
     int change_t = pref_change_times[i];
-    if (t != change_t) {
+    if (t < change_t) {
       continue;
     }
 


### PR DESCRIPTION
This one-character update allows reactors that are deployed after the timestep of the preference change to "see" the new preference change. Otherwise, newly deployed reactors will default back to the original commodity preference scheme.