### PR TITLE
Remove Manual Definition of Position from Cycamore

### DIFF
--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -5,9 +5,8 @@ namespace cycamore {
 
 DeployInst::DeployInst(cyclus::Context* ctx)
     : cyclus::Institution(ctx),
-      latitude(0.0),
-      longitude(0.0),
-      coordinates(latitude, longitude) {}
+    latitude(0.0),
+    longitude(0.0) {}
 
 DeployInst::~DeployInst() {}
 
@@ -65,7 +64,8 @@ void DeployInst::EnterNotify() {
        << " lifetimes vals, expected " << n;
     throw cyclus::ValueError(ss.str());
   }
-  RecordPosition();
+
+  InitializePosition(this);
 }
 
 void DeployInst::BuildNotify(Agent* a) {
@@ -117,18 +117,6 @@ void DeployInst::WriteProducerInformation(
     LOG(cyclus::LEV_DEBUG3, "maninst") << "               cost: " <<
                                        producer->Cost(*it);
   }
-}
-
-void DeployInst::RecordPosition() {
-  std::string specification = this->spec();
-  context()
-      ->NewDatum("AgentPosition")
-      ->AddVal("Spec", specification)
-      ->AddVal("Prototype", this->prototype())
-      ->AddVal("AgentId", id())
-      ->AddVal("Latitude", latitude)
-      ->AddVal("Longitude", longitude)
-      ->Record();
 }
 
 extern "C" cyclus::Agent* ConstructDeployInst(cyclus::Context* ctx) {

--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -101,26 +101,9 @@ class DeployInst :
   std::vector<int> lifetimes;
 
  private:
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double latitude;
+  // Code Injection:
+  #include "toolkit/position.cycpp.h"
 
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double longitude;
-
-  cyclus::toolkit::Position coordinates;
-
-  /// Records an agent's latitude and longitude to the output db
-  void RecordPosition();
 };
 
 }  // namespace cycamore

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -24,10 +24,9 @@ Enrichment::Enrichment(cyclus::Context* ctx)
       feed_recipe(""),
       product_commod(""),
       tails_commod(""),
-      order_prefs(true),
       latitude(0.0),
       longitude(0.0),
-      coordinates(latitude, longitude) {}
+      order_prefs(true) {}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Enrichment::~Enrichment() {}
@@ -55,7 +54,12 @@ void Enrichment::Build(cyclus::Agent* parent) {
   LOG(cyclus::LEV_DEBUG2, "EnrFac") << "Enrichment "
                                     << " entering the simuluation: ";
   LOG(cyclus::LEV_DEBUG2, "EnrFac") << str();
-  RecordPosition();
+  coordinates.RecordPosition(this);
+}
+
+void Enrichment::EnterNotify() {
+  cyclus::Facility::EnterNotify();
+  InitializePosition(this);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -455,19 +459,6 @@ double Enrichment::FeedAssay() {
       inventory.Pop(pop_qty, cyclus::eps_rsrc());
   inventory.Push(fission_matl);
   return cyclus::toolkit::UraniumAssayMass(fission_matl);
-}
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-void Enrichment::RecordPosition() {
-  std::string specification = this->spec();
-  context()
-      ->NewDatum("AgentPosition")
-      ->AddVal("Spec", specification)
-      ->AddVal("Prototype", this->prototype())
-      ->AddVal("AgentId", id())
-      ->AddVal("Latitude", latitude)
-      ->AddVal("Longitude", longitude)
-      ->Record();
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -166,6 +166,8 @@ class Enrichment
   ///     Destructor for the Enrichment class
   virtual ~Enrichment();
 
+  virtual void EnterNotify();
+
   virtual std::string version() { return CYCAMORE_VERSION; }
 
   #pragma cyclus
@@ -249,6 +251,9 @@ class Enrichment
   }
 
  private:
+  // Code Injection:
+  #include "toolkit/position.cycpp.h"
+
   ///   @brief adds a material into the natural uranium inventory
   ///   @throws if the material is not the same composition as the feed_recipe
   void AddMat_(cyclus::Material::Ptr mat);
@@ -272,9 +277,6 @@ class Enrichment
 
   ///  @brief records and enrichment with the cyclus::Recorder
   void RecordEnrichment_(double natural_u, double swu);
-
-  /// Records an agent's latitude and longitude to the output db
-  void RecordPosition();
 
   #pragma cyclus var { \
     "tooltip": "feed commodity",					\
@@ -389,23 +391,6 @@ class Enrichment
   friend class EnrichmentTest;
   // ---
 
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double latitude;
-
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double longitude;
-
-  cyclus::toolkit::Position coordinates;
 };
 
 }  // namespace cycamore

