### PR TITLE
Add link to fuelcycle.org to doxygen homepage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Since last release
 * Update archetype definitions to use cyclus constants instead of arbitrary hardcoded values (#606)
 * Changed the styling of doxygen docs (#626)
 * Use ``CyclusBuildSetup`` macros to replace CMake boilerplate (#627)
+* Updated Doxygen homepage (#632)
 
 **Fixed:**
 

--- a/src/cycamore.h
+++ b/src/cycamore.h
@@ -6,6 +6,7 @@
  * \mainpage Cycamore API Reference
  *
  * Welcome to the Cycamore API reference! Below are some helpful links for learning more:
+ *   - Cyclus Homepage: https://fuelcycle.org
  *   - GitHub repository: https://github.com/cyclus/cycamore
  *   - Kernel developer guide: https://fuelcycle.org/kernel
  *   - Archetype developer guide: https://fuelcycle.org/arche


### PR DESCRIPTION
Partially addresses https://github.com/cyclus/cyclus.github.com/issues/389 in conjunction with https://github.com/cyclus/cyclus/pull/1815