### PR TITLE
prevent underflow when not enough material is available to make a packagable bid

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Since last release
 
 **Added:**
 * Added package parameter to storage (#603, #612, #616)
-* Added package parameter to source (#613, #617)
+* Added package parameter to source (#613, #617, #621)
 * Added default keep packaging to reactor (#618, #619)
 
 **Changed:**

--- a/src/source.cc
+++ b/src/source.cc
@@ -102,11 +102,9 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
     double qty = std::min(target->quantity(), max_qty);
 
     // calculate packaging
-    double bid_qty = context()->GetPackage(package)->GetFillMass(qty);
-    int n_full_bids = 0;
-    if (bid_qty >= context()->GetPackage(package)->fill_min()) {
-      n_full_bids = static_cast<int>(std::floor(qty / bid_qty));
-    }
+    std::pair<double, int> fill = context()->GetPackage(package)->GetFillMass(qty);
+    double bid_qty = fill.first;
+    int n_full_bids = fill.second;
     Package::ExceedsSplitLimits(n_full_bids);
 
     std::vector<double> bids;

--- a/src/source.cc
+++ b/src/source.cc
@@ -103,7 +103,10 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
 
     // calculate packaging
     double bid_qty = context()->GetPackage(package)->GetFillMass(qty);
-    int n_full_bids = static_cast<int>(std::floor(qty / bid_qty));
+    int n_full_bids = 0;
+    if (bid_qty >= context()->GetPackage(package)->fill_min()) {
+      n_full_bids = static_cast<int>(std::floor(qty / bid_qty));
+    }
     Package::ExceedsSplitLimits(n_full_bids);
 
     std::vector<double> bids;


### PR DESCRIPTION
`n_full_bids` could result in negative int max when `bid_qty` = 0, when it should be zero

~~Requires [cyclus#1790](https://github.com/cyclus/cyclus/pull/1790) to be merged first!~~ (merged)