--- a/src/fuel_fab.cc
+++ b/src/fuel_fab.cc
@@ -136,8 +136,7 @@ FuelFab::FuelFab(cyclus::Context* ctx)
       fiss_size(0),
       throughput(0),
       latitude(0.0),
-      longitude(0.0),
-      coordinates(latitude, longitude) {}
+      longitude(0.0) {}
 
 void FuelFab::EnterNotify() {
   cyclus::Facility::EnterNotify();
@@ -163,7 +162,8 @@ void FuelFab::EnterNotify() {
        << " fill_commod_prefs vals, expected " << fill_commods.size();
     throw cyclus::ValidationError(ss.str());
   }
-  RecordPosition();
+
+  InitializePosition(this);
 }
 
 std::set<cyclus::RequestPortfolio<Material>::Ptr> FuelFab::GetMatlRequests() {
@@ -493,18 +493,6 @@ void FuelFab::GetMatlTrades(
       responses.push_back(std::make_pair(trades[i], m));
     }
   }
-}
-
-void FuelFab::RecordPosition() {
-  std::string specification = this->spec();
-  context()
-      ->NewDatum("AgentPosition")
-      ->AddVal("Spec", specification)
-      ->AddVal("Prototype", this->prototype())
-      ->AddVal("AgentId", id())
-      ->AddVal("Latitude", latitude)
-      ->AddVal("Longitude", longitude)
-      ->Record();
 }
 
 extern "C" cyclus::Agent* ConstructFuelFab(cyclus::Context* ctx) {

--- a/src/fuel_fab.h
+++ b/src/fuel_fab.h
@@ -134,12 +134,16 @@ class FuelFab
   GetMatlRequests();
 
  private:
+  // Code Injection:
+  #include "toolkit/position.cycpp.h"
+
   #pragma cyclus var { \
     "doc": "Ordered list of commodities on which to requesting filler stream material.", \
     "uilabel": "Filler Stream Commodities", \
     "uitype": ["oneormore", "incommodity"], \
   }
   std::vector<std::string> fill_commods;
+
   #pragma cyclus var { \
     "default": [], \
     "uilabel": "Filler Stream Preferences", \
@@ -147,18 +151,21 @@ class FuelFab
            " If unspecified, default is to use 1.0 for all preferences.", \
   }
   std::vector<double> fill_commod_prefs;
+
   #pragma cyclus var { \
     "doc": "Name of recipe to be used in filler material stream requests.", \
     "uilabel": "Filler Stream Recipe", \
     "uitype": "inrecipe", \
   }
   std::string fill_recipe;
+
   #pragma cyclus var { \
     "doc": "Size of filler material stream inventory.", \
     "uilabel": "Filler Stream Inventory Capacity", \
     "units": "kg", \
   }
   double fill_size;
+
   #pragma cyclus var {"capacity": "fill_size"}
   cyclus::toolkit::ResBuf<cyclus::Material> fill;
 
@@ -168,6 +175,7 @@ class FuelFab
     "uitype": ["oneormore", "incommodity"], \
   }
   std::vector<std::string> fiss_commods;
+
   #pragma cyclus var { \
     "default": [], \
     "uilabel": "Fissile Stream Preferences", \
@@ -175,6 +183,7 @@ class FuelFab
            " If unspecified, default is to use 1.0 for all preferences.", \
   }
   std::vector<double> fiss_commod_prefs;
