### PR TITLE
support for binomial active/dormant in storage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Since last release
 * Added package parameter to source (#613, #617, #621, #623, #630)
 * Added default keep packaging to reactor (#618, #619)
 * Added support for Ubuntu 24.04 (#633)
+* Added (negative)binomial distributions for disruption modeling to storage (#635) 
 
 **Changed:**
 

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -78,6 +78,13 @@ void Storage::InitBuyPolicyParameters() {
     active_dist_ = cyclus::NormalIntDist::Ptr (new cyclus::NormalIntDist(active_buying_mean, active_buying_stddev,
                           active_buying_min, active_buying_max));
   }
+  else if (active_buying_frequency_type == "Binomial") {
+    if (active_buying_end_probability < 0 || active_buying_end_probability > 1) {
+      throw cyclus::ValueError("Active buying end probability must be between 0 and 1");
+    }
+    int success = 1; // only one success is needed to end the active buying period
+    active_dist_ = cyclus::NegativeBinomialIntDist::Ptr (new cyclus::NegativeBinomialIntDist(success, active_buying_end_probability));
+  }
   else {
     throw cyclus::ValueError("Invalid active buying frequency type");}
 
@@ -100,6 +107,13 @@ void Storage::InitBuyPolicyParameters() {
       dormant_buying_max = std::numeric_limits<int>::max();}
     dormant_dist_ = cyclus::NormalIntDist::Ptr (new cyclus::NormalIntDist(dormant_buying_mean, dormant_buying_stddev,
                           dormant_buying_min, dormant_buying_max));
+  }
+  else if (dormant_buying_frequency_type == "Binomial") {
+    if (dormant_buying_end_probability < 0 || dormant_buying_end_probability > 1) {
+      throw cyclus::ValueError("Dormant buying end probability must be between 0 and 1");
+    }
+    int success = 1; // only one success is needed to end the dormant buying period
+    dormant_dist_ = cyclus::NegativeBinomialIntDist::Ptr (new cyclus::NegativeBinomialIntDist(success, dormant_buying_end_probability));
   }
   else {
     throw cyclus::ValueError("Invalid dormant buying frequency type");}

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -84,6 +84,13 @@ void Storage::InitBuyPolicyParameters() {
     }
     int success = 1; // only one success is needed to end the active buying period
     active_dist_ = cyclus::NegativeBinomialIntDist::Ptr (new cyclus::NegativeBinomialIntDist(success, active_buying_end_probability));
+  } else if (active_buying_frequency_type == "FixedWithDisruption") {
+    if (active_buying_disruption < 0) {
+      throw cyclus::ValueError("Disruption must be greater than or equal to 0");
+    }
+    active_dist_ = cyclus::BinaryIntDist::Ptr (
+      new cyclus::BinaryIntDist(active_buying_disruption_probability,
+      active_buying_disruption, active_buying_val));
   }
   else {
     throw cyclus::ValueError("Invalid active buying frequency type");}
@@ -114,6 +121,13 @@ void Storage::InitBuyPolicyParameters() {
     }
     int success = 1; // only one success is needed to end the dormant buying period
     dormant_dist_ = cyclus::NegativeBinomialIntDist::Ptr (new cyclus::NegativeBinomialIntDist(success, dormant_buying_end_probability));
+  } else if (dormant_buying_frequency_type == "FixedWithDisruption") {
+    if (dormant_buying_disruption < 0) {
+      throw cyclus::ValueError("Disruption must be greater than or equal to 0");
+    }
+    dormant_dist_ = cyclus::BinaryIntDist::Ptr (
+      new cyclus::BinaryIntDist(dormant_buying_disruption_probability,
+      dormant_buying_disruption, dormant_buying_val));
   }
   else {
     throw cyclus::ValueError("Invalid dormant buying frequency type");}

--- a/src/storage.h
+++ b/src/storage.h
@@ -234,12 +234,17 @@ class Storage
 
   #pragma cyclus var {"default": "Fixed",\
                       "tooltip": "Type of active buying frequency",\
-                      "doc": "Options: Fixed, Uniform, Normal, Binomial. Fixed requires active_buying_val. Uniform "\
+                      "doc": "Options: Fixed, Uniform, Normal, Binomial, FixedWithDisruption. "\
+                      "Fixed requires active_buying_val. Uniform "\
                       "requires active_buying_min and active_buying_max.  Normal "\
                       "requires active_buying_mean and active_buying_std, with optional "\
-                      "active_buying_min and active_buying_max. Binomial requires active_buying_end_probability.",\
+                      "active_buying_min and active_buying_max. Binomial requires active_buying_end_probability."\
+                      "FixedWithDisruption has a probability that any given cycle will have a disrupted, "\
+                      "active length.  Once per cycle, a Bernoulli distribution (Binomial dist "\
+                      "with N=1) will be sampled to determine if typical or disrupted cycle. If typical, "\
+                      "active_buying_val is cycle length. If disrupted, active_buying_disruption.",\
                       "uitype": "combobox",\
-                      "categorical": ["Fixed", "Uniform", "Normal", "Binomial"],\
+                      "categorical": ["Fixed", "Uniform", "Normal", "Binomial", "FixedWithDisruption"],\
                       "uilabel": "Active Buying Frequency Type"}
   std::string active_buying_frequency_type;
 
