### PR TITLE
Default to Release build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG make_cores=2
 COPY . /cycamore
 WORKDIR /cycamore
 
-RUN python install.py -j ${make_cores} --build-type=Release --allow-milps
+RUN python install.py -j ${make_cores} --allow-milps
 
 FROM cycamore as deb-generation
 WORKDIR /cycamore/build

--- a/install.py
+++ b/install.py
@@ -184,7 +184,8 @@ def main():
     parser.add_argument('--cmake_prefix_path', help=cmake_prefix_path)
 
     build_type = "the CMAKE_BUILD_TYPE"
-    parser.add_argument('--build-type', '--build_type', help=build_type)
+    parser.add_argument('--build-type', '--build_type', help=build_type,
+                        default='Release')
 
     parser.add_argument('-D', metavar='VAR', action='append',
                         help='Set enviornment variable(s).')


### PR DESCRIPTION
Updates `install.py` to default to a Release build and updates the Dockerfile to omit the --build-type argument