### PR TITLE
Source can package 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Since last release
 
 **Added:**
 * Added package parameter to storage (#603, #612)
+* Added package parameter to source (#613)
 
 **Changed:**
 

--- a/src/source.cc
+++ b/src/source.cc
@@ -109,7 +109,7 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
     std::vector<double> bids;
     bids.assign(n_full_bids, bid_qty);
 
-    double remaining_qty = std::fmod(qty, bid_qty);
+    double remaining_qty = qty - (n_full_bids * bid_qty);
     if ((remaining_qty > cyclus::eps()) && (remaining_qty >= context()->GetPackage(package)->fill_min())) {
       bids.push_back(remaining_qty);
     }
@@ -165,7 +165,6 @@ void Source::GetMatlTrades(
         // If not all material is packaged successfully, return the excess
         // amount to the inventory
         inventory.Push(m);
-        //inventory_size += m->quantity();
       }
 
       Material::Ptr response;

--- a/src/source.cc
+++ b/src/source.cc
@@ -151,14 +151,9 @@ void Source::GetMatlTrades(
   for (it = trades.begin(); it != trades.end(); ++it) {
     if (shippable_trades > 0) {
       double qty = it->amt;
-      
-      // inventory_size -= qty;
 
       Material::Ptr m = inventory.Pop(qty);
-      if (outrecipe.empty()) {
-        m->Transmute(it->request->target()->comp());
-      }
-
+      
       std::vector<Material::Ptr> m_pkgd = m->Package<Material>(context()->GetPackage(package));
 
       if (m->quantity() > cyclus::eps()) {
@@ -171,6 +166,10 @@ void Source::GetMatlTrades(
       if (m_pkgd.size() > 0) {
         response = m_pkgd[0];
         shippable_trades -= 1;
+      }
+
+      if (outrecipe.empty() && response->comp() != it->request->target()->comp()) {
+        response->Transmute(it->request->target()->comp());
       }
 
       responses.push_back(std::make_pair(*it, response));

--- a/src/source.cc
+++ b/src/source.cc
@@ -164,6 +164,9 @@ void Source::GetMatlTrades(
 
       Material::Ptr response;
       if (m_pkgd.size() > 0) {
+        // Because we responded (in GetMatlBids) with individual package-sized
+        // bids, each packaged vector is guaranteed to have no more than one
+        // package in it. This single packaged resource is our response
         response = m_pkgd[0];
         shippable_trades -= 1;
       }

--- a/src/source.h
+++ b/src/source.h
@@ -67,6 +67,8 @@ class Source : public cyclus::Facility,
       GetMatlBids(cyclus::CommodMap<cyclus::Material>::type&
                   commod_requests);
 
+  virtual void EnterNotify();
+
   virtual void GetMatlTrades(
     const std::vector< cyclus::Trade<cyclus::Material> >& trades,
     std::vector<std::pair<cyclus::Trade<cyclus::Material>,
@@ -117,6 +119,28 @@ class Source : public cyclus::Facility,
   double throughput;
 
   #pragma cyclus var { \
+    "default": "unpackaged", \
+    "tooltip": "name of package to provide material in", \
+    "doc": "Name of package that this source provides. Offers will only be" \
+           "made in packagable quantities of material.", \
+    "uilabel": "Output Package Type", \
+    "uitype": "package", \
+  }
+  std::string package;
+
+  #pragma cyclus var { \
+    "default": "unrestricted", \
+    "tooltip": "name of transport unit to ship packages in", \
+    "doc": "Name of transport unit that this source uses to ship packages of " \
+           "material. Offers will only be made in shippable quantities of " \
+           "packages. Optional if packaging is used, but use of transport " \
+           "units requires packaging type to also be set", \
+    "uilabel": "Output Transport Unit Type", \
+    "uitype": "transportunit", \
+  }
+  std::string transport_unit;
+
+  #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical latitude in degrees as a double", \
     "doc": "Latitude of the agent's geographical position. The value should " \
@@ -132,9 +156,14 @@ class Source : public cyclus::Facility,
   }
   double longitude;
 
+  #pragma cyclus var { \
+    "tooltip":"Material buffer"}
+  cyclus::toolkit::ResBuf<cyclus::Material> inventory;
+
   cyclus::toolkit::Position coordinates;
 
   void RecordPosition();
+  void SetPackage();
 };
 
 }  // namespace cycamore

--- a/src/source_tests.cc
+++ b/src/source_tests.cc
@@ -172,8 +172,6 @@ TEST_F(SourceTest, Package) {
   
   sim.context()->AddPackage(package_name, 3, 4, "first");
   package = sim.context()->GetPackage(package_name);
-  // sim.context()->AddTransportUnit(tu_name, 1, 2, "hybrid");
-  // tu = sim.context()->GetTransportUnit(tu_name);
   
   sim.AddSink("commod").Finalize();
 
@@ -186,8 +184,41 @@ TEST_F(SourceTest, Package) {
   conds.push_back(Cond("PackageName", "==", package->name()));
   QueryResult qr_res = sim.db().Query("Resources", &conds);
 
-  EXPECT_EQ(qr_res.rows.size(), 3);
-    
+  EXPECT_EQ(qr_res.rows.size(), 3); 
+}
+
+TEST_F(SourceTest, TransportUnit) {
+  using cyclus::QueryResult;
+  using cyclus::Cond;
+
+  std::string config =
+    "<outcommod>commod</outcommod>"
+    "<package>testpackage</package>"
+    "<transport_unit>testtu</transport_unit>"
+    "<throughput>10</throughput>";
+
+  int simdur = 2;
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Source"), config, simdur);
+  
+  sim.context()->AddPackage(package_name, 3, 4, "equal");
+  package = sim.context()->GetPackage(package_name);
+  sim.context()->AddTransportUnit(tu_name, 2, 2);
+  tu = sim.context()->GetTransportUnit(tu_name);
+  
+  sim.AddSink("commod").Finalize();
+
+  EXPECT_NO_THROW(sim.Run());
+
+  QueryResult qr_tr = sim.db().Query("Transactions", NULL);
+  EXPECT_EQ(qr_tr.rows.size(), 4);
+  
+  std::vector<Cond> conds;
+  conds.push_back(Cond("PackageName", "==", package->name()));
+  QueryResult qr_res = sim.db().Query("Resources", &conds);
+
+  EXPECT_EQ(qr_res.rows.size(), 4);
+
+  QueryResult qr_allres = sim.db().Query("Resources", NULL);
 }
 
 boost::shared_ptr< cyclus::ExchangeContext<cyclus::Material> >

--- a/src/source_tests.h
+++ b/src/source_tests.h
@@ -19,9 +19,11 @@ class SourceTest : public ::testing::Test {
   cyclus::TestContext tc;
   TestFacility* trader;
   cycamore::Source* src_facility;
-  std::string commod, recipe_name;
+  std::string commod, recipe_name, package_name, tu_name;
   double capacity;
   cyclus::Composition::Ptr recipe;
+  cyclus::Package::Ptr package;
+  cyclus::TransportUnit::Ptr tu;
 
   virtual void SetUp();
   virtual void TearDown();


### PR DESCRIPTION
Adds the ability for source to provide materials that are packaged.

Along the way, I also converted Source to a ResBuf facility. This means that the full inventory is created at the `EnterNotify` step and placed into the inventory buffer, then persists throughout the simulation. Previously, material never existed until the moment it was about to be traded, when it would be created. Source just maintained a number that represented the inventory at hand.

This change is generally minor, but it makes packaging easier. Without pre-existing resources in a buffer, trades would be executed by created materials, trying to package them, and then in the rare case where the trade has some leftover material that can't be packaged (rare, and specifically only exists in cases where the requesting agent accepted a partial bid), then you're left with material that was already created but no buffer to place it back into..

This also allows sources to show up on explicit inventory tables, which is something I've wanted for a while anyway, so happy side benefit.