+
   #pragma cyclus var { \
     "doc": "Name for recipe to be used in fissile stream requests." \
            " Empty string results in use of an empty dummy recipe.", \
@@ -183,12 +192,14 @@ class FuelFab
     "default": "", \
   }
   std::string fiss_recipe;
+
   #pragma cyclus var { \
     "doc": "Size of fissile material stream inventory.", \
     "uilabel": "Fissile Stream Inventory Capacity", \
     "units": "kg", \
   }
   double fiss_size;
+
   #pragma cyclus var {"capacity": "fiss_size"}
   cyclus::toolkit::ResBuf<cyclus::Material> fiss;
 
@@ -200,6 +211,7 @@ class FuelFab
     "uitype": "incommodity", \
   }
   std::string topup_commod;
+
   #pragma cyclus var { \
     "doc": "Top-up material stream request preference.", \
     "uilabel": "Top-up Stream Preference", \
@@ -215,6 +227,7 @@ class FuelFab
     "default": "", \
   }
   std::string topup_recipe;
+
   #pragma cyclus var { \
     "doc": "Size of top-up material stream inventory.", \
     "uilabel": "Top-up Stream Inventory Capacity", \
@@ -222,6 +235,7 @@ class FuelFab
     "default": 0, \
   }
   double topup_size;
+
   #pragma cyclus var {"capacity": "topup_size"}
   cyclus::toolkit::ResBuf<cyclus::Material> topup;
 
@@ -255,26 +269,6 @@ class FuelFab
   // map<request, inventory name>
   std::map<cyclus::Request<cyclus::Material>*, std::string> req_inventories_;
 
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double latitude;
-
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double longitude;
-
-  cyclus::toolkit::Position coordinates;
-
-  /// Records an agent's latitude and longitude to the output db
-  void RecordPosition();
 };
 
 double CosiWeight(cyclus::Composition::Ptr c, const std::string& spectrum);

