### PR TITLE
Applies TotalInvTracker and (R,Q)/(s,S) inventory policies to storage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ cycamore Change Log
 * GitHub workflows for building/testing on a PR and push to `main` (#549, #564)
 * Add functionality for random behavior on the size (#550) and frequency (#565) of a sink 
 * GitHub workflow to check that the CHANGELOG has been updated (#562) 
+* Added inventory policies to Storage through the material buy policy (#574)
 
 **Changed:** 
 

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -134,8 +134,10 @@ void Storage::EnterNotify() {
 
   inventory_tracker.set_capacity(max_inv_size);
   if (reorder_point < 0) {
+    InitBuyPolicyParameters();
     buy_policy.Init(this, &inventory, std::string("inventory"),
-                    &inventory_tracker, throughput);
+                    &inventory_tracker, throughput, active_dist_,
+                    dormant_dist_, size_dist_);
   }
   else if (reorder_quantity > 0) {
     if (reorder_point + reorder_quantity > max_inv_size) {
@@ -223,10 +225,6 @@ void Storage::Tick() {
   LOG(cyclus::LEV_INFO5, "ComCnv") << "Processing = " << processing.quantity() << ", ready = " << ready.quantity() << ", stocks = " << stocks.quantity() << " and max inventory = " << max_inv_size;
 
   LOG(cyclus::LEV_INFO4, "ComCnv") << "current capacity " << max_inv_size << " - " << processing.quantity() << " - " << ready.quantity() << " - " << stocks.quantity() << " = " << current_capacity();
-
-  // Set available capacity for Buy Policy
-  // not necessary any more
-  // inventory.capacity(current_capacity());
 
   if (current_capacity() > cyclus::eps_rsrc()) {
     LOG(cyclus::LEV_INFO4, "ComCnv")

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -133,19 +133,23 @@ void Storage::EnterNotify() {
   cyclus::Facility::EnterNotify();
 
   inventory_tracker.set_capacity(max_inv_size);
-  if ((reorder_point >= 0 && reorder_quantity > 0)) {
+  if (reorder_point < 0) {
+    buy_policy.Init(this, &inventory, std::string("inventory"),
+                    &inventory_tracker, throughput);
+  }
+  else if (reorder_quantity > 0) {
     if (reorder_point + reorder_quantity > max_inv_size) {
       throw cyclus::ValueError(
-          "reorder_point + reorder_quantity must be less than max_inv_size");
+          "reorder_point + reorder_quantity must be less than or equal to max_inv_size");
     }
     buy_policy.Init(this, &inventory, std::string("inventory"),
                     &inventory_tracker, throughput, "RQ",
-                    reorder_quantity,
-                    reorder_point);
+                    reorder_quantity, reorder_point);
   }
   else {
     buy_policy.Init(this, &inventory, std::string("inventory"),
-                    &inventory_tracker, throughput);
+                    &inventory_tracker, throughput, "sS",
+                    max_inv_size, reorder_point);
   }
 
   // dummy comp, use in_recipe if provided

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -135,6 +135,7 @@ void Storage::EnterNotify() {
   
   buy_policy.Init(this, &inventory, std::string("inventory"), throughput,
                   active_dist_, dormant_dist_, size_dist_);
+  buy_policy.Init(this, &inventory, std::string("inventory"), reorder_point, reorder_quantity);
 
   // dummy comp, use in_recipe if provided
   cyclus::CompMap v;

--- a/src/storage.h
+++ b/src/storage.h
@@ -406,12 +406,15 @@ class Storage
   #pragma cyclus var {"default": -1,\
                       "tooltip":"Reorder point",\
                       "doc":"The point at which the facility will request more material. "\
-                      "Above this point, no request will be made. Must be less than max_inv_size",\
+                      "Above this point, no request will be made. Must be less than max_inv_size."\
+                      "If paired with reorder_quantity, this agent will have an (R,Q) inventory policy. "\
+                      "If reorder_point is used alone, this agent will have an (s,S) inventory policy, "\
+                      " with S (the maximum) being set at max_inv_size.",\
                       "uilabel":"Reorder Point"}
   double reorder_point;
 
   #pragma cyclus var {"default": -1,\
-                      "tooltip":"Reorder amount",\
+                      "tooltip":"Reorder amount (R,Q inventory policy)",\
                       "doc":"The amount of material that will be requested when the reorder point is reached. "\
                       "Exclusive request, so will demand exactly reorder_quantity."\
                       "Reorder_point + reorder_quantity must be less than max_inv_size.",\

--- a/src/storage.h
+++ b/src/storage.h
@@ -419,11 +419,15 @@ class Storage
   double reorder_quantity;
 
   #pragma cyclus var {"default": 1,\
-                      "tooltip":"Reorder point as a fraction of full inventory",\
-                      "doc":"The point at which the facility will request more material. "\
-                            "This is a fraction of the maximum inventory size.",\
-                      "uilabel":"Reorder Point"}
-  double reorder_point;
+                      "tooltip": "Length of the active buying "\
+                        "period",\
+                      "doc":"During the length of the active buying "\
+                        "period, agent exhibits regular behavior. "\
+                        "If paired with dormant buying period, "\
+                        "alternates between buying and not buying, "\
+                        "regardless if space is available",\
+                      "uilabel":"Active Buying Period"}
+  int active_buying;
 
   #pragma cyclus var {"default": 0,\
                       "tooltip": "Length of the dormant buying "\

--- a/src/storage.h
+++ b/src/storage.h
@@ -298,10 +298,10 @@ class Storage
                       "uilabel": "Dormant Buying Frequency Type"}
   std::string dormant_buying_frequency_type;
 
-  #pragma cyclus var {"default": 0,\
+  #pragma cyclus var {"default": -1,\
                       "tooltip": "Fixed dormant buying frequency",\
                       "doc": "The length in time steps of the dormant buying period. Required for fixed "\
-                      "dormant_buying_frequency_type. Can be zero and agent will only be active (default behavior)",\
+                      "dormant_buying_frequency_type. Default is -1, agent has no dormant period and stays active.",\
                       "uitype": "range", \
                       "range": [-1, 1e299], \
                       "uilabel": "Dormant Buying Frequency Value"}

--- a/src/storage.h
+++ b/src/storage.h
@@ -400,6 +400,20 @@ class Storage
                       "range": [0.0, 1.0], \
                       "uilabel": "Buying Size Standard Deviation"}
   double buying_size_stddev;
+  #pragma cyclus var {"default": 1,\
+                      "tooltip":"Reorder point as a fraction of full inventory",\
+                      "doc":"The point at which the facility will request more material. "\
+                            "This is a fraction of the maximum inventory size.",\
+                      "uilabel":"Reorder Point"}
+  double reorder_point;
+
+  #pragma cyclus var {"default": 1,\
+                      "tooltip":"Reorder amount as a fraction of full inventory",\
+                      "doc":"The amount of material that will be requested when the reorder point is reached. "\
+                          "This is a fraction of the maximum inventory size."\
+                          " Unused if no maximum inventory is set.",\
+                      "uilabel":"Reorder Quantity"}
+  double reorder_quantity;
 
   #pragma cyclus var {"tooltip":"Incoming material buffer"}
   cyclus::toolkit::ResBuf<cyclus::Material> inventory;

