### PR TITLE
fix recorded reactor initial demand

### DIFF
--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -244,7 +244,7 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> Reactor::GetMatlRequests() {
     int max_index = std::distance(fuel_prefs.begin(), result);
 
     cyclus::toolkit::RecordTimeSeries<double>("demand"+fuel_incommods[max_index], this,
-                                          assem_size * n_assem_order) ;
+                                          assem_size) ;
 
     port->AddMutualReqs(mreqs);
     ports.insert(port);


### PR DESCRIPTION
The reactor records initial demand (t=0) as a series of individual demands equal to the number of assemblies in the core plus fresh assemblies requested to keep on hand. However an error meant that the mass request associated with each each assembly demand was equal to the core + fresh assembly mass

E.g. a reactor with 3 assemblies in the core plus 1 on hand, each 1 kg, would previously record 4 separate requests for 3 kg at t=0. After this PR, it will correctly issue 4 separate requests for 1 kg each.

This keeps each individual request to the correct mass of `assem_size`

Closes #514, thanks @danielwojtaszek for already having an issue open when I stumbled upon this myself