@@ -300,14 +305,36 @@ class Storage
                       "uilabel": "Active Buying Offline Probability"}
   double active_buying_end_probability;
 
+  #pragma cyclus var {"default": 0,\
+                      "tooltip": "Probability that a cycle contains a disruption",\
+                      "doc": "Probability that the agent undergoes a disruption (disrupted active period) "\
+                      "during any given cycle. Required for FixedWithDisruption active_buying_frequency_type.",\
+                      "uitype": "range",\
+                      "range": [0.0, 1.0],\
+                      "uilabel": "Active Buying Disruption Probability"}
+  double active_buying_disruption_probability;
+
+  #pragma cyclus var {"default": -1,\
+                      "tooltip": "Fixed length of disrupted active cycle",\
+                      "doc": "When a active cycle is disrupted, this is length of the active period instead "\
+                      "of active_buying_val. Required for FixedWithDisruption active_buying_frequency_type",\
+                      "uitype": "range",\
+                      "range": [0, CY_LARGE_INT]}
+  int active_buying_disruption;
+
   #pragma cyclus var {"default": "Fixed",\
                       "tooltip": "Type of dormant buying frequency",\
-                      "doc": "Options: Fixed, Uniform, Normal, Binomial. Fixed requires dormant_buying_val. "\
+                      "doc": "Options: Fixed, Uniform, Normal, Binomial, FixedWithDisruption. "\
+                      "Fixed requires dormant_buying_val. "\
                       "Uniform requires dormant_buying_min and dormant_buying_max. Normal requires "\
                       "dormant_buying_mean and dormant_buying_std, with optional dormant_buying_min "\
-                      "and dormant_buying_max. Binomial requires dormant_buying_end_probability.",\
+                      "and dormant_buying_max. Binomial requires dormant_buying_end_probability. "\
+                      "FixedWithDisruption has a probability that any given cycle will have a disrupted, "\
+                      "or long, outage.  Once per cycle, a Bernoulli distribution (Binomial dist "\
+                      "with N=1) will be sampled to determine if typical or disrupted cycle. If typical, "\
+                      "dormant_buying_val is cycle length. If disrupted, dormant_buying_disruption.",\
                       "uitype": "combobox",\
-                      "categorical": ["Fixed", "Uniform", "Normal", "Binomial"],\
+                      "categorical": ["Fixed", "Uniform", "Normal", "Binomial", "FixedWithDisruption"],\
                       "uilabel": "Dormant Buying Frequency Type"}
   std::string dormant_buying_frequency_type;
 
@@ -363,8 +390,25 @@ class Storage
                       "Must be between 0 and 1",\
                       "uitype": "range", \
                       "range": [0.0, 1.0], \
-                      "uilabel": "Dormant Buying Offline Probability"}
+                      "uilabel": "Dormant Buying Binomial Offline Probability"}
   double dormant_buying_end_probability;
+
+  #pragma cyclus var {"default": 0,\
+                      "tooltip": "Probability that a cycle contains a disruption",\
+                      "doc": "Probability that the agent undergoes a disruption (longer offline period) "\
+                      "during any given cycle. Required for FixedWithDisruption dormant_buying_frequency_type.",\
+                      "uitype": "range",\
+                      "range": [0.0, 1.0],\
+                      "uilabel": "Dormant Buying Disruption Probability"}
+  double dormant_buying_disruption_probability;
+
+  #pragma cyclus var {"default": -1,\
+                      "tooltip": "Fixed length of disrupted cycle",\
+                      "doc": "When a dormant cycle is disrupted, this is length of the offline period instead "\
+                      "of dormant_buying_val. Required for FixedWithDisruption dormant_buying_frequency_type",\
+                      "uitype": "range",\
+                      "range": [0, CY_LARGE_INT]}
+  int dormant_buying_disruption;
 
   #pragma cyclus var {"default": "Fixed",\
                       "tooltip": "Type of behavior used to determine size of buy request",\