--- a/src/storage_tests.cc
+++ b/src/storage_tests.cc
@@ -766,7 +766,7 @@ TEST_F(StorageTest, sS_Inventory) {
   EXPECT_EQ(2, qr.GetVal<int>("Time", 1));
   EXPECT_EQ(4, qr.GetVal<int>("Time", 2));
 
-  // check that all transactions are of size 3
+  // check that all transactions are of size 5
   qr = sim.db().Query("Resources", NULL);
   EXPECT_EQ(5, qr.GetVal<double>("Quantity", 0));
 }

--- a/src/storage_tests.cc
+++ b/src/storage_tests.cc
@@ -458,59 +458,6 @@ TEST_F(StorageTest, MultipleCommods){
   EXPECT_EQ(1, n_trans2) << "expected 1 transactions, got " << n_trans;
 }
 
-TEST_F(StorageTest, RQ_Inventory_Invalid) {
-  std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <max_inv_size>5</max_inv_size>"
-    "   <reorder_point>2</reorder_point>"
-    "   <reorder_quantity>10</reorder_quantity>";
-
-  EXPECT_THROW(int id = sim.Run(), cyclus::ValueError);
-}
-
-TEST_F(StorageTest, RQ_Inventory) {
-  std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <max_inv_size>5</max_inv_size>"
-    "   <reorder_point>2</reorder_point>"
-    "   <reorder_quantity>3</reorder_quantity>";
-
-  int simdur = 5;
-
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
-
-  sim.AddSource("spent_fuel").capacity(5).Finalize();
-  sim.AddSink("dry_spent").Finalize();
-
-  int id = sim.Run();
-
-  std::vector<cyclus::Cond> conds;
-  conds.push_back(cyclus::Cond("Commodity", "==", std::string("spent_fuel")));
-  cyclus::QueryResult qr = sim.db().Query("Transactions", &conds);
-  int n_trans = qr.rows.size();
-
-  EXPECT_EQ(10, n_trans) << "expected 10 transactions, got " << n_trans;
-  // confirm that transactions are only occurring during active periods
-  // first cycle includes time steps 0 - 3
-  EXPECT_EQ(0, qr.GetVal<int>("Time", 0));
-  EXPECT_EQ(3, qr.GetVal<int>("Time", 3));
-  // second cycle (rows 4 and 4) include time steps 6 and 7
-  EXPECT_EQ(6, qr.GetVal<int>("Time", 4));
-  EXPECT_EQ(7, qr.GetVal<int>("Time", 5));
-  // third cycle (row 6) includes time step 8 -9
-  EXPECT_EQ(8, qr.GetVal<int>("Time", 6));
-  EXPECT_EQ(9, qr.GetVal<int>("Time", 7));
-  // fourth cycle (rows  8, 9) includes time steps 13 - 14
-  EXPECT_EQ(13, qr.GetVal<int>("Time", 8));
-  EXPECT_EQ(14, qr.GetVal<int>("Time", 9));
-
-  qr = sim.db().Query("Resources", NULL);
-  EXPECT_NEAR(0.61256, qr.GetVal<double>("Quantity", 0), 0.00001);
-  EXPECT_NEAR(0.62217, qr.GetVal<double>("Quantity", 1), 0.00001);
-  EXPECT_NEAR(0.39705, qr.GetVal<double>("Quantity", 2), 0.00001);
-}
 
 // Should get one transaction in a 2 step simulation when agent is active for
 // one step and dormant for one step
