### PR TITLE
CI refactoring

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -5,13 +5,15 @@ on:
   workflow_dispatch:
   pull_request:
     paths-ignore:
-      - '.github/workflows/build_test_publish.yml'
+      - '.github/workflows/publish_latest.yml'
+      - '.github/workflows/publish_release.yml'
       - 'docker/**'
       - 'doc/**'
       - 'CHANGELOG.rst'
   push:
     paths-ignore:
-      - '.github/workflows/build_test_publish.yml'
+      - '.github/workflows/publish_latest.yml'
+      - '.github/workflows/publish_release.yml'
       - 'docker/**'
       - 'doc/**'
       - 'CHANGELOG.rst'

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -19,6 +19,9 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -63,6 +63,8 @@ jobs:
           file: docker/Dockerfile
           cache-from: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
           cache-to: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
+          tags: ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-image-cache
+          push: true
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -101,6 +101,6 @@ jobs:
             - Cycamore: ${{steps.build-cycamore.outcome == 'success' && '*Success* :white_check_mark:' || 
                 steps.build-cycamore.outcome == 'failure' && '**Failure** :x:' || 
                 '**Skipped due to upstream failure** :warning:'}}
-            - Cymetric: ${{needs.build-cymetric.outcome == 'success' && '*Success* :white_check_mark:' || 
+            - Cymetric: ${{steps.build-cymetric.outcome == 'success' && '*Success* :white_check_mark:' || 
                 steps.build-cymetric.outcome == 'failure' && '**Failure** :x:' || 
                 '**Skipped due to upstream failure** :warning:'}}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -75,7 +75,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: cyclus/cymetric
-          ref: tag-build-arg
           path: ${{ github.workspace }}/cymetric
 
       - name: Build and Test Cymetric

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           comment_tag: ${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ matrix.cyclus_tag }}
           message: |
-            ## Downstream Build Statuses using Cycamore ${{ github.ref }} on cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}:${{ matrix.cyclus_tag }}
+            ## Build statuses using cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}:${{ matrix.cyclus_tag }}
             - Cycamore: ${{steps.build-cycamore.outcome == 'success' && '*Success* :white_check_mark:' || 
                 steps.build-cycamore.outcome == 'failure' && '**Failure** :x:' || 
                 '**Skipped due to upstream failure** :warning:'}}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           repository: cyclus/cymetric
           ref: tag-build-arg
-          path: $HOME/cymetric
+          path: ${{ github.workspace }}/cymetric
 
       - name: Build and Test Cymetric
         if: ${{ github.event_name == 'pull_request' && steps.build-cycamore.outcome == 'success' }}
@@ -84,8 +84,8 @@ jobs:
         continue-on-error: true
         uses: docker/build-push-action@v5
         with:
-          context: $HOME/cymetric
-          file: $HOME/cymetric/docker/Dockerfile
+          context: ${{ github.workspace }}/cymetric
+          file: ${{ github.workspace }}/cymetric/docker/Dockerfile
           cache-from: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
           cache-to: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
           tags: ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-image-cache

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -51,6 +51,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          logout: false
 
       - name: Checkout Cycamore
         uses: actions/checkout@v4

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -94,7 +94,8 @@ jobs:
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}
             cycamore_tag=ci-image-cache@${{ steps.build-cycamore.outputs.digest }}
-          secrets: ${{ secrets.GITHUB_TOKEN }}
+          secrets: |
+            GIT_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }}
 
       - name: PR Comment
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -51,7 +51,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          logout: false
 
       - name: Checkout Cycamore
         uses: actions/checkout@v4
@@ -95,8 +94,6 @@ jobs:
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}
             cycamore_tag=ci-image-cache@${{ steps.build-cycamore.outputs.digest }}
-          secrets: |
-            GIT_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }}
 
       - name: PR Comment
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -18,7 +18,6 @@ on:
 
 jobs:
   build-and-test:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -35,23 +34,21 @@ jobs:
         cyclus_tag: [
           latest,
         ]
