### PR TITLE
add random behavior for size of sink request

### DIFF
--- a/src/sink.cc
+++ b/src/sink.cc
@@ -53,6 +53,10 @@ void Sink::EnterNotify() {
        << " values, expected " << in_commods.size();
     throw cyclus::ValueError(ss.str());
   }
+  /// Create first requestAmt. Only used in testing, as a simulation will
+  /// overwrite this on Tick()
+  SetRequestAmt();
+
   RecordPosition();
 }
 
@@ -86,17 +90,21 @@ Sink::GetMatlRequests() {
 
   std::set<RequestPortfolio<Material>::Ptr> ports;
   RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
-  double amt = RequestAmt();
   Material::Ptr mat;
 
-  if (recipe_name.empty()) {
-    mat = cyclus::NewBlankMaterial(amt);
-  } else {
-    Composition::Ptr rec = this->context()->GetRecipe(recipe_name);
-    mat = cyclus::Material::CreateUntracked(amt, rec);
+  /// for testing
+  if (requestAmt > SpaceAvailable()) {
+    SetRequestAmt();
   }
 
-  if (amt > cyclus::eps()) {
+  if (recipe_name.empty()) {
+    mat = cyclus::NewBlankMaterial(requestAmt);
+  } else {
+    Composition::Ptr rec = this->context()->GetRecipe(recipe_name);
+    mat = cyclus::Material::CreateUntracked(requestAmt, rec);
+  }
+
+  if (requestAmt > cyclus::eps()) {  
     std::vector<Request<Material>*> mutuals;
     for (int i = 0; i < in_commods.size(); i++) {
       mutuals.push_back(port->AddRequest(mat, this, in_commods[i], in_commod_prefs[i]));
@@ -119,16 +127,15 @@ Sink::GetGenRsrcRequests() {
   std::set<RequestPortfolio<Product>::Ptr> ports;
   RequestPortfolio<Product>::Ptr
       port(new RequestPortfolio<Product>());
-  double amt = RequestAmt();
 
-  if (amt > cyclus::eps()) {
-    CapacityConstraint<Product> cc(amt);
+  if (requestAmt > cyclus::eps()) {
+    CapacityConstraint<Product> cc(requestAmt);
     port->AddConstraint(cc);
 
     std::vector<std::string>::const_iterator it;
     for (it = in_commods.begin(); it != in_commods.end(); ++it) {
       std::string quality = "";  // not clear what this should be..
-      Product::Ptr rsrc = Product::CreateUntracked(amt, quality);
+      Product::Ptr rsrc = Product::CreateUntracked(requestAmt, quality);
       port->AddRequest(rsrc, this, *it);
     }
 
@@ -165,33 +172,12 @@ void Sink::Tick() {
   using std::vector;
   LOG(cyclus::LEV_INFO3, "SnkFac") << prototype() << " is ticking {";
 
-  double amt = RequestAmt();
-  double requestAmt = 0;
+  SetRequestAmt();
 
-  LOG(cyclus::LEV_INFO3, "SnkFac") << prototype() << " has default request amount " << amt;
+  LOG(cyclus::LEV_INFO3, "SnkFac") << prototype() << " has default request amount " << requestAmt;
 
   // inform the simulation about what the sink facility will be requesting
-  if (amt > cyclus::eps()) {
-    if (random_size == "None") {
-      requestAmt = amt;
-    }
-    else if (random_size == "UniformInt") {
-      requestAmt = context()->random_uniform_int(0, amt);
-    }
-    else if (random_size == "UniformReal") {
-      requestAmt = context()->random_uniform_real(0, amt);
-    }
-    else if (random_size == "NormalReal") {
-      requestAmt = context()->random_normal_real(amt * random_size_mean,
-      amt * random_size_stddev, 0, amt);
-    }
-    else if (random_size == "NormalInt") {
-      requestAmt = context()->random_normal_int(amt * random_size_mean,
-      amt * random_size_stddev, 0, amt);
-    }
-    else {
-      requestAmt = amt;
-    }
+  if (requestAmt > cyclus::eps()) {
     LOG(cyclus::LEV_INFO4, "SnkFac") << prototype()
                                        << " has request amount " << requestAmt
                                        << " kg of " << in_commods[0] << ".";
@@ -231,6 +217,29 @@ void Sink::RecordPosition() {
       ->AddVal("Latitude", latitude)
       ->AddVal("Longitude", longitude)
       ->Record();
+}
+
+void Sink::SetRequestAmt() {
+  double amt = SpaceAvailable();
+  if (amt < cyclus::eps()) {
+    requestAmt = 0;
+  }
+
+  if (random_size == "None") {
+    requestAmt =  amt;
+  }
+  else if (random_size == "UniformReal") {
+    requestAmt =  context()->random_uniform_real(0, amt);
+  }
+  else if (random_size == "NormalReal") {
+    requestAmt =  context()->random_normal_real(amt * random_size_mean,
+                                         amt * random_size_stddev, 0, 
+                                         amt);
+  }
+  else {
+    requestAmt =  amt;
+  }
+  return;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/sink.cc
+++ b/src/sink.cc
@@ -41,7 +41,7 @@ Sink::~Sink() {}
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Sink::EnterNotify() {
   cyclus::Facility::EnterNotify();
-  LOG(cyclus::LEV_INFO4, "SnkFac") << " using random behavior " << random_size;
+  LOG(cyclus::LEV_INFO4, "SnkFac") << " using random behavior " << random_size_type;
 
   if (in_commod_prefs.size() == 0) {
     for (int i = 0; i < in_commods.size(); ++i) {
@@ -225,13 +225,13 @@ void Sink::SetRequestAmt() {
     requestAmt = 0;
   }
 
-  if (random_size == "None") {
+  if (random_size_type == "None") {
     requestAmt =  amt;
   }
-  else if (random_size == "UniformReal") {
+  else if (random_size_type == "UniformReal") {
     requestAmt =  context()->random_uniform_real(0, amt);
   }
-  else if (random_size == "NormalReal") {
+  else if (random_size_type == "NormalReal") {
     requestAmt =  context()->random_normal_real(amt * random_size_mean,
                                                 amt * random_size_stddev, 
                                                 0, amt);

--- a/src/sink.cc
+++ b/src/sink.cc
@@ -41,6 +41,7 @@ Sink::~Sink() {}
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Sink::EnterNotify() {
   cyclus::Facility::EnterNotify();
+  LOG(cyclus::LEV_INFO4, "SnkFac") << " using random behavior " << random_size;
 
   if (in_commod_prefs.size() == 0) {
     for (int i = 0; i < in_commods.size(); ++i) {
@@ -164,9 +165,36 @@ void Sink::Tick() {
   using std::vector;
   LOG(cyclus::LEV_INFO3, "SnkFac") << prototype() << " is ticking {";
 
-  double requestAmt = RequestAmt();
+  double amt = RequestAmt();
+  double requestAmt = 0;
+
+  LOG(cyclus::LEV_INFO3, "SnkFac") << prototype() << " has default request amount " << amt;
+
   // inform the simulation about what the sink facility will be requesting
-  if (requestAmt > cyclus::eps()) {
+  if (amt > cyclus::eps()) {
+    if (random_size == "None") {
+      requestAmt = amt;
+    }
+    else if (random_size == "UniformInt") {
+      requestAmt = context()->random_uniform_int(0, amt);
+    }
+    else if (random_size == "UniformReal") {
+      requestAmt = context()->random_uniform_real(0, amt);
+    }
+    else if (random_size == "NormalReal") {
+      requestAmt = context()->random_normal_real(amt * random_size_mean,
+      amt * random_size_stddev, 0, amt);
+    }
+    else if (random_size == "NormalInt") {
+      requestAmt = context()->random_normal_int(amt * random_size_mean,
+      amt * random_size_stddev, 0, amt);
+    }
+    else {
+      requestAmt = amt;
+    }
+    LOG(cyclus::LEV_INFO4, "SnkFac") << prototype()
+                                       << " has request amount " << requestAmt
+                                       << " kg of " << in_commods[0] << ".";
     for (vector<string>::iterator commod = in_commods.begin();
          commod != in_commods.end();
          commod++) {

--- a/src/sink.cc
+++ b/src/sink.cc
@@ -233,8 +233,8 @@ void Sink::SetRequestAmt() {
   }
   else if (random_size == "NormalReal") {
     requestAmt =  context()->random_normal_real(amt * random_size_mean,
-                                         amt * random_size_stddev, 0, 
-                                         amt);
+                                                amt * random_size_stddev, 
+                                                0, amt);
   }
   else {
     requestAmt =  amt;

--- a/src/sink.h
+++ b/src/sink.h
@@ -168,7 +168,7 @@ class Sink
                       "doc": "type of random behavior to use. Default None, " \
                       "other options are 'UniformReal', 'UniformInt', " \
                       "'NormalReal', and 'NormalInt'"}
-  std::string random_size;
+  std::string random_size_type;
 
   // random size mean (as a fraction of available space)
   #pragma cyclus var {"default": 1.0, \

--- a/src/sink.h
+++ b/src/sink.h
@@ -69,6 +69,9 @@ class Sink
       const std::vector< std::pair<cyclus::Trade<cyclus::Product>,
       cyclus::Product::Ptr> >& responses);
 
+  /// @brief SinkFacilities update request amount using random behavior
+  virtual void SetRequestAmt();
+
   ///  add a commodity to the set of input commodities
   ///  @param name the commodity name
   inline void AddCommodity(std::string name) { in_commods.push_back(name); }
@@ -87,7 +90,7 @@ class Sink
   inline double InventorySize() const { return inventory.quantity(); }
 
   /// determines the amount to request
-  inline double RequestAmt() const {
+  inline double SpaceAvailable() const {
     return std::min(capacity, std::max(0.0, inventory.space()));
   }
 
@@ -107,6 +110,7 @@ class Sink
       input_commodity_preferences() const { return in_commod_prefs; }
 
  private:
+  double requestAmt;
   /// all facilities must have at least one input commodity
   #pragma cyclus var {"tooltip": "input commodities", \
                       "doc": "commodities that the sink facility accepts", \

--- a/src/sink.h
+++ b/src/sink.h
@@ -175,11 +175,13 @@ class Sink
                       "tooltip": "fraction of available space to determine the mean", \
                       "uilabel": "Random Size Mean", \
                       "uitype": "range", \
-                      "range": [0.0, 1.0], \
+                      "range": [0.0, 1e299], \
                       "doc": "When a normal distribution is used to determine the " \
                              "size of the request, this is the fraction of available " \
-                             "space to use as the mean. Default 1.0, must be between " \
-                             "0.0 and 1.0"}
+                             "space to use as the mean. Default 1.0. Note " \
+                             "that values significantly above 1 without a " \
+                             "correspondingly large std dev may result in " \
+                             "inefficient use of the random number generator."}
   double random_size_mean;
 
   // random size std dev (as a fraction of available space)

--- a/src/sink.h
+++ b/src/sink.h
@@ -154,6 +154,44 @@ class Sink
   #pragma cyclus var {'capacity': 'max_inv_size'}
   cyclus::toolkit::ResBuf<cyclus::Resource> inventory;
 
+  /// random status (size of request)
+  #pragma cyclus var {"default": "None", \
+                      "tooltip": "type of random behavior when setting the " \
+                      "size of the request", \
+                      "uitype": "combobox", \
+                      "uilabel": "Random Size", \
+                      "categorical": ["None", "UniformReal", "UniformInt", "NormalReal", "NormalInt"], \
+                      "doc": "type of random behavior to use. Default None, " \
+                      "other options are 'UniformReal', 'UniformInt', " \
+                      "'NormalReal', and 'NormalInt'"}
+  std::string random_size;
+
+  // random size mean (as a fraction of available space)
+  #pragma cyclus var {"default": 1.0, \
+                      "tooltip": "fraction of available space to determine the mean", \
+                      "uilabel": "Random Size Mean", \
+                      "uitype": "range", \
+                      "range": [0.0, 1.0], \
+                      "doc": "When a normal distribution is used to determine the " \
+                             "size of the request, this is the fraction of available " \
+                             "space to use as the mean. Default 1.0, must be between " \
+                             "0.0 and 1.0"}
+  double random_size_mean;
+
+  // random size std dev (as a fraction of available space)
+  #pragma cyclus var {"default": 0.1, \
+                      "tooltip": "fraction of available space to determine the std dev", \
+                      "uilabel": "Random Size Std Dev", \
+                      "uitype": "range", \
+                      "range": [0.0, 1e299], \
+                      "doc": "When a normal distribution is used to determine the " \
+                             "size of the request, this is the fraction of available " \
+                             "space to use as the standard deviation. Default 0.1"}
+  double random_size_stddev;
+
+
+  // random status (frequencing/timing of request)
+
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical latitude in degrees as a double", \

--- a/src/sink_tests.cc
+++ b/src/sink_tests.cc
@@ -351,7 +351,7 @@ TEST_F(SinkTest, RandomUniform) {
     "     <val>commods_1</val>"
     "   </in_commods>"
     "   <capacity>10</capacity>"
-    "   <random_size>UniformReal</random_size> ";
+    "   <random_size_type>UniformReal</random_size_type> ";
 
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec
@@ -373,7 +373,7 @@ TEST_F(SinkTest, RandomNormal) {
     "     <val>commods_1</val>"
     "   </in_commods>"
     "   <capacity>10</capacity>"
-    "   <random_size>NormalReal</random_size> ";
+    "   <random_size_type>NormalReal</random_size_type> ";
 
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec
@@ -395,7 +395,7 @@ TEST_F(SinkTest, RandomNormalWithMeanSttdev) {
     "     <val>commods_1</val>"
     "   </in_commods>"
     "   <capacity>10</capacity>"
-    "   <random_size>NormalReal</random_size> "
+    "   <random_size_type>NormalReal</random_size_type> "
     "   <random_size_mean>0.5</random_size_mean> "
     "   <random_size_stddev>0.2</random_size_stddev> ";
 


### PR DESCRIPTION
- Three new optional parameters to vary the size of the sink's request
- `random_size` has default None, but also ~~four~~ two options that call the PRNG from the context: 
    - "UniformReal", "NormalReal"
    - No longer implemented
        - "UniformInt", "NormalInt"
- When using ~~one of~~ the normal distribution~~s~~, two additional parameters `random_size_mean` and `random_size_stddev` are used as fractions of the maximum request size (calculated at each timestep `RequestAmt()`)

Checklist
- [x] testing
closes #556 