### PR TITLE
Fix error in keep_packaging defaults

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Since last release
 **Added:**
 * Added package parameter to storage (#603, #612, #616)
 * Added package parameter to source (#613, #617)
-* Added default keep packaging to reactor (#618)
+* Added default keep packaging to reactor (#618, #619)
 
 **Changed:**
 

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -408,7 +408,7 @@ class Reactor : public cyclus::Facility,
   std::vector<double> pref_change_values;
 
   #pragma cyclus var { \
-    "default": true, \
+    "default": True, \
     "tooltip": "Whether to persist packaging throughout the reactor", \
     "doc": "Boolean value about whether to keep packaging. If true, " \
            "packaging will not be stripped upon acceptance into the " \

--- a/src/sink.h
+++ b/src/sink.h
@@ -258,7 +258,7 @@ class Sink
   int random_frequency_max;
 
   #pragma cyclus var { \
-    "default": true, \
+    "default": True, \
     "tooltip": "Whether to persist packaging in the sink.", \
     "doc": "Boolean value about whether to keep packaging. If true, " \
            "packaging will not be stripped upon acceptance into the " \


### PR DESCRIPTION
default needs to be `True` not `true` for cycamore to build