### PR TITLE
add cumulative cap handling to storage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ cycamore Change Log
 * GitHub workflows for building/testing on a PR and push to `main` (#549, #564, #573, #582, #583)
 * Add functionality for random behavior on the size (#550) and frequency (#565) of a sink
 * GitHub workflow to check that the CHANGELOG has been updated (#562) 
-* Added inventory policies to Storage through the material buy policy (#574)
+* Added inventory policies to Storage through the material buy policy (#574, #588)
 
 **Changed:** 
 

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -133,11 +133,17 @@ void Storage::EnterNotify() {
   cyclus::Facility::EnterNotify();
 
   inventory_tracker.set_capacity(max_inv_size);
-  if (reorder_point < 0) {
+  if (reorder_point < 0 && cumulative_cap <= 0) {
     InitBuyPolicyParameters();
     buy_policy.Init(this, &inventory, std::string("inventory"),
                     &inventory_tracker, throughput, active_dist_,
                     dormant_dist_, size_dist_);
+  }
+  else if (cumulative_cap > 0) {
+    InitBuyPolicyParameters();
+    buy_policy.Init(this, &inventory, std::string("inventory"),
+                    &inventory_tracker, throughput, cumulative_cap,
+                    dormant_dist_);
   }
   else if (reorder_quantity > 0) {
     if (reorder_point + reorder_quantity > max_inv_size) {

--- a/src/storage.h
+++ b/src/storage.h
@@ -421,6 +421,14 @@ class Storage
                       "uilabel":"Reorder Quantity"}
   double reorder_quantity;
 
+  #pragma cyclus var {"default": -1,\
+                      "tooltip": "Total amount of material that can be recieved per cycle.",\
+                      "doc": "After receiving this much material cumulatively, the agent will go dormant. "\
+                      "Must be paired with dormant_buying_frequency_type and any other dormant parameters. "\
+                      "The per-time step demand is unchanged except the cycle cap is almost reached.",\
+                      "uilabel": "Cumulative Cap"}
+  double cumulative_cap;
+
   #pragma cyclus var {"tooltip":"Incoming material buffer"}
   cyclus::toolkit::ResBuf<cyclus::Material> inventory;
 


### PR DESCRIPTION
Adds one new parameter to Storage: `cumulative_cap`, which corresponds to the cumulative cap type of inventory management that is set up in the Material Buy Policy in Cyclus. 

When set to a value above zero, Storage will track the cumulative amount of material it receives, until the point it reaches the cap. Then it will enter a dormant period. To set up the dormant period, users will use the same set of dormant buying parameters that already exist in Storage from #568 

Closes #558 