--- a/src/storage.h
+++ b/src/storage.h
@@ -234,12 +234,12 @@ class Storage
 
   #pragma cyclus var {"default": "Fixed",\
                       "tooltip": "Type of active buying frequency",\
-                      "doc": "Options: Fixed, Uniform, Normal. Fixed requires active_buying_val. Uniform "\
+                      "doc": "Options: Fixed, Uniform, Normal, Binomial. Fixed requires active_buying_val. Uniform "\
                       "requires active_buying_min and active_buying_max.  Normal "\
                       "requires active_buying_mean and active_buying_std, with optional "\
-                      "active_buying_min and active_buying_max.",\
+                      "active_buying_min and active_buying_max. Binomial requires active_buying_end_probability.",\
                       "uitype": "combobox",\
-                      "categorical": ["Fixed", "Uniform", "Normal"],\
+                      "categorical": ["Fixed", "Uniform", "Normal", "Binomial"],\
                       "uilabel": "Active Buying Frequency Type"}
   std::string active_buying_frequency_type;
 
@@ -290,14 +290,24 @@ class Storage
                       "uilabel": "Active Buying Frequency Standard Deviation"}
   double active_buying_stddev;
 
+  #pragma cyclus var {"default": 0,\
+                      "tooltip": "Probability that agent will go offline during the next time step",\
+                      "doc": "Binomial distribution has a fixed probability of going dormant at any given "\
+                      "timestep, like a weighted coin flip. Required for Binomial active_buying_frequency_type. "\
+                      "Must be between 0 and 1",\
+                      "uitype": "range", \
+                      "range": [0.0, 1.0], \
+                      "uilabel": "Active Buying Offline Probability"}
+  double active_buying_end_probability;
+
   #pragma cyclus var {"default": "Fixed",\
                       "tooltip": "Type of dormant buying frequency",\
-                      "doc": "Options: Fixed, Uniform, Normal. Fixed requires dormant_buying_val. Uniform "\
-                      "requires dormant_buying_min and dormant_buying_max. Normal requires "\
+                      "doc": "Options: Fixed, Uniform, Normal, Binomial. Fixed requires dormant_buying_val. "\
+                      "Uniform requires dormant_buying_min and dormant_buying_max. Normal requires "\
                       "dormant_buying_mean and dormant_buying_std, with optional dormant_buying_min "\
-                      "and dormant_buying_max.",\
+                      "and dormant_buying_max. Binomial requires dormant_buying_end_probability.",\
                       "uitype": "combobox",\
-                      "categorical": ["Fixed", "Uniform", "Normal"],\
+                      "categorical": ["Fixed", "Uniform", "Normal", "Binomial"],\
                       "uilabel": "Dormant Buying Frequency Type"}
   std::string dormant_buying_frequency_type;
 
@@ -345,6 +355,16 @@ class Storage
                       "range": [0.0, CY_LARGE_DOUBLE], \
                       "uilabel": "Dormant Buying Frequency Standard Deviation"}
   double dormant_buying_stddev;
+
+  #pragma cyclus var {"default": 0,\
+                      "tooltip": "Probability that agent will return to active during the next time step",\
+                      "doc": "Binomial distribution has a fixed probability of going active at any given "\
+                      "timestep, like a weighted coin flip. Required for Binomial dormant_buying_frequency_type. "\
+                      "Must be between 0 and 1",\
+                      "uitype": "range", \
+                      "range": [0.0, 1.0], \
+                      "uilabel": "Dormant Buying Offline Probability"}
+  double dormant_buying_end_probability;
 
   #pragma cyclus var {"default": "Fixed",\
                       "tooltip": "Type of behavior used to determine size of buy request",\

