### PR TITLE
Update version_tag in `publish_release.yml`

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Tag as stable
         if: ${{ github.repository_owner == 'cyclus' }}
         run: |
-          echo "version_tag=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          echo "version_tag=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
           echo "stable_tag=stable" >> "$GITHUB_ENV"
 
       - name: Log in to the Container registry

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ cycamore Change Log
 .. current developments
 **Added:**
 
-* GitHub workflow for publishing images on release (#573)
+* GitHub workflow for publishing images on release (#573, #580)
 * GitHub workflows for building/testing on a PR and push to `main` (#549, #564, #573)
 * Add functionality for random behavior on the size (#550) and frequency (#565) of a sink 
 * GitHub workflow to check that the CHANGELOG has been updated (#562) 


### PR DESCRIPTION
`${{ github.ref_name }}` does not exist in the context of a workflow triggered by a release