### PR TITLE
`SchedDecom()` instead of `Decommission` in `Reactor::Tick()`

### DIFF
--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -145,7 +145,7 @@ void Reactor::Tick() {
       spent.Push(fresh.Pop());
     }
     if(CheckDecommissionCondition()) {
-      Decommission();    
+      context()->SchedDecom(this);    
     }
     return;
   }


### PR DESCRIPTION
Closes #607. 