@@ -679,8 +626,39 @@ TEST_F(StorageTest, NormalActiveDormantBuyingSize){
     "   <buying_size_mean>0.5</buying_size_mean>"
     "   <buying_size_stddev>0.1</buying_size_stddev>";
 
-    int simdur = 15;
-  EXPECT_THROW(int id = sim.Run(), cyclus::ValueError);
+  int simdur = 15;
+
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+
+  sim.AddSource("spent_fuel").capacity(5).Finalize();
+  sim.AddSink("dry_spent").Finalize();
+
+  int id = sim.Run();
+
+  std::vector<cyclus::Cond> conds;
+  conds.push_back(cyclus::Cond("Commodity", "==", std::string("spent_fuel")));
+  cyclus::QueryResult qr = sim.db().Query("Transactions", &conds);
+  int n_trans = qr.rows.size();
+
+  EXPECT_EQ(10, n_trans) << "expected 10 transactions, got " << n_trans;
+  // confirm that transactions are only occurring during active periods
+  // first cycle includes time steps 0 - 3
+  EXPECT_EQ(0, qr.GetVal<int>("Time", 0));
+  EXPECT_EQ(3, qr.GetVal<int>("Time", 3));
+  // second cycle (rows 4 and 4) include time steps 6 and 7
+  EXPECT_EQ(6, qr.GetVal<int>("Time", 4));
+  EXPECT_EQ(7, qr.GetVal<int>("Time", 5));
+  // third cycle (row 6) includes time step 8 -9
+  EXPECT_EQ(8, qr.GetVal<int>("Time", 6));
+  EXPECT_EQ(9, qr.GetVal<int>("Time", 7));
+  // fourth cycle (rows  8, 9) includes time steps 13 - 14
+  EXPECT_EQ(13, qr.GetVal<int>("Time", 8));
+  EXPECT_EQ(14, qr.GetVal<int>("Time", 9));
+
+  qr = sim.db().Query("Resources", NULL);
+  EXPECT_NEAR(0.61256, qr.GetVal<double>("Quantity", 0), 0.00001);
+  EXPECT_NEAR(0.62217, qr.GetVal<double>("Quantity", 1), 0.00001);
+  EXPECT_NEAR(0.39705, qr.GetVal<double>("Quantity", 2), 0.00001);
 }
 
 TEST_F(StorageTest, IncorrectBuyPolSetupUniform) {
@@ -727,48 +705,6 @@ TEST_F(StorageTest, IncorrectBuyPolSetupMinMax) {
   cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), 
                                          config_uniform_min_bigger_max, simdur);
   EXPECT_THROW(sim.Run(), cyclus::ValueError);
