### PR TITLE
Deprecate `ResourceBuff`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,11 +9,13 @@ Since last release
 
 **Changed:**
 
-* Rely on `python3` in environment instead of `python` (#602)
+* Rely on ``python3`` in environment instead of ``python`` (#602)
 
 **Fixed:**
 
 **Removed:**
+
+* Removed references to deprecated ``ResourceBuff`` class (#604)
 
 
 v1.6.0

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -41,8 +41,7 @@ void Storage::InitFrom(Storage* m) {
 void Storage::InitFrom(cyclus::QueryableBackend* b) {
 #pragma cyclus impl initfromdb cycamore::Storage
 
-  using cyclus::toolkit::Commodity;
-  Commodity commod = Commodity(out_commods.front());
+  cyclus::toolkit::Commodity commod = cyclus::toolkit::Commodity(out_commods.front());
   cyclus::toolkit::CommodityProducer::Add(commod);
   cyclus::toolkit::CommodityProducer::SetCapacity(commod, throughput);
 }
@@ -241,7 +240,6 @@ void Storage::Tick() {
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Storage::Tock() {
-  using cyclus::toolkit::RecordTimeSeries;
   LOG(cyclus::LEV_INFO3, "ComCnv") << prototype() << " is tocking {";
 
   BeginProcessing_();  // place unprocessed inventory into processing
@@ -315,10 +313,6 @@ void Storage::BeginProcessing_() {
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Storage::ProcessMat_(double cap) {
-  using cyclus::Material;
-  using cyclus::ResCast;
-  using cyclus::toolkit::ResBuf;
-
   if (!ready.empty()) {
     try {
       double max_pop = std::min(cap, ready.quantity());
@@ -350,7 +344,6 @@ void Storage::ProcessMat_(double cap) {
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Storage::ReadyMatl_(int time) {
-  using cyclus::toolkit::ResBuf;
   LOG(cyclus::LEV_INFO5, "ComCnv") << "Placing material into ready";
 
   int to_ready = 0;

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -318,7 +318,6 @@ void Storage::ProcessMat_(double cap) {
   using cyclus::Material;
   using cyclus::ResCast;
   using cyclus::toolkit::ResBuf;
-  using cyclus::toolkit::Manifest;
 
   if (!ready.empty()) {
     try {


### PR DESCRIPTION
A small change to allow for the removal of the `ResourceBuff` class in cyclus