### PR TITLE
add recipes to source packaging tests to avoid undesired transmutation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Since last release
 
 **Added:**
 * Added package parameter to storage (#603, #612)
-* Added package parameter to source (#613)
+* Added package parameter to source (#613, #617)
 
 **Changed:**
 

--- a/src/source_tests.cc
+++ b/src/source_tests.cc
@@ -164,12 +164,14 @@ TEST_F(SourceTest, Package) {
 
   std::string config =
     "<outcommod>commod</outcommod>"
+    "<outrecipe>recipe</outrecipe>"
     "<package>testpackage</package>"
     "<throughput>5</throughput>";
 
   int simdur = 3;
   cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Source"), config, simdur);
   
+  sim.context()->AddRecipe(recipe_name, recipe);
   sim.context()->AddPackage(package_name, 3, 4, "first");
   package = sim.context()->GetPackage(package_name);
   
@@ -193,6 +195,7 @@ TEST_F(SourceTest, TransportUnit) {
 
   std::string config =
     "<outcommod>commod</outcommod>"
+    "<outrecipe>recipe</outrecipe>"
     "<package>testpackage</package>"
     "<transport_unit>testtu</transport_unit>"
     "<throughput>10</throughput>";
@@ -200,6 +203,7 @@ TEST_F(SourceTest, TransportUnit) {
   int simdur = 2;
   cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Source"), config, simdur);
   
+  sim.context()->AddRecipe(recipe_name, recipe);
   sim.context()->AddPackage(package_name, 3, 4, "equal");
   package = sim.context()->GetPackage(package_name);
   sim.context()->AddTransportUnit(tu_name, 2, 2);


### PR DESCRIPTION
I figured out why tests in #613 failed. After playing with it a bit, I kept getting results where the number of packaged resources was twice the number of transactions, which didn't make sense (every packaged resource should only be packaged in order to fulfill one transaction). 

Then I realized that my tests didn't include an outrecipe, and the Mock Sink in the Mock Sim was for some reason requesting a different mock composition. So, immediately before trading, the Source transmuted the composition to the request composition, which creates a new line in the resource table, because the composition id (QualId I think) changed. 

This is exactly the kind of extra and confusing resource database entries I mentioned above!

However, I still think it makes sense that resource should only be transmuted _after_ they are packaged and ready to go, because we don't want to do transmuting until we're sure that the packaging will work. Which it normally will, but this keeps coming back to the challenge of requesting agents accepting partial-sized bids, which creates the chance of a failed trade by being an unpackagable amount.

In this case, I solved the issue by creating an outrecipe in my tests.