### PR TITLE
Fix bug that can cause storage capacity to go negative

### DIFF
--- a/src/storage.h
+++ b/src/storage.h
@@ -119,7 +119,8 @@ class Storage
 
   /// @brief current maximum amount that can be added to processing
   inline double current_capacity() const {
-    return (max_inv_size - processing.quantity() - stocks.quantity()); }
+    return (max_inv_size - processing.quantity() - stocks.quantity()
+     - ready.quantity()); }
 
   /// @brief returns the time key for ready materials
   int ready_time(){ return context()->time() - residence_time; }


### PR DESCRIPTION
- Adds `ready` buffer to current_capacity calculation
- Adds a bit more logging on high verbosity (logging levels 4 and 5 especially)

Closes #541 