-    
-    container:
-      image: ghcr.io/cyclus/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus:${{matrix.cyclus_tag}}
 
     steps:
       - name: Checkout Cycamore
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build Cycamore
-        run: |
-          python install.py --prefix=/root/.local --cyclus-root=/root/.local -j 2 --build-type=Release --core-version 99999.99999
-
-      - name: Cycamore Unit Tests
-        run: |
-          cycamore_unit_tests
-
-      - name: Cycamore Python Tests
-        run: |
-          export PYTHONPATH=$(find /root/.local/lib -type d -name 'python*.*' -print -quit)/site-packages
-          cd tests && python -m pytest
+        uses: docker/build-push-action@v5
+        with:
+          file: docker/Dockerfile
+          cache-from: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
+          build-args: |
+            pkg_mgr=${{ matrix.pkg_mgr }}
+            ubuntu_version=${{ matrix.ubuntu_versions }}
+            cyclus_tag=${{ matrix.cyclus_tag }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      pull-requests: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout Cycamore
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -39,13 +39,22 @@ jobs:
         ]
 
     steps:
-      - name: Checkout Cycamore
-        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Checkout Cycamore
+        uses: actions/checkout@v4
+
       - name: Build Cycamore
+        id: build-cycamore
         uses: docker/build-push-action@v5
         with:
           file: docker/Dockerfile
@@ -55,3 +64,39 @@ jobs:
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}
             cyclus_tag=${{ matrix.cyclus_tag }}
+
+      - name: Checkout Cymetric
+        if: ${{ github.event_name == 'pull_request' && steps.build-cycamore.outcome == 'success' }}
+        uses: actions/checkout@v4
+        with:
+          repository: cyclus/cymetric
+          ref: tag-build-arg
+          path: $HOME/cymetric
+
+      - name: Build and Test Cymetric
+        if: ${{ github.event_name == 'pull_request' && steps.build-cycamore.outcome == 'success' }}
+        id: build-cymetric
+        continue-on-error: true
+        uses: docker/build-push-action@v5
+        with:
+          context: $HOME/cymetric
+          file: $HOME/cymetric/docker/Dockerfile
+          cache-from: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
+          tags: ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-image-cache
+          push: true
+          build-args: |
+            pkg_mgr=${{ matrix.pkg_mgr }}
+            ubuntu_version=${{ matrix.ubuntu_versions }}
+            cycamore_tag=ci-image-cache@${{ steps.build-cycamore.outputs.digest }}
+
+      - name: PR Comment
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          comment_tag: ${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ matrix.cyclus_tag }}
+          message: |
+            ## Downstream Build Statuses using Cycamore ${{ github.ref }} on cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}:${{ matrix.cyclus_tag }}
+            - Cymetric: ${{needs.build-cymetric.outcome == 'success' && '*Success* :white_check_mark:' || 
+                steps.build-cymetric.outcome == 'failure' && '**Failure** :x:' || 
+                '**Skipped due to upstream failure** :warning:'}}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -36,6 +36,7 @@ jobs:
         ]
         cyclus_tag: [
           latest,
+          stable,
         ]
 
     steps:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -42,15 +42,15 @@ jobs:
 
     steps:
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Checkout Cycamore
         uses: actions/checkout@v4

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -55,6 +55,7 @@ jobs:
 
       - name: Build Cycamore
         id: build-cycamore
+        continue-on-error: true
         uses: docker/build-push-action@v5
         with:
           file: docker/Dockerfile
@@ -97,6 +98,9 @@ jobs:
           comment_tag: ${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ matrix.cyclus_tag }}
           message: |
             ## Downstream Build Statuses using Cycamore ${{ github.ref }} on cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}:${{ matrix.cyclus_tag }}
+            - Cycamore: ${{steps.build-cycamore.outcome == 'success' && '*Success* :white_check_mark:' || 
+                steps.build-cycamore.outcome == 'failure' && '**Failure** :x:' || 
+                '**Skipped due to upstream failure** :warning:'}}
             - Cymetric: ${{needs.build-cymetric.outcome == 'success' && '*Success* :white_check_mark:' || 
                 steps.build-cymetric.outcome == 'failure' && '**Failure** :x:' || 
                 '**Skipped due to upstream failure** :warning:'}}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -94,6 +94,7 @@ jobs:
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}
             cycamore_tag=ci-image-cache@${{ steps.build-cycamore.outputs.digest }}
+          secrets: ${{ secrets.GITHUB_TOKEN }}
 
       - name: PR Comment
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -7,14 +7,12 @@ on:
     paths-ignore:
       - '.github/workflows/publish_latest.yml'
       - '.github/workflows/publish_release.yml'
