### PR TITLE
movements of resources from ready to stocks is not INFO1 importance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Since last release
 
 * Schedule Decommission in ``Reactor::Tick()`` instead of Decommission (#609)
 * When trades fail in Source due to packaging, send empty material instead of seg faulting (#629)
+* Logging of resource moves between ResBufs in Storage is INFO4 not INFO1 (#625)
 
 **Removed:**
 

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -334,7 +334,7 @@ void Storage::ProcessMat_(double cap) {
         stocks.Push(ready.Pop(max_pop, cyclus::eps_rsrc()));
       }
 
-      LOG(cyclus::LEV_INFO1, "ComCnv") << "Storage " << prototype()
+      LOG(cyclus::LEV_INFO4, "ComCnv") << "Storage " << prototype()
                                        << " moved resources"
                                        << " from ready to stocks"
                                        << " at t= " << context()->time();


### PR DESCRIPTION
The only thing that shows up in my terminal when I run simulations with verbosity 2 is the time step... and a single logging function in Storage, `Storage prototype() moved resources from ready to stocks at t=->time()`.

Moving resources between ResBufs is not a `LEV_INFO1` level of logging, and most (all?) other archetypes don't log anything above `LEV_INFO3`. Changed to a level commensurate with the logging of other ResBuf moves in Storage