### PR TITLE
Use `python3` instead of `python` in environment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Since last release
 
 **Changed:**
 
+* Rely on `python3` in environment instead of `python` (#602)
+
 **Fixed:**
 
 **Removed:**

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -45,7 +45,7 @@ Run the install script:
 
 .. code-block:: bash
   
-  python install.py
+  python3 install.py
 
 
 If you successfully followed the instructions above, then the Cycamore library
@@ -130,7 +130,7 @@ installation flag. The otherwise identical process would look like:
 
 .. code-block:: bash
 
-    .../cycamore$  python install.py --coin_root=path/to/coin
+    .../cycamore$  python3 install.py --coin_root=path/to/coin
 
 
 CMake Cycamore Installation

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ github is fairly straightforward:
 
 - Clone the Cyclus Repo: ``git clone https://github.com/cyclus/cycamore.git``,
 
-- to install Cyclus locally (in ``~/.local/``) just run: ``python install.py``
+- to install Cyclus locally (in ``~/.local/``) just run: ``python3 install.py``
   from cycamore folder,
 
 - finally, add the following Cyclus installation path (``~/.local/cyclus``) to

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG make_cores=2
 COPY . /cycamore
 WORKDIR /cycamore
 
-RUN python install.py -j ${make_cores} --allow-milps
+RUN python3 install.py -j ${make_cores} --allow-milps
 
 FROM cycamore as deb-generation
 WORKDIR /cycamore/build
@@ -21,4 +21,4 @@ FROM cycamore as cycamore-test
 RUN cycamore_unit_tests
 
 FROM cycamore-test as cycamore-pytest
-RUN cd tests && python -m pytest
+RUN cd tests && python3 -m pytest

--- a/install.py
+++ b/install.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 from __future__ import print_function, unicode_literals
 import os
 import sys

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -37,7 +37,7 @@ Next, generate the new databases:
 
 .. code-block:: bash
 
-  $ python ref.py gen
+  $ python3 ref.py gen
 
 Next, rename the databases:
 
@@ -93,4 +93,4 @@ those tables. See the module's help:
 
 .. code-block:: python
 
-  $ python analysis.py -h
+  $ python3 analysis.py -h

--- a/tests/run_inputs.py.in
+++ b/tests/run_inputs.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 import subprocess
@@ -42,7 +42,7 @@ def check_inputs():
 
 def print_usage() :
     """This prints the proper way to treat the command line interface"""
-    print(""" Usage: python run_inputs.py\n 
+    print(""" Usage: python3 run_inputs.py\n 
             Allowed Options : \n 
             -v arg                    output log verbosity. \n 
                                 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 import os
 import uuid
 import sqlite3


### PR DESCRIPTION
We used to require a version agnostic `python` in the environment.  This removes that necessity and refers to `python3` instead 