-      - 'docker/**'
       - 'doc/**'
       - 'CHANGELOG.rst'
   push:
     paths-ignore:
       - '.github/workflows/publish_latest.yml'
       - '.github/workflows/publish_release.yml'
-      - 'docker/**'
       - 'doc/**'
       - 'CHANGELOG.rst'
 

--- a/.github/workflows/build_test_publish.yml
+++ b/.github/workflows/build_test_publish.yml
@@ -51,7 +51,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build_test_publish.yml
+++ b/.github/workflows/build_test_publish.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   build-dependency-and-test-img:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     strategy:
       matrix:
@@ -25,17 +28,20 @@ jobs:
           apt,
           conda,
         ]
+        cyclus_tag : [
+          latest,
+        ]
 
     name: Installing Dependencies, Building Cycamore and Running Tests
     steps:
-      - name: default environment
+      - name: Tag as ci-image-cache
         run: |
-          echo "tag-latest-on-default=false" >> "$GITHUB_ENV"
+          echo "tag=ci-image-cache" >> "$GITHUB_ENV"
 
-      - name: condition on trigger parameters
+      - name: Tag as latest
         if: ${{ github.repository_owner == 'cyclus' && github.ref == 'refs/heads/main' }}
         run: |
-          echo "tag-latest-on-default=true" >> "$GITHUB_ENV"
+          echo "tag=latest" >> "$GITHUB_ENV"
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -47,14 +53,29 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Multi-Stage Build Action
-        uses: firehed/multistage-docker-build-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and Test Cycamore
+        uses: docker/build-push-action@v5
         with:
-          repository: ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}
-          stages: cycamore
-          server-stage: cycamore-test
-          quiet: false
-          parallel: true
-          tag-latest-on-default: ${{ env.tag-latest-on-default }}
-          dockerfile: docker/Dockerfile
-          build-args: pkg_mgr=${{ matrix.pkg_mgr }}, ubuntu_version=${{ matrix.ubuntu_versions }}
+          cache-from: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
+          file: docker/Dockerfile
+          build-args: |
+            pkg_mgr=${{ matrix.pkg_mgr }}
+            ubuntu_version=${{ matrix.ubuntu_versions }}
+            cyclus_tag=${{ matrix.cyclus_tag }}
+
+      - name: Push Cycamore Image
+        uses: docker/build-push-action@v5
+        with:
+          cache-from: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
+          file: docker/Dockerfile
+          target: cycamore
+          push: true
+          tags: ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ env.tag }}
+          build-args: |
+            pkg_mgr=${{ matrix.pkg_mgr }}
+            ubuntu_version=${{ matrix.ubuntu_versions }}
+            cyclus_tag=latest

--- a/.github/workflows/build_test_publish.yml
+++ b/.github/workflows/build_test_publish.yml
@@ -44,7 +44,7 @@ jobs:
           echo "tag=latest" >> "$GITHUB_ENV"
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/changelog_test.yml
+++ b/.github/workflows/changelog_test.yml
@@ -22,7 +22,7 @@ jobs:
           git --version
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - '.github/workflows/build_test_publish.yml'
+      - '.github/workflows/publish_latest.yml'
       - 'docker/**'
   push:
     branches:

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -32,7 +32,7 @@ jobs:
           latest,
         ]
 
-    name: Building Cycamore and Running Tests
+    name: Build, Test, Publish
     steps:
       - name: Tag as ci-image-cache
         run: |

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     paths:
       - '.github/workflows/publish_latest.yml'
-      - 'docker/**'
   push:
     branches:
       - main
@@ -68,7 +67,6 @@ jobs:
             cyclus_tag=latest
           
       - name: Checkout Cymetric
-        if: ${{ steps.build-cycamore.outcome == 'success' }}
         uses: actions/checkout@v4
         with:
           repository: cyclus/cymetric
@@ -76,7 +74,6 @@ jobs:
           path: $HOME/cymetric
 
       - name: Build and Test Cymetric
-        if: ${{ steps.build-cycamore.outcome == 'success' }}
         continue-on-error: true
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Cycamore Images
+name: Publish Latest Cycamore
 
 on:
   # allows us to run workflows manually
@@ -32,7 +32,7 @@ jobs:
           latest,
         ]
 
-    name: Installing Dependencies, Building Cycamore and Running Tests
+    name: Building Cycamore and Running Tests
     steps:
       - name: Tag as ci-image-cache
         run: |

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -71,14 +71,14 @@ jobs:
         with:
           repository: cyclus/cymetric
           ref: tag-build-arg
