### PR TITLE
Update newer test classes to skip if cyclus does not have COIN

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ cycamore Change Log
 * Minor modifications for compatibility with the latest GTest library (#598)
 * Remove FindCyclus.cmake from this repo since it is installed with Cyclus (#597)
 * Default to a Release build when installing via python script (#600)
+* Update pytests to skip appropriately when COIN is not supported (#601)
 
 v1.5.5
 ====================

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -13,7 +13,7 @@ from cyclus.lib import Env
 from pytest import skip
 
 import helper
-from helper import check_cmd, run_cyclus, table_exist, cyclus_has_coin
+from helper import run_cyclus
 
 
 ALLOW_MILPS = Env().allow_milps
@@ -276,9 +276,8 @@ class TestDynamicCapacitated(TestRegression):
     """   
     @classmethod
     def setup_class(cls):
+        skip_if_dont_allow_milps()
         super(TestDynamicCapacitated, cls).setup_class("./input/dynamic_capacitated.xml")
-        if not cyclus_has_coin():
-            raise skip('Cyclus not compiled with COIN')
 
         # Find agent ids of source and sink facilities
         cls.agent_ids = cls.to_ary(cls.agent_entry, "AgentId")
@@ -380,9 +379,8 @@ class TestGrowth1(TestRegression):
     """
     @classmethod
     def setup_class(cls):
+        skip_if_dont_allow_milps()
         super(TestGrowth1, cls).setup_class("./input/growth.xml")
-        if not cyclus_has_coin():
-            raise skip('Cyclus not compiled with COIN')
 
     @classmethod
     def teardown_class(cls):
@@ -425,9 +423,8 @@ class TestGrowth2(TestRegression):
     """
     @classmethod
     def setup_class(cls):
+        skip_if_dont_allow_milps()
         super(TestGrowth2, cls).setup_class("../input/growth/deploy_and_manager_insts.xml")
-        if not cyclus_has_coin():
-            raise skip('Cyclus not compiled with COIN')
 
     @classmethod
     def teardown_class(cls):
@@ -465,9 +462,8 @@ class TestDeployInst(TestRegression):
     """        
     @classmethod
     def setup_class(cls):
+        skip_if_dont_allow_milps()
         super(TestDeployInst, cls).setup_class("../input/deploy_inst.xml")
-        if not cyclus_has_coin():
-            raise skip('Cyclus not compiled with COIN')
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
In a handful of places the method being used to skip tests is different than the standard method (`skip_if_dont_allow_milps()`).  This has not been tested in CI since we always install cyclus and cycamore with the `--allow-milps` flag and COIN.  I tested this locally to confirm that the correct tests are now skipped when cyclus and cycamore are installed without MILPS support - I encourage any reviewers to test locally as well

If we wish to hold this back until CI is in place to test, that is fine with me.  Currently all of our distribution methods build cyclus and cycamore with COIN support so this might not be super pressing