### PR TITLE
Add commit hash to PR comment

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -123,9 +123,16 @@ jobs:
       - name: Save PR number to file
         run: |
           echo "${{ github.event.number }}" > pr_number
+          echo "${{ github.event.pull_request.head.sha }}" > commit_hash
       
-      - name: Upload artifact
+      - name: Upload PR number artifact
         uses: actions/upload-artifact@v4
         with:
           name: pr_number
           path: pr_number
+
+      - name: Upload Commit hash artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: commit_hash
+          path: commit_hash

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -120,10 +120,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
+      - name: Checkout cycamore
+        uses: actions/checkout@v4
+
       - name: Save PR number to file
         run: |
           echo "${{ github.event.number }}" > pr_number
-          echo "${{ github.event.pull_request.head.sha }}" > commit_hash
+          echo "${{ github.event.pull_request.head.sha }} - $(git log -1 --format=%ci)" > commit_hash_timestamp
       
       - name: Upload PR number artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -137,5 +137,5 @@ jobs:
       - name: Upload Commit hash artifact
         uses: actions/upload-artifact@v4
         with:
-          name: commit_hash
-          path: commit_hash
+          name: commit_hash_timestamp
+          path: commit_hash_timestamp

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Merge artifacts and get PR number
         run: |
-          echo "### Build Status Report - $(cat commit_hash)" > artifacts_merged.md
+          echo "### Build Status Report - $(cat commit_hash_timestamp)" > artifacts_merged.md
           cat ./*.txt >> artifacts_merged.md
           echo "PR_NUMBER=$(cat pr_number)" >> "$GITHUB_ENV"
 

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Merge artifacts and get PR number
         run: |
-          echo "### Build Status Report" > artifacts_merged.md
+          echo "### Build Status Report - $(cat commit_hash)" > artifacts_merged.md
           cat ./*.txt >> artifacts_merged.md
           echo "PR_NUMBER=$(cat pr_number)" >> "$GITHUB_ENV"
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ cycamore Change Log
 
 * Downstream testing in CI workflows (#573, #580, #582, #583)
 * GitHub workflow for publishing images on release (#573, #582, #583)
-* GitHub workflows for building/testing on a PR and push to `main` (#549, #564, #573, #582, #583)
+* GitHub workflows for building/testing on a PR and push to `main` (#549, #564, #573, #582, #583, #590)
 * Add functionality for random behavior on the size (#550) and frequency (#565) of a sink
 * GitHub workflow to check that the CHANGELOG has been updated (#562) 
 * Added inventory policies to Storage through the material buy policy (#574, #588)


### PR DESCRIPTION
The PR comment for downstream testing statuses is updated with each successive build.  This PR adds the commit hash that generated the statuses to the comment.