--- a/src/growth_region.cc
+++ b/src/growth_region.cc
@@ -6,8 +6,7 @@ namespace cycamore {
 GrowthRegion::GrowthRegion(cyclus::Context* ctx)
     : cyclus::Region(ctx),
       latitude(0.0),
-      longitude(0.0),
-      coordinates(latitude, longitude) {
+      longitude(0.0) {
   #if !CYCLUS_HAS_COIN
     throw cyclus::Error("Growth Region requires that Cyclus & Cycamore be compiled "
                         "with COIN support.");
@@ -55,7 +54,8 @@ void GrowthRegion::EnterNotify() {
                                    << it->first;
     AddCommodityDemand_(it->first, it->second);
   }
-  RecordPosition();
+  
+  InitializePosition(this);
 }
 
 void GrowthRegion::DecomNotify(Agent* a) {
@@ -172,18 +172,6 @@ void GrowthRegion::OrderBuilds(cyclus::toolkit::Commodity& commodity,
   throw cyclus::Error("Growth Region requires that Cyclus & Cycamore be compiled "
                       "with COIN support.");
 #endif
-}
-
-void GrowthRegion::RecordPosition() {
-  std::string specification = this->spec();
-  context()
-      ->NewDatum("AgentPosition")
-      ->AddVal("Spec", specification)
-      ->AddVal("Prototype", this->prototype())
-      ->AddVal("AgentId", id())
-      ->AddVal("Latitude", latitude)
-      ->AddVal("Longitude", longitude)
-      ->Record();
 }
 
 extern "C" cyclus::Agent* ConstructGrowthRegion(cyclus::Context* ctx) {

--- a/src/growth_region.h
+++ b/src/growth_region.h
@@ -90,7 +90,7 @@ class GrowthRegion : public cyclus::Region,
     "description is comprised of a function type and associated parameters. "\
     "\n\n"                                       \
     "  * Start times are inclusive. For a start time :math:`t_0`, the demand "\
-    "function is evaluated on :math:`[t_0, \infty)`."                     \
+    "function is evaluated on :math:`[t_0, infinity)`."                     \
     "\n\n"                                       \
     "  * Supported function types are based on the "\
     "`cyclus::toolkit::BasicFunctionFactory "\
@@ -129,26 +129,9 @@ class GrowthRegion : public cyclus::Region,
   void OrderBuilds(cyclus::toolkit::Commodity& commodity, double unmetdemand);
 
   private:
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double latitude;
+  // Code Injection:
+  #include "toolkit/position.cycpp.h"
 
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double longitude;
-
-  cyclus::toolkit::Position coordinates;
-
-  /// Records an agent's latitude and longitude to the output db
-  void RecordPosition();
 };
 }  // namespace cycamore
 

--- a/src/manager_inst.cc
+++ b/src/manager_inst.cc
@@ -7,8 +7,7 @@ namespace cycamore {
 ManagerInst::ManagerInst(cyclus::Context* ctx)
       : cyclus::Institution(ctx),
         latitude(0.0),
-        longitude(0.0),
-        coordinates(latitude, longitude) {}
+        longitude(0.0) {}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ManagerInst::~ManagerInst() {}
@@ -43,7 +42,8 @@ void ManagerInst::EnterNotify() {
       Builder::Register(cp_cast);
     }
   }
-  RecordPosition();
+
+  InitializePosition(this);
 }
 
 void ManagerInst::Register_(Agent* a) {
@@ -87,18 +87,6 @@ void ManagerInst::WriteProducerInformation(
     LOG(cyclus::LEV_DEBUG3, "maninst") << "               cost: " <<
                                        producer->Cost(*it);
   }
-}
-
-void ManagerInst::RecordPosition() {
-  std::string specification = this->spec();
-  context()
-      ->NewDatum("AgentPosition")
-      ->AddVal("Spec", specification)
-      ->AddVal("Prototype", this->prototype())
-      ->AddVal("AgentId", id())
-      ->AddVal("Latitude", latitude)
-      ->AddVal("Longitude", longitude)
-      ->Record();
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/manager_inst.h
+++ b/src/manager_inst.h
@@ -45,6 +45,9 @@ class ManagerInst
                                 producer);
 
   private:
+  // Code Injection:
+  #include "toolkit/position.cycpp.h"
+
   /// register a child
   void Register_(cyclus::Agent* agent);
 
@@ -61,26 +64,6 @@ class ManagerInst
     }
   std::vector<std::string> prototypes;
 
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double latitude;
-
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double longitude;
-
-  cyclus::toolkit::Position coordinates;
-
-  /// Records an agent's latitude and longitude to the output db
-  void RecordPosition();
 };
 
 }  // namespace cycamore

--- a/src/mixer.cc
+++ b/src/mixer.cc
@@ -8,11 +8,9 @@ Mixer::Mixer(cyclus::Context* ctx)
     : cyclus::Facility(ctx),
       throughput(0),
       latitude(0.0),
-      longitude(0.0),
-      coordinates(latitude, longitude) {
+      longitude(0.0) {
   cyclus::Warn<cyclus::EXPERIMENTAL_WARNING>(
       "the Mixer archetype is experimental");
-  RecordPosition();
 }
 
 cyclus::Inventories Mixer::SnapshotInv() {
@@ -61,6 +59,8 @@ void Mixer::EnterNotify() {
       streambufs[name].capacity(cap);
     }
     in_commods.push_back(streams_[i].second);
+
+    InitializePosition(this);
   }
 
   // ratio normalisation
@@ -199,18 +199,6 @@ void Mixer::AcceptMatlTrades(
   }
 
   req_inventories_.clear();
-}
-
-void Mixer::RecordPosition() {
-  std::string specification = spec();
-  context()
-      ->NewDatum("AgentPosition")
-      ->AddVal("Spec", specification)
-      ->AddVal("Prototype", this->prototype())
-      ->AddVal("AgentId", id())
-      ->AddVal("Latitude", latitude)
-      ->AddVal("Longitude", longitude)
-      ->Record();
 }
 
 extern "C" cyclus::Agent* ConstructMixer(cyclus::Context* ctx) {

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -115,26 +115,9 @@ class Mixer
   cyclus::toolkit::MatlSellPolicy sell_policy;
 
   private:
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double latitude;
-
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double longitude;
-
-  cyclus::toolkit::Position coordinates;
-
-  /// Records an agent's latitude and longitude to the output db
-  void RecordPosition();
+  // Code Injection:
+  #include "toolkit/position.cycpp.h"
+  
 };
 
 }  // namespace cycamore

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -23,8 +23,7 @@ Reactor::Reactor(cyclus::Context* ctx)
       discharged(false),
       latitude(0.0),
       longitude(0.0),
