### PR TITLE
Fix CI Refactor

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -62,7 +62,7 @@ jobs:
           file: docker/Dockerfile
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
-          tags: ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:local-ci-image
+          tags: cycamore
           load: true
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
@@ -89,7 +89,9 @@ jobs:
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}
-            cycamore_tag=local-ci-image@${{ steps.build-cycamore.outputs.digest }}
+            cycamore_tag=local-ci-tag
+          build-contexts: |
+            ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:local-ci-tag=docker-image://cycamore@${{ steps.build-cycamore.outputs.digest }}
 
       - name: Export Environment Variables
         if: github.event_name == 'pull_request'

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -61,10 +61,10 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: docker/Dockerfile
-          cache-from: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
-          tags: ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-image-cache
-          push: true
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
+          tags: ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-tag
+          load: true
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}
@@ -85,14 +85,12 @@ jobs:
         with:
           context: ${{ github.workspace }}/cymetric
           file: ${{ github.workspace }}/cymetric/docker/Dockerfile
-          cache-from: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
-          tags: ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-image-cache
-          push: true
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}
-            cycamore_tag=ci-image-cache@${{ steps.build-cycamore.outputs.digest }}
+            cycamore_tag=ci-tag@${{ steps.build-cycamore.outputs.digest }}
 
       - name: PR Comment
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -117,3 +117,17 @@ jobs:
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.ARTIFACT_NAME }}.txt
+
+  upload-pr-number:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Save PR number to file
+        run: |
+          echo "${{ github.event.number }}" > pr_number
+      
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr_number

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -108,7 +108,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           echo "
-          ##### Build \`FROM cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus:${{ matrix.cyclus }}\`
+          ##### Build \`FROM cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus:${{ matrix.cyclus_tag }}\`
            - Cycamore: ${{ env.CYCAMORE_BUILD_STATUS }}
            - Cymetric: ${{ env.CYMETRIC_BUILD_STATUS }}" > ${{ env.ARTIFACT_NAME }}.txt
       

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -62,8 +62,8 @@ jobs:
           file: docker/Dockerfile
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
-          tags: cycamore
-          load: true
+          tags: ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-image-cache
+          push: true
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}
@@ -89,9 +89,9 @@ jobs:
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}
-            cycamore_tag=local-ci-tag
+            cycamore_tag=ci-image-cache
           build-contexts: |
-            ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:local-ci-tag=docker-image://cycamore@${{ steps.build-cycamore.outputs.digest }}
+            ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-image-cache=docker-image://ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-image-cache@${{ steps.build-cycamore.outputs.digest }}
 
       - name: Export Environment Variables
         if: github.event_name == 'pull_request'

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -62,9 +62,8 @@ jobs:
           file: docker/Dockerfile
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
-          # tags: ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-image-cache
-          # push: true
-          outputs: type=image,name=cycamore:ci-image-cache
+          tags: ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-image-cache
+          push: true
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}
@@ -92,7 +91,7 @@ jobs:
             ubuntu_version=${{ matrix.ubuntu_versions }}
             cycamore_tag=ci-image-cache
           build-contexts: |
-            ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-image-cache=docker-image://cycamore:ci-image-cache@${{ steps.build-cycamore.outputs.digest }}
+            ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-image-cache=docker-image://ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-image-cache@${{ steps.build-cycamore.outputs.digest }}
 
       - name: Export Environment Variables
         if: github.event_name == 'pull_request'

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -22,7 +22,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      pull-requests: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -107,7 +107,8 @@ jobs:
       - name: Construct Artifact
         if: github.event_name == 'pull_request'
         run: |
-          echo "Build \`FROM cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus:${{ matrix.cyclus }}\`
+          echo "
+          ##### Build \`FROM cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus:${{ matrix.cyclus }}\`
            - Cycamore: ${{ env.CYCAMORE_BUILD_STATUS }}
            - Cymetric: ${{ env.CYMETRIC_BUILD_STATUS }}" > ${{ env.ARTIFACT_NAME }}.txt
       

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -62,7 +62,7 @@ jobs:
           file: docker/Dockerfile
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
-          tags: ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-tag
+          tags: ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:local-ci-image
           load: true
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
@@ -89,7 +89,7 @@ jobs:
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}
-            cycamore_tag=ci-tag@${{ steps.build-cycamore.outputs.digest }}
+            cycamore_tag=local-ci-image@${{ steps.build-cycamore.outputs.digest }}
 
       - name: Export Environment Variables
         if: github.event_name == 'pull_request'

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -92,16 +92,29 @@ jobs:
             ubuntu_version=${{ matrix.ubuntu_versions }}
             cycamore_tag=ci-tag@${{ steps.build-cycamore.outputs.digest }}
 