--- a/src/storage.h
+++ b/src/storage.h
@@ -61,9 +61,11 @@ namespace cycamore {
 /// dormant_buying_mean is the mean length of the dormant buying period if dormant_buying_frequency_type is Normal
 /// dormant_buying_std is the standard deviation of the dormant buying period if dormant_buying_frequency_type is Normal
 /// dormant_buying_end_probability is the probability that at any given timestep, the agent ends the dormant buying period if
-/// the dormant buying frequency type is Binomial
+///                               the dormant buying frequency type is Binomial
 /// dormant_buying_disruption_probability is the probability that in any given cycle, the agent undergoes a disruption (disrupted
-/// offline period) if the dormant buying frequency type is FixedWithDisruption
+///                               offline period) if the dormant buying frequency type is FixedWithDisruption
+/// dormant_buying_disruption is the length of the disrupted dormant cycle if the dormant buying frequency type is 
+///                               FixedWithDisruption
 /// buying_size_type is the type of distribution used to determine the size of buy requests, as a fraction of the current capacity
 /// buying_size_val is the size of the buy request for Fixed  buying_size_type
 /// buying_size_min is the minimum size of the buy request if buying_size_type is Uniform (required) or Normal (optional)

--- a/src/storage.h
+++ b/src/storage.h
@@ -46,6 +46,11 @@ namespace cycamore {
 /// Normal (optional)
 /// active_buying_mean is the mean length of the active buying period if active_buying_frequency_type is Normal
 /// active_buying_std is the standard deviation of the active buying period if active_buying_frequency_type is Normal
+/// active_buying_end_probability is the probability that at any given timestep, the agent ends the active buying period if
+/// the active buying frequency type is Binomial
+/// active_buying_disruption_probability is the probability that in any given cycle, the agent undergoes a disruption (disrupted 
+/// active period) if the active buying frequency type is FixedWithDisruption
+/// active_buying_disruption is the length of the disrupted active cycle if the active buying frequency type is FixedWithDisruption
 /// dormant_buying_frequency_type is the type of distribution used to determine the length of the dormant buying period
 /// dormant_buying_val is the length of the dormant buying period if dormant_buying_frequency_type is Fixed
 /// dormant_buying_min is the minimum length of the dormant buying period if dormant_buying_frequency_type is Uniform (required) or
@@ -54,6 +59,10 @@ namespace cycamore {
 /// Normal (optional)
 /// dormant_buying_mean is the mean length of the dormant buying period if dormant_buying_frequency_type is Normal
 /// dormant_buying_std is the standard deviation of the dormant buying period if dormant_buying_frequency_type is Normal
+/// dormant_buying_end_probability is the probability that at any given timestep, the agent ends the dormant buying period if
+/// the dormant buying frequency type is Binomial
+/// dormant_buying_disruption_probability is the probability that in any given cycle, the agent undergoes a disruption (disrupted
+/// offline period) if the dormant buying frequency type is FixedWithDisruption
 /// buying_size_type is the type of distribution used to determine the size of buy requests, as a fraction of the current capacity
 /// buying_size_val is the size of the buy request for Fixed  buying_size_type
 /// buying_size_min is the minimum size of the buy request if buying_size_type is Uniform (required) or Normal (optional)

--- a/src/storage.h
+++ b/src/storage.h
@@ -46,11 +46,12 @@ namespace cycamore {
 /// Normal (optional)
 /// active_buying_mean is the mean length of the active buying period if active_buying_frequency_type is Normal
 /// active_buying_std is the standard deviation of the active buying period if active_buying_frequency_type is Normal
-/// active_buying_end_probability is the probability that at any given timestep, the agent ends the active buying period if
-/// the active buying frequency type is Binomial
-/// active_buying_disruption_probability is the probability that in any given cycle, the agent undergoes a disruption (disrupted 
-/// active period) if the active buying frequency type is FixedWithDisruption
-/// active_buying_disruption is the length of the disrupted active cycle if the active buying frequency type is FixedWithDisruption
+/// active_buying_end_probability is the probability that at any given timestep, the agent ends the active buying 
+///                               period if the active buying frequency type is Binomial
+/// active_buying_disruption_probability is the probability that in any given cycle, the agent undergoes a disruption 
+///                               (disrupted active period) if the active buying frequency type is FixedWithDisruption
+/// active_buying_disruption is the length of the disrupted active cycle if the active buying frequency type is 
+///                               FixedWithDisruption
 /// dormant_buying_frequency_type is the type of distribution used to determine the length of the dormant buying period
 /// dormant_buying_val is the length of the dormant buying period if dormant_buying_frequency_type is Fixed
 /// dormant_buying_min is the minimum length of the dormant buying period if dormant_buying_frequency_type is Uniform (required) or


### PR DESCRIPTION
Adds the ability to use a binomial distribution to active and dormant cycles which requires one parameter, the probability that any individual time step would end the current cycle. This is specifically useful for disruption modeling, where you can assume that at every time step there is some very small chance that the agent goes offline (i.e. dormant) and vice versa for dormant.

This is a negative binomial distribution (since we're sampling the number of trials until n successes, rather than sampling the successes in n trials), in the specific case where the number of successes is always one. This is equal to a geometric distribution, but since negative binomial is more generic that's what is implemented in [cyclus#1841](https://github.com/cyclus/cyclus/pull/1821) and used here. Note that like a coin toss, every time step is independent and has the same probability, `active_buying_end_probability` (or dormant)

Requires [cyclus#1841](https://github.com/cyclus/cyclus/pull/1821) to be merged first