-      keep_packaging(true),
-      coordinates(latitude, longitude) {}
+      keep_packaging(true) {}
 
 
 #pragma cyclus def clone cycamore::Reactor
@@ -111,7 +110,8 @@ void Reactor::EnterNotify() {
   if (ss.str().size() > 0) {
     throw ValueError(ss.str());
   }
-  RecordPosition();
+  
+  InitializePosition(this);
 }
 
 bool Reactor::CheckDecommissionCondition() {
@@ -566,18 +566,6 @@ void Reactor::Record(std::string name, std::string val) {
       ->AddVal("Time", context()->time())
       ->AddVal("Event", name)
       ->AddVal("Value", val)
-      ->Record();
-}
-
-void Reactor::RecordPosition() {
-  std::string specification = this->spec();
-  context()
-      ->NewDatum("AgentPosition")
-      ->AddVal("Spec", specification)
-      ->AddVal("Prototype", this->prototype())
-      ->AddVal("AgentId", id())
-      ->AddVal("Latitude", latitude)
-      ->AddVal("Longitude", longitude)
       ->Record();
 }
 

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -134,6 +134,9 @@ class Reactor : public cyclus::Facility,
   #pragma cyclus decl
 
  private:
+  // Code Injection:
+  #include "toolkit/position.cycpp.h"
+
   std::string fuel_incommod(cyclus::Material::Ptr m);
   std::string fuel_outcommod(cyclus::Material::Ptr m);
   std::string fuel_inrecipe(cyclus::Material::Ptr m);
@@ -187,6 +190,7 @@ class Reactor : public cyclus::Facility,
     "doc": "Ordered list of input commodities on which to requesting fuel.", \
   }
   std::vector<std::string> fuel_incommods;
+
   #pragma cyclus var { \
     "uitype": ["oneormore", "inrecipe"], \
     "uilabel": "Fresh Fuel Recipe List", \
@@ -204,6 +208,7 @@ class Reactor : public cyclus::Facility,
            "requests (default).", \
   }
   std::vector<double> fuel_prefs;
+
   #pragma cyclus var { \
     "uitype": ["oneormore", "outcommodity"], \
     "uilabel": "Spent Fuel Commodity List", \
@@ -211,6 +216,7 @@ class Reactor : public cyclus::Facility,
            "received as each particular input commodity (same order)." \
   }
   std::vector<std::string> fuel_outcommods;
+
   #pragma cyclus var {           \
     "uitype": ["oneormore", "outrecipe"], \
     "uilabel": "Spent Fuel Recipe List", \
@@ -229,6 +235,7 @@ class Reactor : public cyclus::Facility,
            "a requested fresh fuel.", \
   }
   std::vector<int> recipe_change_times;
+
   #pragma cyclus var { \
     "default": [], \
     "uilabel": "Commodity for Changed Fresh/Spent Fuel Recipe", \
@@ -238,6 +245,7 @@ class Reactor : public cyclus::Facility,
     "uitype": ["oneormore", "incommodity"], \
   }
   std::vector<std::string> recipe_change_commods;
+
   #pragma cyclus var { \
     "default": [], \
     "uilabel": "New Recipe for Fresh Fuel", \
@@ -247,6 +255,7 @@ class Reactor : public cyclus::Facility,
     "uitype": ["oneormore", "inrecipe"], \
   }
   std::vector<std::string> recipe_change_in;
+
   #pragma cyclus var { \
     "default": [], \
     "uilabel": "New Recipe for Spent Fuel", \