-      - name: PR Comment
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: thollander/actions-comment-pull-request@v2
+      - name: Export Environment Variables
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "CYCAMORE_BUILD_STATUS=${{steps.build-cycamore.outcome == 'success' && '**Success** :white_check_mark:' || 
+          steps.build-cycamore.outcome == 'failure' && '**Failure** :x:' || 
+          '**Skipped due to upstream failure** :warning:'}}" >> "$GITHUB_ENV"
+
+          echo "CYMETRIC_BUILD_STATUS=${{steps.build-cymetric.outcome == 'success' && '**Success** :white_check_mark:' || 
+          steps.build-cymetric.outcome == 'failure' && '**Failure** :x:' || 
+          '**Skipped due to upstream failure** :warning:'}}" >> "$GITHUB_ENV"
+
+          echo "ARTIFACT_NAME=${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ matrix.cyclus_tag }}" >> "$GITHUB_ENV"
+
+      - name: Construct Artifact
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "Build \`FROM cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus:${{ matrix.cyclus }}\`
+           - Cycamore: ${{ env.CYCAMORE_BUILD_STATUS }}
+           - Cymetric: ${{ env.CYMETRIC_BUILD_STATUS }}" > ${{ env.ARTIFACT_NAME }}.txt
+      
+      - name: Upload Artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
-          comment_tag: ${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ matrix.cyclus_tag }}
-          message: |
-            ## Build statuses using cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}:${{ matrix.cyclus_tag }}
-            - Cycamore: ${{steps.build-cycamore.outcome == 'success' && '*Success* :white_check_mark:' || 
-                steps.build-cycamore.outcome == 'failure' && '**Failure** :x:' || 
-                '**Skipped due to upstream failure** :warning:'}}
-            - Cymetric: ${{steps.build-cymetric.outcome == 'success' && '*Success* :white_check_mark:' || 
-                steps.build-cymetric.outcome == 'failure' && '**Failure** :x:' || 
-                '**Skipped due to upstream failure** :warning:'}}
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.ARTIFACT_NAME }}.txt

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -62,8 +62,9 @@ jobs:
           file: docker/Dockerfile
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
-          tags: ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-image-cache
-          push: true
+          # tags: ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-image-cache
+          # push: true
+          outputs: type=image,name=cycamore:ci-image-cache
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}
@@ -91,7 +92,7 @@ jobs:
             ubuntu_version=${{ matrix.ubuntu_versions }}
             cycamore_tag=ci-image-cache
           build-contexts: |
-            ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-image-cache=docker-image://ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-image-cache@${{ steps.build-cycamore.outputs.digest }}
+            ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-image-cache=docker-image://cycamore:ci-image-cache@${{ steps.build-cycamore.outputs.digest }}
 
       - name: Export Environment Variables
         if: github.event_name == 'pull_request'

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -1,0 +1,32 @@
+name: Comment on PR
+
+on:
+  workflow_run:
+    workflows: ["Build/Test for PR and collaborator push"]
+    types:
+      - completed
+
+jobs:
+  pr-comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          merge-multiple: true
+
+      - name: Merge artifacts and get PR number
+        run: |
+          echo "### Build Status Report" > artifacts_merged.md
+          cat ./*.txt >> artifacts_merged.md
+          echo "PR_NUMBER=$(cat pr_number)" >> "$GITHUB_ENV"
+
+      - name: PR Comment
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          pr_number: ${{ env.PR_NUMBER }}
+          comment_tag: build_status_report
+          filePath: artifacts_merged.md

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -56,11 +56,11 @@ jobs:
         id: build-cycamore
         uses: docker/build-push-action@v5
         with:
-          cache-from: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
           file: docker/Dockerfile
           push: true
-          tags: ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ env.tag }}
+          tags: ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ env.tag }}
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}
@@ -78,9 +78,9 @@ jobs:
         with:
           context: ${{ github.workspace }}/cymetric
           file: ${{ github.workspace }}/cymetric/docker/Dockerfile
-          cache-from: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
-          tags: ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.tag }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
+          tags: ghcr.io/${{ github.repository_owner }}/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.tag }}
           push: true
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -52,13 +52,13 @@ jobs:
       - name: Build, Test, and Push Cycamore
         uses: docker/build-push-action@v5
         with:
-          cache-from: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
           file: docker/Dockerfile
           push: true
           tags: |
-            ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ env.version_tag }}
-            ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ env.stable_tag }}
+            ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ env.version_tag }}
+            ghcr.io/${{ github.repository_owner }}/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ env.stable_tag }}
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,9 @@ cycamore Change Log
 .. current developments
 **Added:**
 
-* GitHub workflow for publishing images on release (#573)
-* GitHub workflows for building/testing on a PR and push to `main` (#549, #564, #573)
+* Downstream testing in CI workflows (#573, #580, #582)
+* GitHub workflow for publishing images on release (#573, #582)
+* GitHub workflows for building/testing on a PR and push to `main` (#549, #564, #573, #582)
 * Add functionality for random behavior on the size (#550) and frequency (#565) of a sink 
 * GitHub workflow to check that the CHANGELOG has been updated (#562) 
 * Added inventory policies to Storage through the material buy policy (#574)


### PR DESCRIPTION
Any images are now pushed to the ghcr of `github.repository_owner` instead of cyclus to prevent 403 forbidden errors when PRs originate from forks. 

Also modifies the PR comment implementation to use a separate workflow - also to prevent permissions errors when PRs originate from forks.