### PR TITLE
update call to Package::GetFillMass

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Since last release
 
 **Added:**
 * Added package parameter to storage (#603, #612, #616)
-* Added package parameter to source (#613, #617, #621, #623)
+* Added package parameter to source (#613, #617, #621, #623, #630)
 * Added default keep packaging to reactor (#618, #619)
 
 **Changed:**

--- a/src/source.cc
+++ b/src/source.cc
@@ -107,18 +107,7 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
     double qty = std::min(target->quantity(), max_qty);
 
     // calculate packaging
-    std::pair<double, int> fill = context()->GetPackage(package)->GetFillMass(qty);
-    double bid_qty = fill.first;
-    int n_full_bids = fill.second;
-    Package::ExceedsSplitLimits(n_full_bids);
-
-    std::vector<double> bids;
-    bids.assign(n_full_bids, bid_qty);
-
-    double remaining_qty = qty - (n_full_bids * bid_qty);
-    if ((remaining_qty > cyclus::eps()) && (remaining_qty >= context()->GetPackage(package)->fill_min())) {
-      bids.push_back(remaining_qty);
-    }
+    std::vector<double> bids = context()->GetPackage(package)->GetFillMass(qty);
 
     // calculate transport units
     int shippable_pkgs = context()->GetTransportUnit(transport_unit)


### PR DESCRIPTION
Must be merged after [cyclus#1813](https://github.com/cyclus/cyclus/pull/1813). Tests on latest should be re-run and should pass after that's merged