@@ -275,6 +284,7 @@ class Reactor : public cyclus::Facility,
            "Batch size is equivalent to ``n_assem_batch / n_assem_core``.", \
   }
   int n_assem_batch;
+
   #pragma cyclus var { \
     "default": 3, \
     "uilabel": "Number of Assemblies in Core", \
@@ -283,6 +293,7 @@ class Reactor : public cyclus::Facility,
     "doc": "Number of assemblies that constitute a full core.", \
   }
   int n_assem_core;
+
   #pragma cyclus var { \
     "default": 0, \
     "uilabel": "Minimum Fresh Fuel Inventory", \
@@ -292,6 +303,7 @@ class Reactor : public cyclus::Facility,
     "doc": "Number of fresh fuel assemblies to keep on-hand if possible.", \
   }
   int n_assem_fresh;
+
   #pragma cyclus var { \
     "default": 1000000000, \
     "uilabel": "Maximum Spent Fuel Inventory", \
@@ -312,6 +324,7 @@ class Reactor : public cyclus::Facility,
     "units": "time steps", \
   }
   int cycle_time;
+
   #pragma cyclus var { \
     "default": 1, \
     "doc": "The duration of a full refueling period - the minimum time between"\
@@ -320,6 +333,7 @@ class Reactor : public cyclus::Facility,
     "units": "time steps", \
   }
   int refuel_time;
+
   #pragma cyclus var { \
     "default": 0, \
     "doc": "Number of time steps since the start of the last cycle." \
@@ -389,6 +403,7 @@ class Reactor : public cyclus::Facility,
            "particular fresh fuel type.", \
   }
   std::vector<int> pref_change_times;
+
   #pragma cyclus var { \
     "default": [], \
     "doc": "The input commodity for a particular fuel preference change.  " \
@@ -398,6 +413,7 @@ class Reactor : public cyclus::Facility,
     "uitype": ["oneormore", "incommodity"], \
   }
   std::vector<std::string> pref_change_commods;
+
   #pragma cyclus var { \
     "default": [], \
     "uilabel": "Changed Fresh Fuel Preference",                        \
@@ -445,27 +461,6 @@ class Reactor : public cyclus::Facility,
 
   // populated lazily and no need to persist.
   std::set<std::string> uniq_outcommods_;
