### PR TITLE
Publish docker images on all pushes to main

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,11 +8,13 @@ on:
       - '.github/workflows/build_test_publish.yml'
       - 'docker/**'
       - 'doc/**'
+      - 'CHANGELOG.rst'
   push:
     paths-ignore:
       - '.github/workflows/build_test_publish.yml'
       - 'docker/**'
       - 'doc/**'
+      - 'CHANGELOG.rst'
 
 jobs:
   build-and-test:

--- a/.github/workflows/build_test_publish.yml
+++ b/.github/workflows/build_test_publish.yml
@@ -10,9 +10,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - '.github/workflows/build_test_publish.yml'
-      - 'docker/**'
 
 jobs:
   build-dependency-and-test-img:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ cycamore Change Log
 .. current developments
 **Added:**
 
-* GitHub workflows for building/testing on a PR and push to `main` (#549)
+* GitHub workflows for building/testing on a PR and push to `main` (#549, #564)
 * Add functionality for random behavior on the size of a sink (#550)
 * GitHub workflow to check that the CHANGELOG has been updated (#562) 
 


### PR DESCRIPTION
Push new images on all pushes to main, so that they can be used in downstream testing (e.g. Cymetric)

Fixes #563 