### PR TITLE
Remove Libxml++ requirement from build

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Since last release
 **Removed:**
 
 * Removed references to deprecated ``ResourceBuff`` class (#604)
+* Removed ``Libxml++`` from build requirements (#634)
 
 
 v1.6.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,15 +70,6 @@ IF(NOT CYCLUS_DOC_ONLY)
     # Include macros installed with cyclus core
     INCLUDE(UseCyclus)
 
-    # Find LibXML++ and dependencies
-    pkg_check_modules(LIBXMLXX IMPORTED_TARGET libxml++-4.0)
-    IF ( NOT LIBXMLXX_FOUND )
-       pkg_check_modules(LIBXMLXX REQUIRED IMPORTED_TARGET libxml++-2.6)
-    ENDIF ( NOT LIBXMLXX_FOUND )
-    SET(LIBS ${LIBS} PkgConfig::LIBXMLXX)
-    message("-- LibXML++ Include Dir: ${LIBXMLXX_INCLUDE_DIRS}")
-    message("-- LibXML++ Librarires: ${LIBXMLXX_LIBRARIES}")
-
     # Include the boost header files and the program_options library
     # Please be sure to use Boost rather than BOOST.
     # Capitalization matters on some platforms


### PR DESCRIPTION
I was working on the cycamore_dev conda build and it demonstrated to me that we don't actually need Libxml++ to build cycamore.  This PR removes it as a CMake build requirement