### PR TITLE
Documentation Update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ cycamore Change Log
 * Added active/dormant and request size variation from buy policy to Storage (#546, #568, #586, #587)
 * Update build procedure to force a rebuild when a test file is changed (#584)
 * Define the version number in `CMakeLists.txt` and rely on CMake to propagate the version throughout the code (#589)
+* Update version numbers in documentation and fix references to `master` branch (#591)
 
 v1.5.5
 ====================

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,9 +12,9 @@ General Notes
 * Use a branching workflow similar to the one described at
   http://progit.org/book/ch3-4.html.
 
-* Keep your own "master"  branch in sync with the mainline
-  repository's "master" branch. Specifically, do not push your
-  own commits directly to your "master" branch.
+* Keep your own "main"  branch in sync with the mainline
+  repository's "main" branch. Specifically, do not push your
+  own commits directly to your "main" branch.
 
 * Any commit should *pass all tests* (see `Running Tests`_).
 
@@ -30,11 +30,11 @@ Issuing a Pull Request
 ======================
 
 * When you are ready to move changes from one of your topic branches into the
-  "master" branch, it must be reviewed and accepted by another developer.
+  "main" branch, it must be reviewed and accepted by another developer.
 
 * You may want to review this `tutorial
   <https://help.github.com/articles/using-pull-requests/>`_ before you make a
-  pull request to the master branch.
+  pull request to the main branch.
 
 Reviewing a Pull Request
 ========================
@@ -51,7 +51,7 @@ Reviewing a Pull Request
 * Click the green "Merge Pull Request" button
 
   * Note: if the button is not available, the requester needs to merge or rebase
-    from the current HEAD of the blessed's "master" branch.
+    from the current HEAD of the blessed's "main" branch.
 
 Running Tests
 =============
@@ -75,7 +75,7 @@ Cautions
 * **DO NOT** rebase any commits that have been pulled/pushed anywhere else other
   than your own fork (especially if those commits have been integrated into the
   blessed repository).  You should NEVER rebase commits that are a part of the
-  'master' branch. *If you do, we will never, ever accept your pull request*.
+  'main' branch. *If you do, we will never, ever accept your pull request*.
 
 An Example
 ==========
@@ -90,13 +90,13 @@ For the sake of simplicity, let us assume that we want a single "sandbox" branch
 in which we would like to work, i.e. where we can store all of our work that may not
 yet pass tests or even compile, but where we also want to save our progress. Let us
 call this branch "Work". So, when all is said and done, in our fork there will be
-three branches: "Master", "Develop", and "Work".
+three branches: "Main", "Develop", and "Work".
 
 Acquiring Cyclus and Workflow
 -----------------------------
 
 We begin with a fork of the main ("blessed") Cyclus repository. After initially forking
-the repo, we will have two branches in our fork: "Master" and "Develop".
+the repo, we will have two branches in our fork: "Main" and "Develop".
 
 Acquiring a Fork of the Cyclus Repository
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -111,9 +111,9 @@ First, let's make our "work" branch:
     .../cyclus_dir/$ git branch work
     .../cyclus_dir/$ git push origin work
 
-We now have the following situation: there exists the "blessed" copy of the Master and
-Develop branches, there exists your fork's copy of the Master, Develop, and Work branches,
-*AND* there exists your *local* copy of the Master, Develop, and Work branches. It is
+We now have the following situation: there exists the "blessed" copy of the Main and
+Develop branches, there exists your fork's copy of the Main, Develop, and Work branches,
+*AND* there exists your *local* copy of the Main, Develop, and Work branches. It is
 important now to note that you may wish to work from home or the office. If you keep your
 fork's branches up to date (i.e., "push" your changes before you leave), only your *local*
 copies of your branches may be different when you next sit down at the other location.
@@ -128,22 +128,22 @@ work, finished, and successfully pushed your changes to your *Origin*
 repository. You are now at home and want to continue working a bit. To begin,
 let's update our *home's local branches*.  ::
 
-    .../cyclus_dir/$ git checkout master
-    .../cyclus_dir/$ git pull upstream master
-    .../cyclus_dir/$ git push origin master
+    .../cyclus_dir/$ git checkout main
+    .../cyclus_dir/$ git pull upstream main
+    .../cyclus_dir/$ git push origin main
 
     .../cyclus_dir/$ git checkout work
     .../cyclus_dir/$ git pull origin work
-    .../cyclus_dir/$ git rebase master
+    .../cyclus_dir/$ git rebase main
     .../cyclus_dir/$ git push origin work
 
 Perhaps a little explanation is required. We first want to make sure that this new local copy of
-the master branch is up-to-date with respect to the remote origin's branch and remote upstream's
+the main branch is up-to-date with respect to the remote origin's branch and remote upstream's
 branch. If there was a change from the remote upstream's branch, we want to push that to origin.
 We then follow the same process to update the work branch, except:
 
 #. we don't need to worry about the *upstream* repo because it doesn't have a work branch, and
-#. we want to incorporate any changes which may have been introduced in the master branch update.
+#. we want to incorporate any changes which may have been introduced in the main branch update.
 
 Workflow: The End
 ^^^^^^^^^^^^^^^^^
@@ -176,5 +176,5 @@ Releases
 
 If you are going through a release of Cyclus and Cycamore, check out the release
 procedure notes `here
-<https://github.com/cyclus/cyclus/blob/master/doc/release_procedure.rst>`_ and
+<https://github.com/cyclus/cyclus/blob/main/doc/release_procedure.rst>`_ and
 on the `website <http://fuelcycle.org/cep/cep3.html>`_.

--- a/DEPENDENCIES.rst
+++ b/DEPENDENCIES.rst
@@ -98,13 +98,13 @@ installation procedure also assumes that you have root access to you computer.
 
       * - Ubuntu 20.04
         - `Standard install
-          <https://github.com/bennibbelink/cyclus/releases/latest>`_ 
+          <https://github.com/cyclus/cyclus/releases/latest>`_ 
       * - Ubuntu 22.04
         - `Standard install
-          <https://github.com/bennibbelink/cyclus/releases/latest>`_ 
+          <https://github.com/cyclus/cyclus/releases/latest>`_ 
 
   You can download previous/different version `here
-   <https://github.com/bennibbelink/cyclus/releases>`_.
+   <https://github.com/cyclus/cyclus/releases>`_.
 
         
 #. Install the package by running:

--- a/DEPENDENCIES.rst
+++ b/DEPENDENCIES.rst
@@ -20,7 +20,7 @@ Dependencies
 ====================   ==================
 Package                Minimum Version
 ====================   ==================
-`Cyclus`               1.4
+`Cyclus`               1.5
 ====================   ==================
 
 
@@ -46,7 +46,7 @@ well as variety of relevant information: maintainer, description, version,
 dependencies (other software or libraries required to use it).  The Cyclus
 team provides pre-built Cyclus and Cycamore Debian packages to simplify
 installation for the user. These packages are available for LTS Ubuntu version
-14.04 and 16.04 (though they may also work on other Linux systems).
+20.04 and 22.04 (though they may also work on other Linux systems).
 
 .. website_include_binary_end
 
@@ -77,8 +77,8 @@ Debian Package Manager
 ~~~~~~~~~~~~~~~~~~~~~~
 
 
-This installation procedure assumes that you are using Ubuntu (LTS) 14.04 or
-16.04. This method has only been tested on those Ubuntu versions. This
+This installation procedure assumes that you are using Ubuntu (LTS) 20.04 or
+22.04. This method has only been tested on those Ubuntu versions. This
 installation procedure also assumes that you have root access to you computer.
 
 #. Install Cyclus dependencies:
@@ -92,35 +92,26 @@ installation procedure also assumes that you have root access to you computer.
    If you need/want more information about dependency installation please read the
    `dependency installation documentation`_.
 
-#. Download the lastest version Cyclus Core Debian installation package:
+#. Download the latest version Cyclus Core Debian installation package:
    
    .. list-table::
 
-      * - Ubuntu 14.04
-        - `without Python 
-          <http://dory.fuelcycle.org:4848/ubuntu/14.04/cyclus_latest.deb>`_ 
-        - `with Python 2.7 
-          <http://dory.fuelcycle.org:4848/ubuntu/14.04/python2/cyclus_latest.deb>`_ 
-        - 
+      * - Ubuntu 20.04
+        - `Standard install
+          <https://github.com/bennibbelink/cyclus/releases/latest>`_ 
+      * - Ubuntu 22.04
+        - `Standard install
+          <https://github.com/bennibbelink/cyclus/releases/latest>`_ 
 
-      * - Ubuntu 16.04
-        - `without Python 
-          <http://dory.fuelcycle.org:4848/ubuntu/16.04/cyclus_latest.deb>`_
-        - `with Python 2.7 
-          <http://dory.fuelcycle.org:4848/ubuntu/16.04/python2/cyclus_latest.deb>`_
-        - `with Python 3.5 
-          <http://dory.fuelcycle.org:4848/ubuntu/16.04/python3/cyclus_latest.deb>`_
-
-   You can download previous/different version `here
-   <http://dory.fuelcycle.org:4848/>`_.
-    
+  You can download previous/different version `here
+   <https://github.com/bennibbelink/cyclus/releases>`_.
 
         
 #. Install the package by running:
 
    .. code-block:: bash 
 
-     $ sudo dpkg -i cyclus_latest.deb
+     $ sudo dpkg -i cyclus-x.x.x-Linux.deb
 
 .. website_include_deb_end
 
@@ -130,4 +121,4 @@ installation procedure also assumes that you have root access to you computer.
 .. _`Cycamore Repo`: https://github.com/cyclus/cycamore
 .. _Anaconda: https://www.continuum.io/downloads
 .. _miniconda: http://conda.pydata.org/miniconda.html
-.. _`dependency installation documentation`: https://github.com/cyclus/cyclus/blob/develop/DEPENDENCIES.rst
+.. _`dependency installation documentation`: https://github.com/cyclus/cyclus/blob/main/DEPENDENCIES.rst

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -17,7 +17,7 @@ Cycamore's only dependency is the Cyclus Core.
 ====================   ==================
 Package                Minimum Version
 ====================   ==================
-`Cyclus`               1.4
+`Cyclus`               1.5
 ====================   ==================
 
 There are a number of ways to install the Cyclus core:

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ a list of `contributed modules <http://fuelcycle.org/user/index.html#third-party
   the** `Users Guide <http://fuelcycle.org/user/index.html>`_,
 
 - **If you would like to contribute to Cycamore, please check our**
-  `Contribution Guidelines <https://github.com/cyclus/cyclus/blob/master/CONTRIBUTING.rst>`_.
+  `Contribution Guidelines <https://github.com/cyclus/cyclus/blob/main/CONTRIBUTING.rst>`_.
 
 
 .. contents:: Table of Contents
@@ -45,7 +45,7 @@ Cycamore's only dependency is the Cyclus Core.
 ====================   ==================
 Package                Minimum Version
 ====================   ==================
-`Cyclus`               1.4
+`Cyclus`               1.5
 ====================   ==================
 
 There are a number of ways to install the Cyclus core:
@@ -95,11 +95,11 @@ to contribute into Cyclus, please follow this procedure:
 
 #. Fork Cycamore repository,
 
-#. Create a working branch on you fork from the ``master`` branch,
+#. Create a working branch on you fork from the ``main`` branch,
 
 #. Implement your modification of the Cycamore source code,
 
-#. Submit a Pull request into ``cycamore/master`` branch,
+#. Submit a Pull request into ``cycamore/main`` branch,
 
 #. Wait for reviews/merge (the Puller cannot be the Merger).
 


### PR DESCRIPTION
The biggest changes are `master` to `main`.  I also updated the Ubuntu versions and changed the links to point to our GitHub releases.  

The minimum required Cyclus version will need to be updated again when we issue the new release.

I will make a separate PR for documenting our container images as an installation option.