### PR TITLE
Add CHANGELOG test workflow

### DIFF
--- a/.github/workflows/changelog_test.yml
+++ b/.github/workflows/changelog_test.yml
@@ -1,0 +1,38 @@
+name: Changelog check
+
+on:
+  # allows us to run workflows manually
+  workflow_dispatch:
+  pull_request:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  changelog_update:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.14
+
+    name: Is Changelog up-to-date ?
+    steps:
+      - name: Install latest git
+        run: |
+          apk add --no-cache bash git openssh
+          git --version
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+          cd $GITHUB_WORKSPACE
+          git remote add cycamore https://github.com/cyclus/cycamore.git
+          git fetch cycamore
+          change=`git diff cycamore/main -- CHANGELOG.rst | wc -l`
+          git remote remove cycamore
+          if [ $change -eq 0 ]; then 
+            echo "CHANGELOG.rst has not been updated"
+            exit 1 
+          fi
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,16 @@ cyclus Change Log
 =================
 
 .. current developments
+**Added:**
+
+* GitHub workflows for building/testing on a PR and push to `main` (#549)
+* Add functionality for random behavior on the size of a sink (#550)
+* GitHub workflow to check that the CHANGELOG has been updated (#551) 
+
+**Changed:** 
+
+* Updated build procedure to use newer versions of packages in 2023 (#549)
+
 
 v1.5.5
 ====================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
 =================
-cyclus Change Log
+cycamore Change Log
 =================
 
 .. current developments

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ cycamore Change Log
 
 * GitHub workflows for building/testing on a PR and push to `main` (#549)
 * Add functionality for random behavior on the size of a sink (#550)
-* GitHub workflow to check that the CHANGELOG has been updated (#551) 
+* GitHub workflow to check that the CHANGELOG has been updated (#562) 
 
 **Changed:** 
 


### PR DESCRIPTION
Copied the workflow from cyclus and modified to fit cycamore.  Also added the last few PRs to the CHANGELOG (since the first one I made), do we need to go back and fill in old changes?

Fixes #561 