-          path: $HOME/cymetric
+          path: ${{ github.workspace }}/cymetric
 
       - name: Build and Test Cymetric
         continue-on-error: true
         uses: docker/build-push-action@v5
         with:
-          context: $HOME/cymetric
-          file: $HOME/cymetric/docker/Dockerfile
+          context: ${{ github.workspace }}/cymetric
+          file: ${{ github.workspace }}/cymetric/docker/Dockerfile
           cache-from: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
           cache-to: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
           tags: ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.tag }}

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -28,9 +28,6 @@ jobs:
           apt,
           conda,
         ]
-        cyclus_tag : [
-          latest,
-        ]
 
     name: Build, Test, Publish
     steps:
@@ -62,17 +59,6 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
           cache-to: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
           file: docker/Dockerfile
-          build-args: |
-            pkg_mgr=${{ matrix.pkg_mgr }}
-            ubuntu_version=${{ matrix.ubuntu_versions }}
-            cyclus_tag=${{ matrix.cyclus_tag }}
-
-      - name: Push Cycamore Image
-        uses: docker/build-push-action@v5
-        with:
-          cache-from: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
-          file: docker/Dockerfile
-          target: cycamore
           push: true
           tags: ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ env.tag }}
           build-args: |

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -54,6 +54,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Test Cycamore
+        id: build-cycamore
         uses: docker/build-push-action@v5
         with:
           cache-from: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
@@ -65,3 +66,28 @@ jobs:
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}
             cyclus_tag=latest
+          
+      - name: Checkout Cymetric
+        if: ${{ steps.build-cycamore.outcome == 'success' }}
+        uses: actions/checkout@v4
+        with:
+          repository: cyclus/cymetric
+          ref: tag-build-arg
+          path: $HOME/cymetric
+
+      - name: Build and Test Cymetric
+        if: ${{ steps.build-cycamore.outcome == 'success' }}
+        continue-on-error: true
+        uses: docker/build-push-action@v5
+        with:
+          context: $HOME/cymetric
+          file: $HOME/cymetric/docker/Dockerfile
+          cache-from: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
+          tags: ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.tag }}
+          push: true
+          build-args: |
+            pkg_mgr=${{ matrix.pkg_mgr }}
+            ubuntu_version=${{ matrix.ubuntu_versions }}
+            cycamore_tag=${{ env.tag }}@${{ steps.build-cycamore.outputs.digest }}
+    

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -70,7 +70,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: cyclus/cymetric
-          ref: tag-build-arg
           path: ${{ github.workspace }}/cymetric
 
       - name: Build and Test Cymetric

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -40,18 +40,18 @@ jobs:
         run: |
           echo "tag=latest" >> "$GITHUB_ENV"
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Build and Test Cycamore
         uses: docker/build-push-action@v5

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,11 +1,8 @@
 name: Publish Stable Cycamore
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - '*'
+  release:
+    types: [released]
 
 jobs:
   build-and-test-for-release:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -52,23 +52,12 @@ jobs:
       - name: Checkout Cycamore
         uses: actions/checkout@v4
 
-      - name: Build and Test Cycamore
+      - name: Build, Test, and Push Cycamore
         uses: docker/build-push-action@v5
         with:
           cache-from: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
           cache-to: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
           file: docker/Dockerfile
-          build-args: |
-            pkg_mgr=${{ matrix.pkg_mgr }}
-            ubuntu_version=${{ matrix.ubuntu_versions }}
-            cyclus_tag=stable
-
-      - name: Push Cycamore
-        uses: docker/build-push-action@v5
-        with:
-          cache-from: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
-          file: docker/Dockerfile
-          target: cycamore
           push: true
           tags: |
             ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ env.version_tag }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,4 +1,4 @@
-name: Publish Cycamore Release
+name: Publish Stable Cycamore
 
 on:
   push:
@@ -26,7 +26,7 @@ jobs:
           conda
         ]
 
