### PR TITLE
Link against `libxml++` imported target 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Since last release
 **Changed:**
 
 * Rely on ``python3`` in environment instead of ``python`` (#602)
+* Link against ``libxml++`` imported target in CMake instead of ``LIBXMLXX_LIBRARIES`` (#608)
 
 **Fixed:**
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,10 +119,10 @@ IF(NOT CYCLUS_DOC_ONLY)
 
     # Find LibXML++ and dependencies
     pkg_check_modules(LIBXMLXX IMPORTED_TARGET libxml++-4.0)
-    IF ( NOT LIBXMLXX_LIBRARIES )
+    IF ( NOT LIBXMLXX_FOUND )
        pkg_check_modules(LIBXMLXX REQUIRED IMPORTED_TARGET libxml++-2.6)
-    ENDIF ( NOT LIBXMLXX_LIBRARIES )
-    SET(LIBS ${LIBS} ${LIBXMLXX_LIBRARIES})
+    ENDIF ( NOT LIBXMLXX_FOUND )
+    SET(LIBS ${LIBS} PkgConfig::LIBXMLXX)
     message("-- LibXML++ Include Dir: ${LIBXMLXX_INCLUDE_DIRS}")
     message("-- LibXML++ Librarires: ${LIBXMLXX_LIBRARIES}")
 


### PR DESCRIPTION
This change was implemented in cyclus already in https://github.com/cyclus/cyclus/pull/1748.  It resolves issues with linking in a conda-forge feedstock, and issues with linking on MacOS.