-
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double latitude;
-
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double longitude;
-
-  cyclus::toolkit::Position coordinates;
-
-  /// Records an agent's latitude and longitude to the output db
-  void RecordPosition();
 };
 
 } // namespace cycamore

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -11,8 +11,7 @@ namespace cycamore {
 Separations::Separations(cyclus::Context* ctx)
     : cyclus::Facility(ctx),
       latitude(0.0),
-      longitude(0.0),
-      coordinates(latitude, longitude) {}
+      longitude(0.0) {}
 
 cyclus::Inventories Separations::SnapshotInv() {
   cyclus::Inventories invs;
@@ -65,7 +64,8 @@ void Separations::EnterNotify() {
     for (it2 = stream.second.begin(); it2 != stream.second.end(); it2++) {
       efficiency_[it2->first] += it2->second;
     }
-    RecordPosition();
+
+    InitializePosition(this);
   }
 
   std::vector<int> eff_pb_;
@@ -365,18 +365,6 @@ bool Separations::CheckDecommissionCondition() {
   }
 
   return true;
-}
-
-void Separations::RecordPosition() {
-  std::string specification = this->spec();
-  context()
-      ->NewDatum("AgentPosition")
-      ->AddVal("Spec", specification)
-      ->AddVal("Prototype", this->prototype())
-      ->AddVal("AgentId", id())
-      ->AddVal("Latitude", latitude)
-      ->AddVal("Longitude", longitude)
-      ->Record();
 }
 
 void Separations::Record(std::string name, double val, std::string type) {

--- a/src/separations.h
+++ b/src/separations.h
@@ -105,6 +105,9 @@ class Separations
   virtual void InitInv(cyclus::Inventories& inv);
 
  private:
+ // Code Injection:
+ #include "toolkit/position.cycpp.h"
+
   #pragma cyclus var { \
     "doc": "Ordered list of commodities on which to request feed material to " \
            "separate. Order only matters for matching up with feed commodity " \
@@ -208,26 +211,6 @@ class Separations
   // state var.
   std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material> > streambufs;
 
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double latitude;
-
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double longitude;
-
-  cyclus::toolkit::Position coordinates;
-
-  /// Records an agent's latitude and longitude to the output db
-  void RecordPosition();
   void Record(std::string name, double val, std::string type);
 };
 

--- a/src/sink.cc
+++ b/src/sink.cc
@@ -14,8 +14,7 @@ Sink::Sink(cyclus::Context* ctx)
       capacity(std::numeric_limits<double>::max()),
       latitude(0.0),
       longitude(0.0),
-      keep_packaging(true),
-      coordinates(latitude, longitude) {
+      keep_packaging(true) {
   SetMaxInventorySize(std::numeric_limits<double>::max());}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -73,7 +72,8 @@ void Sink::EnterNotify() {
                                      << random_frequency_type
                                      << " for determining request frequency.";
   }
-  RecordPosition();
+
+  InitializePosition(this);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -231,18 +231,6 @@ void Sink::Tock() {
                                    << " units of material at the close of timestep "
                                    << context()->time() << ".";
   LOG(cyclus::LEV_INFO3, "SnkFac") << "}";
-}
-
-void Sink::RecordPosition() {
-  std::string specification = this->spec();
-  context()
-      ->NewDatum("AgentPosition")
-      ->AddVal("Spec", specification)
-      ->AddVal("Prototype", this->prototype())
-      ->AddVal("AgentId", id())
-      ->AddVal("Latitude", latitude)
-      ->AddVal("Longitude", longitude)
-      ->Record();
 }
 
 void Sink::SetRequestAmt() {

--- a/src/sink.h
+++ b/src/sink.h
@@ -115,6 +115,9 @@ class Sink
       input_commodity_preferences() const { return in_commod_prefs; }
 
  private:
+  // Code Injection:
+  #include "toolkit/position.cycpp.h"
+
   double requestAmt;
   int nextBuyTime;
   /// all facilities must have at least one input commodity
@@ -269,25 +272,6 @@ class Sink
     "uitype": "bool"}
   bool keep_packaging;
 
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double latitude;
-
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double longitude;
-
-  cyclus::toolkit::Position coordinates;
-
-  void RecordPosition();
 };
 
 }  // namespace cycamore

--- a/src/source.cc
+++ b/src/source.cc
@@ -14,8 +14,7 @@ Source::Source(cyclus::Context* ctx)
       latitude(0.0),
       longitude(0.0),
       package(cyclus::Package::unpackaged_name()),
-      transport_unit(cyclus::TransportUnit::unrestricted_name()),
-      coordinates(latitude, longitude) {}
+      transport_unit(cyclus::TransportUnit::unrestricted_name()) {}
 
 Source::~Source() {}
 
@@ -55,7 +54,7 @@ std::string Source::str() {
 
 void Source::EnterNotify() {
   cyclus::Facility::EnterNotify();
-  RecordPosition();
+  InitializePosition(this);
 }
 
 void Source::Build(cyclus::Agent* parent) {
@@ -178,18 +177,6 @@ void Source::GetMatlTrades(
                                       << " for " << response->quantity() << " of " << outcommod;
     }
   }
-}
-
-void Source::RecordPosition() {
-  std::string specification = this->spec();
-  context()
-      ->NewDatum("AgentPosition")
-      ->AddVal("Spec", specification)
-      ->AddVal("Prototype", this->prototype())
-      ->AddVal("AgentId", id())
-      ->AddVal("Latitude", latitude)
-      ->AddVal("Longitude", longitude)
-      ->Record();
 }
 
 extern "C" cyclus::Agent* ConstructSource(cyclus::Context* ctx) {

--- a/src/source.h
+++ b/src/source.h
@@ -81,6 +81,9 @@ class Source : public cyclus::Facility,
     cyclus::Material::Ptr> >& responses);
 
  private:
