### PR TITLE
Rebuild when test file changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ cycamore Change Log
 
 * Updated build procedure to use newer versions of packages in 2023 (#549)
 * Added active/dormant and request size variation from buy policy to Storage (#546, #568)
+* Update build procedure to force a rebuild when a test file is changed (#584)
 
 v1.5.5
 ====================

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,13 @@
 # ------------------- Add all Concrete Agents ----------------------------
+# CMAKE_CONFIGURE_DEPENDS will force a rebuild on a change to the source file
+FILE(GLOB test_files CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/*_tests.*")
+FOREACH(file ${test_files})
+    SET_PROPERTY(
+        DIRECTORY
+        APPEND
+        PROPERTY CMAKE_CONFIGURE_DEPENDS ${file}
+    )
+ENDFOREACH()
 
 EXECUTE_PROCESS(COMMAND git describe --tags OUTPUT_VARIABLE cycamore_version OUTPUT_STRIP_TRAILING_WHITESPACE)
 CONFIGURE_FILE(cycamore_version.h.in "${CMAKE_CURRENT_SOURCE_DIR}/cycamore_version.h" @ONLY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,4 @@
 # ------------------- Add all Concrete Agents ----------------------------
-# CMAKE_CONFIGURE_DEPENDS will force a rebuild on a change to the source file
-FILE(GLOB test_files CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/*_tests.*")
-FOREACH(file ${test_files})
-    SET_PROPERTY(
-        DIRECTORY
-        APPEND
-        PROPERTY CMAKE_CONFIGURE_DEPENDS ${file}
-    )
-ENDFOREACH()
 
 EXECUTE_PROCESS(COMMAND git describe --tags OUTPUT_VARIABLE cycamore_version OUTPUT_STRIP_TRAILING_WHITESPACE)
 CONFIGURE_FILE(cycamore_version.h.in "${CMAKE_CURRENT_SOURCE_DIR}/cycamore_version.h" @ONLY)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,7 +20,7 @@ INSTALL(FILES run_inputs.py
     COMPONENT testing
     )
 
-    # CMAKE_CONFIGURE_DEPENDS will force a rebuild on a change to the source file
+# CMAKE_CONFIGURE_DEPENDS will force a rebuild on a change to the source file
 FILE(GLOB test_files CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/src/*_tests.*")
 FOREACH(file ${test_files})
     SET_PROPERTY(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,3 +19,13 @@ INSTALL(FILES run_inputs.py
     DESTINATION bin
     COMPONENT testing
     )
+
+    # CMAKE_CONFIGURE_DEPENDS will force a rebuild on a change to the source file
+FILE(GLOB test_files CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/src/*_tests.*")
+FOREACH(file ${test_files})
+    SET_PROPERTY(
+        DIRECTORY
+        APPEND
+        PROPERTY CMAKE_CONFIGURE_DEPENDS ${file}
+    )
+ENDFOREACH()


### PR DESCRIPTION
Closes #476.  CMake wasn't rebuilding on a change to the test files because the `cyclus_unit_tests` target doesn't reference the source files directly - we use the `UseCyclus` macro to handle a lot of the cycamore build and "return" env vars holding build info.  

This forces cmake to rebuild the `test/` directory when one of the test files changes.

I'm no CMake expert... if someone knows a better way to handle this please let me know.