### PR TITLE
Support Boost 1.86

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Since last release
 * Added package parameter to source (#613, #617, #621, #623, #630)
 * Added default keep packaging to reactor (#618, #619)
 * Added support for Ubuntu 24.04 (#633)
-* Added (negative)binomial distributions for disruption modeling to storage (#635) 
+* Added (negative)binomial distributions for disruption modeling to storage (#635)
 
 **Changed:**
 
@@ -27,6 +27,7 @@ Since last release
 * Schedule Decommission in ``Reactor::Tick()`` instead of Decommission (#609)
 * When trades fail in Source due to packaging, send empty material instead of seg faulting (#629)
 * Logging of resource moves between ResBufs in Storage is INFO4 not INFO1 (#625)
+* Support Boost>=1.86.0 (#637)
 
 **Removed:**
 
@@ -43,10 +44,10 @@ v1.6.0
 * GitHub workflow for publishing images and debian packages on release (#573, #582, #583, #593)
 * GitHub workflows for building/testing on a PR and push to `main` (#549, #564, #573, #582, #583, #590)
 * Add functionality for random behavior on the size (#550) and frequency (#565) of a sink
-* GitHub workflow to check that the CHANGELOG has been updated (#562) 
+* GitHub workflow to check that the CHANGELOG has been updated (#562)
 * Added inventory policies to Storage through the material buy policy (#574, #588)
 
-**Changed:** 
+**Changed:**
 
 * Updated build procedure to use newer versions of packages and compilers in 2023 (#549, #596, #599)
 * Added active/dormant and request size variation from buy policy to Storage (#546, #568, #586, #587)
@@ -72,12 +73,12 @@ v1.5.4
 
 * RecordTimeSeries has been added to the several archetypes; Reactor, Source, Sink,
   FuelFab, Separations, and Storage. This change was made to allow these agents to
-  interact with the d3ploy archetypes. 
+  interact with the d3ploy archetypes.
 * Added unit tests for Cycamore archetypes with Position toolkit.
 
 * Record function for Cycamore archetypes' coordinates in Sqlite Output.
 
-**Changed:** 
+**Changed:**
 
 - All cycamore archetypes have been edited to now include Cyclus::toolkit::Position.
 
@@ -88,7 +89,3 @@ v1.5.3
 **Changed:**
 
 * Many build system improvements, including making COIN optional.
-
-
-
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ IF(NOT CYCLUS_DOC_ONLY)
     MESSAGE("--    Boost Filesystem location: ${Boost_FILESYSTEM_LIBRARY}")
     SET(LIBS ${LIBS} ${Boost_SERIALIZATION_LIBRARY})
     MESSAGE("--    Boost Serialization location: ${Boost_SERIALIZATION_LIBRARY}")
+    ADD_DEFINITIONS(-DBOOST_VERSION_MINOR=${Boost_VERSION_MINOR})
 
     # find lapack and link to it
     # note there is no include directory variable:


### PR DESCRIPTION
Adds a `-DBOOST_VERSION_MINOR` definition to support changes in https://github.com/cyclus/cyclus/pull/1792.