### PR TITLE
Require C++17 standard in cycamore

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ cycamore Change Log
 
 **Changed:** 
 
-* Updated build procedure to use newer versions of packages in 2023 (#549, #596)
+* Updated build procedure to use newer versions of packages and compilers in 2023 (#549, #596, #599)
 * Added active/dormant and request size variation from buy policy to Storage (#546, #568, #586, #587)
 * Update build procedure to force a rebuild when a test file is changed (#584)
 * Define the version number in `CMakeLists.txt` and rely on CMake to propagate the version throughout the code (#589)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,11 @@ PROJECT(CYCAMORE VERSION 1.5.5)
 
 # check for and enable c++11 support (required for cyclus)
 INCLUDE(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-IF(COMPILER_SUPPORTS_CXX11)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
+IF(COMPILER_SUPPORTS_CXX17)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 ELSE()
-    MESSAGE(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+    MESSAGE(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++17 support. Please use a different C++ compiler.")
 ENDIF()
 
 # quiets fortify_source warnings when not compiling with optimizations


### PR DESCRIPTION
Updates the C++ standard required by the compiler.  This is provoked by https://github.com/cyclus/cyclus/pull/1738 but should be done anyway in my opinion since we require C++17 in cyclus/cyclus.