### PR TITLE
Old active dormant parameters hanging around in storage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,14 +8,14 @@ cycamore Change Log
 * Downstream testing in CI workflows (#573, #580, #582, #583)
 * GitHub workflow for publishing images on release (#573, #582, #583)
 * GitHub workflows for building/testing on a PR and push to `main` (#549, #564, #573, #582, #583)
-* Add functionality for random behavior on the size (#550) and frequency (#565) of a sink (#586)
+* Add functionality for random behavior on the size (#550) and frequency (#565) of a sink
 * GitHub workflow to check that the CHANGELOG has been updated (#562) 
 * Added inventory policies to Storage through the material buy policy (#574)
 
 **Changed:** 
 
 * Updated build procedure to use newer versions of packages in 2023 (#549)
-* Added active/dormant and request size variation from buy policy to Storage (#546, #568)
+* Added active/dormant and request size variation from buy policy to Storage (#546, #568, #586, #587)
 * Update build procedure to force a rebuild when a test file is changed (#584)
 
 v1.5.5

--- a/src/storage.h
+++ b/src/storage.h
@@ -421,29 +421,6 @@ class Storage
                       "uilabel":"Reorder Quantity"}
   double reorder_quantity;
 
-  #pragma cyclus var {"default": 1,\
-                      "tooltip": "Length of the active buying "\
-                        "period",\
-                      "doc":"During the length of the active buying "\
-                        "period, agent exhibits regular behavior. "\
-                        "If paired with dormant buying period, "\
-                        "alternates between buying and not buying, "\
-                        "regardless if space is available",\
-                      "uilabel":"Active Buying Period"}
-  int active_buying;
-
-  #pragma cyclus var {"default": 0,\
-                      "tooltip": "Length of the dormant buying "\
-                        "period",\
-                      "doc":"During the length of the dormant buying "\
-                        "period, agent will not request any new "\
-                        "material from the DRE. Paired with active "\
-                        "buying period, alternates between buying "\
-                        "and not buying, regardless if space is "\
-                        "available",\
-                      "uilabel":"Dormant (No Buying) Period"}
-  int dormant_buying;
-
   #pragma cyclus var {"tooltip":"Incoming material buffer"}
   cyclus::toolkit::ResBuf<cyclus::Material> inventory;
 


### PR DESCRIPTION
I had a messy merge when finalizing #574, and somehow the old fixed-integer `active_buying` and `dormant_buying` parameters stuck around in the storage header. They're unused and now I removed them to avoid confusion