-
-  EXPECT_EQ(3, n_trans) << "expected 3 transactions, got " << n_trans;
-  // check that the transactions occur at the expected time (0, 2, 4)
-  EXPECT_EQ(0, qr.GetVal<int>("Time", 0));
-  EXPECT_EQ(2, qr.GetVal<int>("Time", 1));
-  EXPECT_EQ(4, qr.GetVal<int>("Time", 2));
-
-  // check that all transactions are of size 3
-  qr = sim.db().Query("Resources", NULL);
-  EXPECT_EQ(3, qr.GetVal<double>("Quantity", 0));
-}
-
-
-TEST_F(StorageTest, sS_Inventory) {
-  std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <max_inv_size>5</max_inv_size>"
-    "   <reorder_point>2</reorder_point>";
-
-  int simdur = 5;
-
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
-
-  sim.AddSource("spent_fuel").capacity(5).Finalize();
-  sim.AddSink("dry_spent").Finalize();
-
-  int id = sim.Run();
-
-  std::vector<cyclus::Cond> conds;
-  conds.push_back(cyclus::Cond("Commodity", "==", std::string("spent_fuel")));
-  cyclus::QueryResult qr = sim.db().Query("Transactions", &conds);
-  int n_trans = qr.rows.size();
-  EXPECT_EQ(3, n_trans) << "expected 3 transactions, got " << n_trans;
-  // check that the transactions occur at the expected time (0, 2, 4)
-  EXPECT_EQ(0, qr.GetVal<int>("Time", 0));
-  EXPECT_EQ(2, qr.GetVal<int>("Time", 1));
-  EXPECT_EQ(4, qr.GetVal<int>("Time", 2));
-
-  // check that all transactions are of size 5
-  qr = sim.db().Query("Resources", NULL);
-  EXPECT_EQ(5, qr.GetVal<double>("Quantity", 0));
 }
 
 TEST_F(StorageTest, PositionInitialize){
@@ -818,6 +754,86 @@ TEST_F(StorageTest, Longitude){
   EXPECT_EQ(qr.GetVal<double>("Latitude"), 50.0);
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 35.0);
 }
+
+TEST_F(StorageTest, RQ_Inventory_Invalid) {
+  std::string config =
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <max_inv_size>5</max_inv_size>"
+    "   <reorder_point>2</reorder_point>"
+    "   <reorder_quantity>10</reorder_quantity>";
+
+  int simdur = 2;
+ 
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+
+  EXPECT_THROW(int id = sim.Run(), cyclus::ValueError);
+}
+
+TEST_F(StorageTest, RQ_Inventory) {
+  std::string config =
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <max_inv_size>5</max_inv_size>"
+    "   <reorder_point>2</reorder_point>"
+    "   <reorder_quantity>3</reorder_quantity>";
+
+  int simdur = 5;
+
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+
+  sim.AddSource("spent_fuel").capacity(5).Finalize();
+  sim.AddSink("dry_spent").Finalize();
+
+  int id = sim.Run();
+
+  std::vector<cyclus::Cond> conds;
+  conds.push_back(cyclus::Cond("Commodity", "==", std::string("spent_fuel")));
+  cyclus::QueryResult qr = sim.db().Query("Transactions", &conds);
+  int n_trans = qr.rows.size();
+
+  EXPECT_EQ(3, n_trans) << "expected 3 transactions, got " << n_trans;
+  // check that the transactions occur at the expected time (0, 2, 4)
+  EXPECT_EQ(0, qr.GetVal<int>("Time", 0));
+  EXPECT_EQ(2, qr.GetVal<int>("Time", 1));
+  EXPECT_EQ(4, qr.GetVal<int>("Time", 2));
+
+  // check that all transactions are of size 3
+  qr = sim.db().Query("Resources", NULL);
+  EXPECT_EQ(3, qr.GetVal<double>("Quantity", 0));
+}
+
+TEST_F(StorageTest, sS_Inventory) {
+  std::string config =
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <max_inv_size>5</max_inv_size>"
+    "   <reorder_point>2</reorder_point>";
+
+  int simdur = 5;
+
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+
+  sim.AddSource("spent_fuel").capacity(5).Finalize();
+  sim.AddSink("dry_spent").Finalize();
+
+  int id = sim.Run();
+
+  std::vector<cyclus::Cond> conds;
+  conds.push_back(cyclus::Cond("Commodity", "==", std::string("spent_fuel")));
+  cyclus::QueryResult qr = sim.db().Query("Transactions", &conds);
+  int n_trans = qr.rows.size();
+  EXPECT_EQ(3, n_trans) << "expected 3 transactions, got " << n_trans;
+  // check that the transactions occur at the expected time (0, 2, 4)
+  EXPECT_EQ(0, qr.GetVal<int>("Time", 0));
+  EXPECT_EQ(2, qr.GetVal<int>("Time", 1));
+  EXPECT_EQ(4, qr.GetVal<int>("Time", 2));
+
+  // check that all transactions are of size 5
+  qr = sim.db().Query("Resources", NULL);
+  EXPECT_EQ(5, qr.GetVal<double>("Quantity", 0));
+}
+
 
 } // namespace cycamore
 