-    name: Installing Dependencies, Building Cycamore and running tests
+    name: Building Cycamore and running tests
     steps:
       - name: Tag as ci-image-cache
         run: |

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,79 @@
+name: Publish Cycamore Release
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+
+jobs:
+  build-and-test-for-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu_versions : [
+          20.04,
+          22.04,
+        ]
+        pkg_mgr : [
+          apt,
+          conda
+        ]
+
+    name: Installing Dependencies, Building Cycamore and running tests
+    steps:
+      - name: Tag as ci-image-cache
+        run: |
+          echo "version_tag=ci-image-cache" >> "$GITHUB_ENV"
+          echo "stable_tag=ci-image-cache" >> "$GITHUB_ENV"
+
+      - name: Tag as stable
+        if: ${{ github.repository_owner == 'cyclus' }}
+        run: |
+          echo "version_tag=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          echo "stable_tag=stable" >> "$GITHUB_ENV"
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Checkout Cycamore
+        uses: actions/checkout@v4
+
+      - name: Build and Test Cycamore
+        uses: docker/build-push-action@v5
+        with:
+          cache-from: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
+          file: docker/Dockerfile
+          build-args: |
+            pkg_mgr=${{ matrix.pkg_mgr }}
+            ubuntu_version=${{ matrix.ubuntu_versions }}
+            cyclus_tag=stable
+
+      - name: Push Cycamore
+        uses: docker/build-push-action@v5
+        with:
+          cache-from: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
+          file: docker/Dockerfile
+          target: cycamore
+          push: true
+          tags: |
+            ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ env.version_tag }}
+            ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ env.stable_tag }}
+          build-args: |
+            pkg_mgr=${{ matrix.pkg_mgr }}
+            ubuntu_version=${{ matrix.ubuntu_versions }}
+            cyclus_tag=stable

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -26,7 +26,7 @@ jobs:
           conda
         ]
 
-    name: Building Cycamore and running tests
+    name: Build, Test, Publish
     steps:
       - name: Tag as ci-image-cache
         run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,8 @@ cycamore Change Log
 .. current developments
 **Added:**
 
-* GitHub workflows for building/testing on a PR and push to `main` (#549, #564)
+* GitHub workflow for publishing images on release (#573)
+* GitHub workflows for building/testing on a PR and push to `main` (#549, #564, #573)
 * Add functionality for random behavior on the size (#550) and frequency (#565) of a sink 
 * GitHub workflow to check that the CHANGELOG has been updated (#562) 
 * Added inventory policies to Storage through the material buy policy (#574)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,17 @@
 ARG pkg_mgr=apt
 ARG ubuntu_version=22.04
+ARG cyclus_tag=stable
 
-FROM ghcr.io/cyclus/cyclus_${ubuntu_version}_${pkg_mgr}/cyclus as cycamore
+FROM ghcr.io/cyclus/cyclus_${ubuntu_version}_${pkg_mgr}/cyclus:${cyclus_tag} as cycamore
 ARG make_cores=2
 
 COPY . /cycamore
 WORKDIR /cycamore
 
-RUN python install.py -j ${make_cores} --build-type=Release --core-version 99999.99999
+RUN python install.py -j ${make_cores} --build-type=Release --core-version 999999.999999
 
 FROM cycamore as cycamore-test
 RUN cycamore_unit_tests
 
-FROM cycamore as cycamore-pytest
+FROM cycamore-test as cycamore-pytest
 RUN cd tests && python -m pytest


### PR DESCRIPTION
This PR should be considered in conjunction with cyclus PR [#1637](https://github.com/cyclus/cyclus/pull/1637).

The main changes being made are converting CI workflows to use [docker/build-push-action](https://github.com/docker/build-push-action) to build and test cycamore (and downstream cymetric) using the Dockerfiles we maintain. 

Some notes:
- the Dockerfile now takes a build argument to specify the tag of the cyclus image to build from
- we use our ghcr registry as a cache backend, such that cached layers are located at <image name>:ci-layer-cache
- we also use ghcr to store images produced from workflow runs, located at <image name>:ci-image-cache.  This allows us to build downstream projects from a unique cycamore image (which is specified by digest in the workflow)
- I added a workflow to publish images on release and tag them as `:stable` and `:<version number>`.  It only builds against `cyclus:stable`. The idea being that we would publish a cyclus release as `stable`, then have a corresponding cycamore release also tagged as `stable`
- the build_test workflow includes a matrix variable for the cyclus tag to build cycamore against (`stable` and `latest`)
- **Cycamore build failures will still pass CI**, a bot will comment the build statuses of each respective cycamore build (I wanted to just make it a single comment but struggled to find a way to do it generically with the testing matrix)
