### PR TITLE
Adding transport units to Storage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Since last release
 ======================
 
 **Added:**
-* Added package parameter to storage (#603, #612)
+* Added package parameter to storage (#603, #612, #616)
 * Added package parameter to source (#613, #617)
 
 **Changed:**

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -183,9 +183,10 @@ void Storage::EnterNotify() {
   buy_policy.Start();
 
   std::string package_name_ =  context()->GetPackage(package)->name();
+  std::string tu_name_ = context()->GetTransportUnit(transport_unit)->name();
   if (out_commods.size() == 1) {
     sell_policy.Init(this, &stocks, std::string("stocks"), 1e+299, false,
-                     sell_quantity, package_name_)
+                     sell_quantity, package_name_, tu_name_)
       .Set(out_commods.front())
       .Start();
 

--- a/src/storage.h
+++ b/src/storage.h
@@ -437,6 +437,14 @@ class Storage
                       "uilabel": "Package"}
   std::string package;
 
+  #pragma cyclus var {"default": "unrestricted", \
+                      "tooltip": "Output transport unit", \
+                      "doc": "Outgoing material, after packaging, will be "\
+                      "further restricted by transport unit when trading.", \
+                      "uitype": "transportunit", \
+                      "uilabel": "Transport Unit"}
+  std::string transport_unit;
+
   #pragma cyclus var {"tooltip":"Incoming material buffer"}
   cyclus::toolkit::ResBuf<cyclus::Material> inventory;
 


### PR DESCRIPTION
Adds a new parameter to Storage to take advantage of the transport unit capability in the material sell policy.

Closes #557 