--- a/src/storage_tests.cc
+++ b/src/storage_tests.cc
@@ -729,6 +729,46 @@ TEST_F(StorageTest, IncorrectBuyPolSetupMinMax) {
   EXPECT_THROW(sim.Run(), cyclus::ValueError);
 
   EXPECT_EQ(3, n_trans) << "expected 3 transactions, got " << n_trans;
+  // check that the transactions occur at the expected time (0, 2, 4)
+  EXPECT_EQ(0, qr.GetVal<int>("Time", 0));
+  EXPECT_EQ(2, qr.GetVal<int>("Time", 1));
+  EXPECT_EQ(4, qr.GetVal<int>("Time", 2));
+
+  // check that all transactions are of size 3
+  qr = sim.db().Query("Resources", NULL);
+  EXPECT_EQ(3, qr.GetVal<double>("Quantity", 0));
+}
+
+
+TEST_F(StorageTest, sS_Inventory) {
+  std::string config =
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <max_inv_size>5</max_inv_size>"
+    "   <reorder_point>2</reorder_point>";
+
+  int simdur = 5;
+
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+
+  sim.AddSource("spent_fuel").capacity(5).Finalize();
+  sim.AddSink("dry_spent").Finalize();
+
+  int id = sim.Run();
+
+  std::vector<cyclus::Cond> conds;
+  conds.push_back(cyclus::Cond("Commodity", "==", std::string("spent_fuel")));
+  cyclus::QueryResult qr = sim.db().Query("Transactions", &conds);
+  int n_trans = qr.rows.size();
+  EXPECT_EQ(3, n_trans) << "expected 3 transactions, got " << n_trans;
+  // check that the transactions occur at the expected time (0, 2, 4)
+  EXPECT_EQ(0, qr.GetVal<int>("Time", 0));
+  EXPECT_EQ(2, qr.GetVal<int>("Time", 1));
+  EXPECT_EQ(4, qr.GetVal<int>("Time", 2));
+
+  // check that all transactions are of size 3
+  qr = sim.db().Query("Resources", NULL);
+  EXPECT_EQ(5, qr.GetVal<double>("Quantity", 0));
 }
 
 TEST_F(StorageTest, PositionInitialize){

--- a/src/storage_tests.cc
+++ b/src/storage_tests.cc
@@ -639,7 +639,6 @@ TEST_F(StorageTest, NormalActiveDormantBuyingSize){
   conds.push_back(cyclus::Cond("Commodity", "==", std::string("spent_fuel")));
   cyclus::QueryResult qr = sim.db().Query("Transactions", &conds);
   int n_trans = qr.rows.size();
-
   EXPECT_EQ(10, n_trans) << "expected 10 transactions, got " << n_trans;
   // confirm that transactions are only occurring during active periods
   // first cycle includes time steps 0 - 3


### PR DESCRIPTION
Relies on Cyclus PR [cyclus#1646](https://github.com/cyclus/cyclus/pull/1646). Until that one is merged, this one cannot be merged. They should be merged together if possible

This PR implements the new `TotalInvTracker` from [cyclus#1646](https://github.com/cyclus/cyclus/pull/1646) into Storage, which provides an agent-wide inventory limitation and is required as part of initializing the buy policy.

This fixes the janky way that Storage was previously calculating an agent-wide limitation! Now, the `max_inv_size` is applied to the whole facility through the use of `TotalInvTracker`. Closes #554, Storage no longer needs to change the capacity of Resource Buffers ever time step

This also adds two variables 
- `reorder_point` when total facility inventory is above this point, no new demands will be made. At or below this point, the agent will request material
- `reorder_quantity` when applicable, agent will request exactly this amount. It will make an exclusive demand for exactly this value

When `reorder_point` is used alone, it results in a (s,S) or min/max inventory policy. When the buffer inventory is below `reorder_point`, buypol tries to buy up to a full facility (`max_inv_size`, which is facility-wide). When used with `reorder_quantity`, this is a (R,Q) buy pol where the facility makes a single exclusive request of size `reorder_quantity` once below `reorder_point`. In both cases, when the inventory is above `reorder_point`, no requests are made

Closes #577, closes #578