+ // Code Injection:
+ #include "toolkit/position.cycpp.h"
+
   #pragma cyclus var { \
     "tooltip": "source output commodity", \
     "doc": "Output commodity on which the source offers material.", \
@@ -147,28 +150,9 @@ class Source : public cyclus::Facility,
   std::string transport_unit;
 
   #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double latitude;
-
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double longitude;
-
-  #pragma cyclus var { \
     "tooltip":"Material buffer"}
   cyclus::toolkit::ResBuf<cyclus::Material> inventory;
 
-  cyclus::toolkit::Position coordinates;
-
-  void RecordPosition();
   void SetPackage();
 };
 

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -8,8 +8,7 @@ namespace cycamore {
 Storage::Storage(cyclus::Context* ctx)
     : cyclus::Facility(ctx),
       latitude(0.0),
-      longitude(0.0),
-      coordinates(latitude, longitude) {
+      longitude(0.0) {
   inventory_tracker.Init({&inventory, &stocks, &ready, &processing}, cyclus::CY_LARGE_DOUBLE);
   cyclus::Warn<cyclus::EXPERIMENTAL_WARNING>(
       "The Storage Facility is experimental.");};
@@ -223,7 +222,8 @@ void Storage::EnterNotify() {
     ss << "out_commods has " << out_commods.size() << " values, expected 1.";
     throw cyclus::ValueError(ss.str());
   }
-  RecordPosition();
+  
+  InitializePosition(this);
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -386,19 +386,6 @@ void Storage::ReadyMatl_(int time) {
 
   ready.Push(processing.PopN(to_ready));
 }
-
-void Storage::RecordPosition() {
-  std::string specification = this->spec();
-  context()
-      ->NewDatum("AgentPosition")
-      ->AddVal("Spec", specification)
-      ->AddVal("Prototype", this->prototype())
-      ->AddVal("AgentId", id())
-      ->AddVal("Latitude", latitude)
-      ->AddVal("Longitude", longitude)
-      ->Record();
-}
-
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 extern "C" cyclus::Agent* ConstructStorage(cyclus::Context* ctx) {

--- a/src/storage.h
+++ b/src/storage.h
@@ -549,31 +549,16 @@ class Storage
   //// A policy for sending material
   cyclus::toolkit::MatlSellPolicy sell_policy;
 
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double latitude;
-
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
-  }
-  double longitude;
-
   cyclus::IntDistribution::Ptr active_dist_ = NULL;
   cyclus::IntDistribution::Ptr dormant_dist_ = NULL;
   cyclus::DoubleDistribution::Ptr size_dist_ = NULL;
 
-  cyclus::toolkit::Position coordinates;
-
-  void RecordPosition();
-
   friend class StorageTest;
+
+  private:
+  // Code Injection:
+  #include "toolkit/position.cycpp.h"
+  
 };
 
 }  // namespace cycamore


### PR DESCRIPTION
# Summary of Changes
This PR removes all the manual definition of position in Cycamore Agents. 

# Related CEPs and Issues

This PR is related to:

- cyclus/cycamore#502
- #1853 
- #1510 
- Closes #1871   

# Associated Developers

@bam241 
@gonuke 

# Design Notes

I attempted to remove all initialization from the constructor (the `latitude(0.0), longitude(0.0), coordinates(0, 0)` bit), but because of limitations with the `#pragma cyclus var` system, it is impossible to inject something like `double latitude = 0.0` (it throws an error). I was able to remove the `coordinates(0, 0)` bit, and to condense the initialization into an injected function, however. 

## TODO:
- Update the changelog (oops)

# Testing and Validation

The code was built locally on my machine. No additional tests were added, but all existing tests passed on my machine. 

# Checklist

 - [x] Read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide.
 - [x]  Compile and run locally.
 - [ ]  Add or update tests.
 - [ ]  Document if needed.
 - [x]  Follow style guidelines.
 - [ ]  Update the changelog.
 - [ ]  Address all review comments.
Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).