### PR TITLE
Add Protection to, and clang-format Cycamore

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,10 @@
+Language: Cpp
+BasedOnStyle: Google
+# only allow single line functions if they are inlined in class def'n
+AllowShortFunctionsOnASingleLine: Inline
+# do not force new line after template declarations
+AlwaysBreakTemplateDeclarations: false
+# Automatically detect whether a given fuction's arguments are one-per-line
+ExperimentalAutoDetectBinPacking: true
+# Use C++11 standard
+Standard: Cpp11

--- a/.clang-format
+++ b/.clang-format
@@ -1,10 +1,12 @@
-Language: Cpp
-BasedOnStyle: Google
-# only allow single line functions if they are inlined in class def'n
+Language:        Cpp
+BasedOnStyle:    Google
+# Only allow single-line functions if they are inlined in class definition
 AllowShortFunctionsOnASingleLine: Inline
-# do not force new line after template declarations
+# Do not force new line after template declarations
 AlwaysBreakTemplateDeclarations: false
-# Automatically detect whether a given fuction's arguments are one-per-line
+# Automatically detect whether a given function's arguments are one-per-line
 ExperimentalAutoDetectBinPacking: true
 # Use C++11 standard
 Standard: Cpp11
+# Prevent automatic include sorting
+SortIncludes: Never

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Since last release
 ======================
 
 **Added:**
+* Added clang-format protection to all .h files with #pragma blocks in /src (#644)
 * Replaced manual matl_buy/sell_policy code in storage with code injection (#639)
 * Added package parameter to storage (#603, #612, #616)
 * Added package parameter to source (#613, #617, #621, #623, #630)
@@ -14,7 +15,7 @@ Since last release
 * Added (negative)binomial distributions for disruption modeling to storage (#635)
 
 **Changed:**
-
+* Ran clang-format on /src (#644)
 * Rely on ``python3`` in environment instead of ``python`` (#602)
 * Link against ``libxml++`` imported target in CMake instead of ``LIBXMLXX_LIBRARIES`` (#608)
 * Cleaned up ``using`` declarations throughout archetypes (#610)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,12 +6,9 @@ Since last release
 ======================
 
 **Added:**
-<<<<<<< HEAD
 * Added clang-format protection to all .h files with #pragma blocks in /src (#644)
-=======
 * Added tests for Conversion Facility (#658)
 * Added Conversion Facility (#657)
->>>>>>> c61cf6ce07a2492a389d526729a755c63c45ad0c
 * Replaced manual matl_buy/sell_policy code in storage with code injection (#639)
 * Added package parameter to storage (#603, #612, #616)
 * Added package parameter to source (#613, #617, #621, #623, #630)
@@ -21,11 +18,8 @@ Since last release
 * Added new variable to Deploy Institution to shift the deployment times (#677)
 
 **Changed:**
-<<<<<<< HEAD
 * Ran clang-format on /src (#644)
-=======
 * Cleaned up manual definitions of Position in favor of code injection (#641)
->>>>>>> c61cf6ce07a2492a389d526729a755c63c45ad0c
 * Rely on ``python3`` in environment instead of ``python`` (#602)
 * Link against ``libxml++`` imported target in CMake instead of ``LIBXMLXX_LIBRARIES`` (#608)
 * Cleaned up ``using`` declarations throughout archetypes (#610)

--- a/src/conversion.cc
+++ b/src/conversion.cc
@@ -6,26 +6,24 @@
 
 #include "conversion.h"
 
-using cyclus::RequestPortfolio;
 using cyclus::BidPortfolio;
-using cyclus::CommodMap;
-using cyclus::Request;
-using cyclus::Trade;
-using cyclus::Material;
 using cyclus::CapacityConstraint;
-using cyclus::toolkit::ResBuf;
+using cyclus::CommodMap;
+using cyclus::Material;
+using cyclus::Request;
+using cyclus::RequestPortfolio;
+using cyclus::Trade;
 using cyclus::toolkit::RecordTimeSeries;
+using cyclus::toolkit::ResBuf;
 
 namespace cycamore {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Conversion::Conversion(cyclus::Context* ctx)
-    : cyclus::Facility(ctx) {
-
-      // Make our Resource Buffers bulk buffers
-      input = ResBuf<Material>(true);
-      output = ResBuf<Material>(true);
-    }
+Conversion::Conversion(cyclus::Context* ctx) : cyclus::Facility(ctx) {
+  // Make our Resource Buffers bulk buffers
+  input = ResBuf<Material>(true);
+  output = ResBuf<Material>(true);
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Conversion::~Conversion() {}
@@ -105,11 +103,11 @@ std::set<RequestPortfolio<Material>::Ptr> Conversion::GetMatlRequests() {
 
   // Create material request with no recipe
   Material::Ptr mat = cyclus::NewBlankMaterial(available_capacity);
- 
 
   // Add request for all commodities using default preference
   for (std::vector<std::string>::iterator it = incommods.begin();
-       it != incommods.end(); ++it) {
+       it != incommods.end();
+       ++it) {
     Request<Material>* req = port->AddRequest(mat, this, *it);
   }
 
@@ -123,7 +121,7 @@ std::set<RequestPortfolio<Material>::Ptr> Conversion::GetMatlRequests() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::set<BidPortfolio<Material>::Ptr> Conversion::GetMatlBids(
-  CommodMap<Material>::type& commod_requests) {
+    CommodMap<Material>::type& commod_requests) {
   std::set<BidPortfolio<Material>::Ptr> ports;
 
   // Check if we have material to offer
@@ -135,14 +133,15 @@ std::set<BidPortfolio<Material>::Ptr> Conversion::GetMatlBids(
   // Respond to requests for our commodity
   std::vector<Request<Material>*>& requests = commod_requests[outcommod];
   for (std::vector<Request<Material>*>::iterator it = requests.begin();
-      it != requests.end(); ++it) {
-
+       it != requests.end();
+       ++it) {
     double available = output.quantity();
     double requested = (*it)->target()->quantity();
     double offer_qty = std::min(available, requested);
 
     if (offer_qty > 0) {
-      Material::Ptr offer = Material::CreateUntracked(offer_qty, output.Peek()->comp());
+      Material::Ptr offer =
+          Material::CreateUntracked(offer_qty, output.Peek()->comp());
       port->AddBid(*it, offer, this);  // Note: *it, not **it
     }
   }
@@ -157,26 +156,23 @@ std::set<BidPortfolio<Material>::Ptr> Conversion::GetMatlBids(
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Conversion::AcceptMatlTrades(
-  const std::vector<std::pair<Trade<Material>, Material::Ptr>>& responses) {
-
-  for (std::vector<std::pair<Trade<Material>, Material::Ptr>>::const_iterator it =
-      responses.begin(); it != responses.end(); ++it) {
-
-
+    const std::vector<std::pair<Trade<Material>, Material::Ptr>>& responses) {
+  for (std::vector<std::pair<Trade<Material>, Material::Ptr>>::const_iterator
+           it = responses.begin();
+       it != responses.end();
+       ++it) {
     // Add material to the input buffer
     input.Push(it->second);
-    
   }
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Conversion::GetMatlTrades(
-  const std::vector<Trade<Material>>& trades,
-  std::vector<std::pair<Trade<Material>, Material::Ptr>>& responses) {
-
+    const std::vector<Trade<Material>>& trades,
+    std::vector<std::pair<Trade<Material>, Material::Ptr>>& responses) {
   for (std::vector<Trade<Material>>::const_iterator it = trades.begin();
-      it != trades.end(); ++it) {
-
+       it != trades.end();
+       ++it) {
     Material::Ptr response = output.Pop(it->amt);
 
     responses.push_back(std::make_pair(*it, response));
@@ -189,4 +185,3 @@ extern "C" cyclus::Agent* ConstructConversion(cyclus::Context* ctx) {
 }
 
 }  // namespace cycamore
-

--- a/src/conversion.h
+++ b/src/conversion.h
@@ -30,7 +30,7 @@ class Conversion : public cyclus::Facility, public cyclus::toolkit::Position {
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-// clanag-format off
+// clang-format off
 #pragma cyclus note { \
     "doc": \
     " A conversion facility that accepts materials and products and with a \n"\

--- a/src/conversion.h
+++ b/src/conversion.h
@@ -18,12 +18,11 @@ namespace cycamore {
 class Context;
 
 /// This facility acts as a simple conversion facility from its input commodity
-/// to its output commodity. It has a fixed throughput (per time step), and 
+/// to its output commodity. It has a fixed throughput (per time step), and
 /// converts without regard to the composition of the input material.
-class Conversion
-  : public cyclus::Facility,
-    public cyclus::toolkit::Position  {
+class Conversion : public cyclus::Facility, public cyclus::toolkit::Position {
   friend class ConversionTest;
+
  public:
   Conversion(cyclus::Context* ctx);
 
@@ -31,14 +30,14 @@ class Conversion
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-  // clanag-format off
-  #pragma cyclus note { \
+// clanag-format off
+#pragma cyclus note { \
     "doc": \
     " A conversion facility that accepts materials and products and with a \n"\
     " fixed throughput (per time step) converts them into its outcommod. " \
     }
 
-  #pragma cyclus decl
+#pragma cyclus decl
   // clang-format on
 
   virtual std::string str();
@@ -48,35 +47,32 @@ class Conversion
   virtual void Tick();
 
   virtual void Tock();
-  
+
   double AvailableFeedstockCapacity();
 
   void Convert();
 
-
   /// @brief Conversion Facilities request Materials of their given commodity.
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-      GetMatlRequests();
+  GetMatlRequests();
 
-  virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
-  GetMatlBids(cyclus::CommodMap<cyclus::Material>::type&
-      commod_requests);
+  virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> GetMatlBids(
+      cyclus::CommodMap<cyclus::Material>::type& commod_requests);
 
   virtual void GetMatlTrades(
-      const std::vector< cyclus::Trade<cyclus::Material> >& trades,
+      const std::vector<cyclus::Trade<cyclus::Material>>& trades,
       std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-      cyclus::Material::Ptr> >& responses);
+                            cyclus::Material::Ptr>>& responses);
 
-  /// @brief Conversion Facilities place accepted trade Materials in their Inventory
+  /// @brief Conversion Facilities place accepted trade Materials in their
+  /// Inventory
   virtual void AcceptMatlTrades(
-      const std::vector< std::pair<cyclus::Trade<cyclus::Material>,
-      cyclus::Material::Ptr> >& responses);
-
- 
+      const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                                  cyclus::Material::Ptr>>& responses);
 
  private:
-  // Code Injection:
-  #include "toolkit/position.cycpp.h"
+// Code Injection:
+#include "toolkit/position.cycpp.h"
 
   // clang-format off
   /// all facilities must have at least one input commodity
@@ -126,10 +122,8 @@ class Conversion
   /// a buffer for outgoing material
   cyclus::toolkit::ResBuf<cyclus::Material> output;
   // clang-format on
-
 };
 
 }  // namespace cycamore
 
 #endif  // CYCAMORE_SRC_CONVERSION_H_
-

--- a/src/conversion_tests.cc
+++ b/src/conversion_tests.cc
@@ -38,20 +38,20 @@ void ConversionTest::InitParameters() {
 void ConversionTest::SetUpConversion() {
   std::vector<std::string> incommods_vec;
   incommods_vec.push_back(INCOMMOD1);
-  
+
   incommods(conv_facility, incommods_vec);
   outcommod(conv_facility, OUTCOMMOD_NAME);
   throughput(conv_facility, throughput_val);
   input_capacity(conv_facility, input_capacity_val);
-  
+
   // Set the actual buffer capacity
   set_input_capacity(conv_facility, input_capacity_val);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(ConversionTest, Clone) {
-  cycamore::Conversion* cloned_fac = dynamic_cast<cycamore::Conversion*>
-                                         (conv_facility->Clone());
+  cycamore::Conversion* cloned_fac =
+      dynamic_cast<cycamore::Conversion*>(conv_facility->Clone());
 
   EXPECT_EQ(incommods(conv_facility), incommods(cloned_fac));
   EXPECT_EQ(outcommod(conv_facility), outcommod(cloned_fac));
@@ -69,11 +69,11 @@ TEST_F(ConversionTest, Print) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(ConversionTest, InitialState) {
   conv_facility->EnterNotify();
-  
+
   EXPECT_EQ(throughput_val, throughput(conv_facility));
   EXPECT_EQ(input_capacity_val, input_capacity(conv_facility));
   EXPECT_EQ(OUTCOMMOD_NAME, outcommod(conv_facility));
-  
+
   std::vector<std::string> expected_incommods;
   expected_incommods.push_back(INCOMMOD1);
   EXPECT_EQ(expected_incommods, incommods(conv_facility));
@@ -82,23 +82,25 @@ TEST_F(ConversionTest, InitialState) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(ConversionTest, AvailableFeedstockCapacity) {
   conv_facility->EnterNotify();
-  
+
   // Initially, capacity should be full
-  EXPECT_DOUBLE_EQ(input_capacity_val, conv_facility->AvailableFeedstockCapacity());
-  
+  EXPECT_DOUBLE_EQ(input_capacity_val,
+                   conv_facility->AvailableFeedstockCapacity());
+
   // Add some material to input buffer
   cyclus::Material::Ptr mat = cyclus::NewBlankMaterial(TEST_QUANTITY);
   input_push(conv_facility, mat);
-  
+
   // Capacity should be reduced
-  EXPECT_DOUBLE_EQ(input_capacity_val - TEST_QUANTITY, conv_facility->AvailableFeedstockCapacity());
+  EXPECT_DOUBLE_EQ(input_capacity_val - TEST_QUANTITY,
+                   conv_facility->AvailableFeedstockCapacity());
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(ConversionTest, GetMatlRequests) {
-  using cyclus::RequestPortfolio;
-  using cyclus::Material;
   using cyclus::CapacityConstraint;
+  using cyclus::Material;
+  using cyclus::RequestPortfolio;
 
   conv_facility->EnterNotify();
 
@@ -113,15 +115,15 @@ TEST_F(ConversionTest, GetMatlRequests) {
   // Check the portfolio for the request for incommod1 (should be the only one)
   EXPECT_EQ(1, port->requests().size());
 
-  const std::set<CapacityConstraint<Material> >& constrs = port->constraints();
+  const std::set<CapacityConstraint<Material>>& constrs = port->constraints();
   ASSERT_EQ(1, constrs.size());
   EXPECT_EQ(CapacityConstraint<Material>(input_capacity_val), *constrs.begin());
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(ConversionTest, GetMatlRequestsWhenFull) {
-  using cyclus::RequestPortfolio;
   using cyclus::Material;
+  using cyclus::RequestPortfolio;
 
   conv_facility->EnterNotify();
 
@@ -139,9 +141,9 @@ TEST_F(ConversionTest, GetMatlRequestsWhenFull) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(ConversionTest, GetMatlBids) {
   using cyclus::BidPortfolio;
-  using cyclus::Material;
   using cyclus::CapacityConstraint;
   using cyclus::CommodMap;
+  using cyclus::Material;
 
   conv_facility->EnterNotify();
 
@@ -152,8 +154,8 @@ TEST_F(ConversionTest, GetMatlBids) {
   // Create commodity requests
   CommodMap<Material>::type commod_requests;
   cyclus::Material::Ptr req_mat = cyclus::NewBlankMaterial(TEST_QUANTITY);
-  cyclus::Request<Material>* req = cyclus::Request<Material>::Create(
-      req_mat, trader, OUTCOMMOD_NAME);
+  cyclus::Request<Material>* req =
+      cyclus::Request<Material>::Create(req_mat, trader, OUTCOMMOD_NAME);
   commod_requests[OUTCOMMOD_NAME].push_back(req);
 
   std::set<BidPortfolio<Material>::Ptr> ports =
@@ -169,7 +171,7 @@ TEST_F(ConversionTest, GetMatlBids) {
   EXPECT_EQ(1, port->bids().size());
 
   // Check capacity constraint
-  const std::set<CapacityConstraint<Material> >& constrs = port->constraints();
+  const std::set<CapacityConstraint<Material>>& constrs = port->constraints();
   ASSERT_EQ(1, constrs.size());
   EXPECT_EQ(CapacityConstraint<Material>(TEST_QUANTITY), *constrs.begin());
 
@@ -179,16 +181,16 @@ TEST_F(ConversionTest, GetMatlBids) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(ConversionTest, GetMatlBidsWhenEmpty) {
   using cyclus::BidPortfolio;
-  using cyclus::Material;
   using cyclus::CommodMap;
+  using cyclus::Material;
 
   conv_facility->EnterNotify();
 
   // Create commodity requests
   CommodMap<Material>::type commod_requests;
   cyclus::Material::Ptr req_mat = cyclus::NewBlankMaterial(TEST_QUANTITY);
-  cyclus::Request<Material>* req = cyclus::Request<Material>::Create(
-      req_mat, trader, OUTCOMMOD_NAME);
+  cyclus::Request<Material>* req =
+      cyclus::Request<Material>::Create(req_mat, trader, OUTCOMMOD_NAME);
   commod_requests[OUTCOMMOD_NAME].push_back(req);
 
   std::set<BidPortfolio<Material>::Ptr> ports =
@@ -202,10 +204,10 @@ TEST_F(ConversionTest, GetMatlBidsWhenEmpty) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(ConversionTest, AcceptMatlTrades) {
-  using cyclus::Material;
-  using cyclus::Trade;
-  using cyclus::Request;
   using cyclus::Bid;
+  using cyclus::Material;
+  using cyclus::Request;
+  using cyclus::Trade;
 
   conv_facility->EnterNotify();
 
@@ -215,7 +217,7 @@ TEST_F(ConversionTest, AcceptMatlTrades) {
   Bid<Material>* bid = Bid<Material>::Create(req, mat, trader);
   Trade<Material> trade(req, bid, TEST_QUANTITY);
 
-  std::vector<std::pair<Trade<Material>, Material::Ptr> > responses;
+  std::vector<std::pair<Trade<Material>, Material::Ptr>> responses;
   responses.push_back(std::make_pair(trade, mat));
 
   // Accept the trade
@@ -230,10 +232,10 @@ TEST_F(ConversionTest, AcceptMatlTrades) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(ConversionTest, GetMatlTrades) {
-  using cyclus::Material;
-  using cyclus::Trade;
-  using cyclus::Request;
   using cyclus::Bid;
+  using cyclus::Material;
+  using cyclus::Request;
+  using cyclus::Trade;
 
   conv_facility->EnterNotify();
 
@@ -243,14 +245,15 @@ TEST_F(ConversionTest, GetMatlTrades) {
 
   // Create a trade
   Material::Ptr req_mat = cyclus::NewBlankMaterial(TEST_QUANTITY);
-  Request<Material>* req = Request<Material>::Create(req_mat, trader, OUTCOMMOD_NAME);
+  Request<Material>* req =
+      Request<Material>::Create(req_mat, trader, OUTCOMMOD_NAME);
   Bid<Material>* bid = Bid<Material>::Create(req, req_mat, trader);
   Trade<Material> trade(req, bid, TEST_QUANTITY);
 
-  std::vector<Trade<Material> > trades;
+  std::vector<Trade<Material>> trades;
   trades.push_back(trade);
 
-  std::vector<std::pair<Trade<Material>, Material::Ptr> > responses;
+  std::vector<std::pair<Trade<Material>, Material::Ptr>> responses;
 
   // Get the trade
   conv_facility->GetMatlTrades(trades, responses);
@@ -278,7 +281,7 @@ TEST_F(ConversionTest, Convert) {
   conv_facility->Convert();
 
   // Check that material was moved from input to output
-  EXPECT_DOUBLE_EQ(DEFAULT_THROUGHPUT, input_quantity(conv_facility));  
+  EXPECT_DOUBLE_EQ(DEFAULT_THROUGHPUT, input_quantity(conv_facility));
   EXPECT_DOUBLE_EQ(DEFAULT_THROUGHPUT, output_quantity(conv_facility));
 }
 
@@ -294,7 +297,7 @@ TEST_F(ConversionTest, ConvertWithLessThanThroughput) {
   conv_facility->Convert();
 
   // Check that all material was moved from input to output
-  EXPECT_DOUBLE_EQ(0.0, input_quantity(conv_facility)); 
+  EXPECT_DOUBLE_EQ(0.0, input_quantity(conv_facility));
   EXPECT_DOUBLE_EQ(DEFAULT_THROUGHPUT / 2, output_quantity(conv_facility));
 }
 
@@ -346,7 +349,8 @@ TEST_F(ConversionTest, Tock) {
 TEST_F(ConversionTest, PositionInitialize) {
   std::string config = DEFAULT_CONFIG;
   int simdur = SIMULATION_DURATION;
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Conversion"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Conversion"), config,
+                      simdur);
   int id = sim.Run();
 
   cyclus::QueryResult qr = sim.db().Query("AgentPosition", NULL);
@@ -356,11 +360,14 @@ TEST_F(ConversionTest, PositionInitialize) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(ConversionTest, PositionWithCoordinates) {
-  std::string config = DEFAULT_CONFIG + 
-    "<latitude>" + std::to_string(TEST_POSITION) + "</latitude>"
-    "<longitude>" + std::to_string(TEST_POSITION) + "</longitude>";
+  std::string config = DEFAULT_CONFIG + "<latitude>" +
+                       std::to_string(TEST_POSITION) +
+                       "</latitude>"
+                       "<longitude>" +
+                       std::to_string(TEST_POSITION) + "</longitude>";
   int simdur = SIMULATION_DURATION;
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Conversion"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Conversion"), config,
+                      simdur);
   int id = sim.Run();
 
   cyclus::QueryResult qr = sim.db().Query("AgentPosition", NULL);
@@ -368,4 +375,4 @@ TEST_F(ConversionTest, PositionWithCoordinates) {
   EXPECT_EQ(qr.GetVal<double>("Longitude"), TEST_POSITION);
 }
 
-}  // namespace cycamore 
+}  // namespace cycamore

--- a/src/conversion_tests.h
+++ b/src/conversion_tests.h
@@ -25,25 +25,32 @@ class ConversionTest : public ::testing::Test {
   double throughput_val, input_capacity_val;
   cyclus::Composition::Ptr recipe;
 
-  const double TEST_QUANTITY = 10.0;  
+  const double TEST_QUANTITY = 10.0;
 
   const int SIMULATION_DURATION = 3;
   const double DEFAULT_POSITION = 0.0;
   const double TEST_POSITION = 0.01;
-  
+
   const double DEFAULT_THROUGHPUT = 10.0;
   const double DEFAULT_INPUT_CAPACITY = 50.0;
-  
+
   const std::string INCOMMOD1 = "incommod1";
   const std::string OUTCOMMOD_NAME = "outcommod";
 
-  const std::string DEFAULT_CONFIG = 
-    "<incommods>"
-    "  <incommodity>" + INCOMMOD1 + "</incommodity>"
-    "</incommods>"
-    "<outcommod>" + OUTCOMMOD_NAME + "</outcommod>"
-    "<throughput>" + std::to_string(DEFAULT_THROUGHPUT) + "</throughput>"
-    "<input_capacity>" + std::to_string(DEFAULT_INPUT_CAPACITY) + "</input_capacity>";
+  const std::string DEFAULT_CONFIG =
+      "<incommods>"
+      "  <incommodity>" +
+      INCOMMOD1 +
+      "</incommodity>"
+      "</incommods>"
+      "<outcommod>" +
+      OUTCOMMOD_NAME +
+      "</outcommod>"
+      "<throughput>" +
+      std::to_string(DEFAULT_THROUGHPUT) +
+      "</throughput>"
+      "<input_capacity>" +
+      std::to_string(DEFAULT_INPUT_CAPACITY) + "</input_capacity>";
 
   virtual void SetUp();
   virtual void TearDown();
@@ -51,7 +58,9 @@ class ConversionTest : public ::testing::Test {
   void SetUpConversion();
 
   // Accessor methods for private members
-  std::vector<std::string> incommods(cycamore::Conversion* c) { return c->incommods; }
+  std::vector<std::string> incommods(cycamore::Conversion* c) {
+    return c->incommods;
+  }
   std::string outcommod(cycamore::Conversion* c) { return c->outcommod; }
   double throughput(cycamore::Conversion* c) { return c->throughput; }
   double input_capacity(cycamore::Conversion* c) { return c->input_capacity; }
@@ -64,17 +73,26 @@ class ConversionTest : public ::testing::Test {
     c->outcommod = commod;
   }
   void throughput(cycamore::Conversion* c, double val) { c->throughput = val; }
-  void input_capacity(cycamore::Conversion* c, double val) { c->input_capacity = val; }
+  void input_capacity(cycamore::Conversion* c, double val) {
+    c->input_capacity = val;
+  }
 
   // Accessor methods for private buffers
   double input_quantity(cycamore::Conversion* c) { return c->input.quantity(); }
-  double output_quantity(cycamore::Conversion* c) { return c->output.quantity(); }
-  void input_push(cycamore::Conversion* c, cyclus::Material::Ptr mat) { c->input.Push(mat); }
-  void output_push(cycamore::Conversion* c, cyclus::Material::Ptr mat) { c->output.Push(mat); }
-  void set_input_capacity(cycamore::Conversion* c, double cap) { c->input.capacity(cap); }
-
+  double output_quantity(cycamore::Conversion* c) {
+    return c->output.quantity();
+  }
+  void input_push(cycamore::Conversion* c, cyclus::Material::Ptr mat) {
+    c->input.Push(mat);
+  }
+  void output_push(cycamore::Conversion* c, cyclus::Material::Ptr mat) {
+    c->output.Push(mat);
+  }
+  void set_input_capacity(cycamore::Conversion* c, double cap) {
+    c->input.capacity(cap);
+  }
 };
 
-} // namespace cycamore
+}  // namespace cycamore
 
-#endif  // CYCAMORE_SRC_CONVERSION_TESTS_H_ 
+#endif  // CYCAMORE_SRC_CONVERSION_TESTS_H_

--- a/src/cycamore.h
+++ b/src/cycamore.h
@@ -5,20 +5,20 @@
 /*!
  * \mainpage Cycamore API Reference
  *
- * Welcome to the Cycamore API reference! Below are some helpful links for learning more:
+ * Welcome to the Cycamore API reference! Below are some helpful links for
+ * learning more:
  *   - Cyclus Homepage: https://fuelcycle.org
  *   - GitHub repository: https://github.com/cyclus/cycamore
  *   - Kernel developer guide: https://fuelcycle.org/kernel
  *   - Archetype developer guide: https://fuelcycle.org/arche
- * 
+ *
  */
 
 // These includes must come before others.
-#include "cyclus.h"
-#include "cycamore_version.h"
-
 #include "batch_reactor.h"
 #include "batch_reactor_tests.h"
+#include "cycamore_version.h"
+#include "cyclus.h"
 #include "deploy_inst.h"
 #include "deploy_inst_tests.h"
 #include "enrichment.h"

--- a/src/cycamore.h
+++ b/src/cycamore.h
@@ -5,20 +5,20 @@
 /*!
  * \mainpage Cycamore API Reference
  *
- * Welcome to the Cycamore API reference! Below are some helpful links for
- * learning more:
+ * Welcome to the Cycamore API reference! Below are some helpful links for learning more:
  *   - Cyclus Homepage: https://fuelcycle.org
  *   - GitHub repository: https://github.com/cyclus/cycamore
  *   - Kernel developer guide: https://fuelcycle.org/kernel
  *   - Archetype developer guide: https://fuelcycle.org/arche
- *
+ * 
  */
 
 // These includes must come before others.
+#include "cyclus.h"
+#include "cycamore_version.h"
+
 #include "batch_reactor.h"
 #include "batch_reactor_tests.h"
-#include "cycamore_version.h"
-#include "cyclus.h"
 #include "deploy_inst.h"
 #include "deploy_inst_tests.h"
 #include "enrichment.h"

--- a/src/cycamore.h
+++ b/src/cycamore.h
@@ -5,12 +5,13 @@
 /*!
  * \mainpage Cycamore API Reference
  *
- * Welcome to the Cycamore API reference! Below are some helpful links for learning more:
+ * Welcome to the Cycamore API reference! Below are some helpful links for
+ * learning more:
  *   - Cyclus Homepage: https://fuelcycle.org
  *   - GitHub repository: https://github.com/cyclus/cycamore
  *   - Kernel developer guide: https://fuelcycle.org/kernel
  *   - Archetype developer guide: https://fuelcycle.org/arche
- * 
+ *
  */
 
 // These includes must come before others.

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -82,8 +82,9 @@ void DeployInst::Register_(Agent* a) {
 
   CommodityProducer* cp_cast = dynamic_cast<CommodityProducer*>(a);
   if (cp_cast != NULL) {
-    LOG(cyclus::LEV_INFO3, "mani") << "Registering agent " << a->prototype()
-                                   << a->id() << " as a commodity producer.";
+    LOG(cyclus::LEV_INFO3, "mani") << "Registering agent "
+                                   << a->prototype() << a->id()
+                                   << " as a commodity producer.";
     CommodityProducerManager::Register(cp_cast);
   }
 }
@@ -93,26 +94,28 @@ void DeployInst::Unregister_(Agent* a) {
   using cyclus::toolkit::CommodityProducerManager;
 
   CommodityProducer* cp_cast = dynamic_cast<CommodityProducer*>(a);
-  if (cp_cast != NULL) CommodityProducerManager::Unregister(cp_cast);
+  if (cp_cast != NULL)
+    CommodityProducerManager::Unregister(cp_cast);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void DeployInst::WriteProducerInformation(
-    cyclus::toolkit::CommodityProducer* producer) {
+  cyclus::toolkit::CommodityProducer* producer) {
   using std::set;
-  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>
-      commodities = producer->ProducedCommodities();
-  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>::iterator
-      it;
+  set<cyclus::toolkit::Commodity,
+      cyclus::toolkit::CommodityCompare> commodities =
+          producer->ProducedCommodities();
+  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>::
+      iterator it;
 
-  LOG(cyclus::LEV_DEBUG3, "maninst")
-      << " Clone produces " << commodities.size() << " commodities.";
+  LOG(cyclus::LEV_DEBUG3, "maninst") << " Clone produces " << commodities.size()
+                                     << " commodities.";
   for (it = commodities.begin(); it != commodities.end(); it++) {
     LOG(cyclus::LEV_DEBUG3, "maninst") << " Commodity produced: " << it->name();
-    LOG(cyclus::LEV_DEBUG3, "maninst")
-        << "           capacity: " << producer->Capacity(*it);
-    LOG(cyclus::LEV_DEBUG3, "maninst")
-        << "               cost: " << producer->Cost(*it);
+    LOG(cyclus::LEV_DEBUG3, "maninst") << "           capacity: " <<
+                                       producer->Capacity(*it);
+    LOG(cyclus::LEV_DEBUG3, "maninst") << "               cost: " <<
+                                       producer->Cost(*it);
   }
 }
 

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -82,9 +82,8 @@ void DeployInst::Register_(Agent* a) {
 
   CommodityProducer* cp_cast = dynamic_cast<CommodityProducer*>(a);
   if (cp_cast != NULL) {
-    LOG(cyclus::LEV_INFO3, "mani") << "Registering agent "
-                                   << a->prototype() << a->id()
-                                   << " as a commodity producer.";
+    LOG(cyclus::LEV_INFO3, "mani") << "Registering agent " << a->prototype()
+                                   << a->id() << " as a commodity producer.";
     CommodityProducerManager::Register(cp_cast);
   }
 }
@@ -94,28 +93,26 @@ void DeployInst::Unregister_(Agent* a) {
   using cyclus::toolkit::CommodityProducerManager;
 
   CommodityProducer* cp_cast = dynamic_cast<CommodityProducer*>(a);
-  if (cp_cast != NULL)
-    CommodityProducerManager::Unregister(cp_cast);
+  if (cp_cast != NULL) CommodityProducerManager::Unregister(cp_cast);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void DeployInst::WriteProducerInformation(
-  cyclus::toolkit::CommodityProducer* producer) {
+    cyclus::toolkit::CommodityProducer* producer) {
   using std::set;
-  set<cyclus::toolkit::Commodity,
-      cyclus::toolkit::CommodityCompare> commodities =
-          producer->ProducedCommodities();
-  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>::
-      iterator it;
+  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>
+      commodities = producer->ProducedCommodities();
+  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>::iterator
+      it;
 
-  LOG(cyclus::LEV_DEBUG3, "maninst") << " Clone produces " << commodities.size()
-                                     << " commodities.";
+  LOG(cyclus::LEV_DEBUG3, "maninst")
+      << " Clone produces " << commodities.size() << " commodities.";
   for (it = commodities.begin(); it != commodities.end(); it++) {
     LOG(cyclus::LEV_DEBUG3, "maninst") << " Commodity produced: " << it->name();
-    LOG(cyclus::LEV_DEBUG3, "maninst") << "           capacity: " <<
-                                       producer->Capacity(*it);
-    LOG(cyclus::LEV_DEBUG3, "maninst") << "               cost: " <<
-                                       producer->Cost(*it);
+    LOG(cyclus::LEV_DEBUG3, "maninst")
+        << "           capacity: " << producer->Capacity(*it);
+    LOG(cyclus::LEV_DEBUG3, "maninst")
+        << "               cost: " << producer->Cost(*it);
   }
 }
 

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -4,8 +4,7 @@
 
 namespace cycamore {
 
-DeployInst::DeployInst(cyclus::Context* ctx)
-    : cyclus::Institution(ctx) {}
+DeployInst::DeployInst(cyclus::Context* ctx) : cyclus::Institution(ctx) {}
 
 DeployInst::~DeployInst() {}
 
@@ -14,11 +13,10 @@ void DeployInst::Build(cyclus::Agent* parent) {
   BuildSched::iterator it;
   std::set<std::string> protos;
 
-  int sim_start = 12*(context()->sim_info().y0) + 
-                            context()->sim_info().m0;
+  int sim_start = 12 * (context()->sim_info().y0) + context()->sim_info().m0;
   int d_t = 0;
-  if(deployyear!=-1){
-    d_t += deployyear*12 - sim_start;
+  if (deployyear != -1) {
+    d_t += deployyear * 12 - sim_start;
   }
 
   for (int i = 0; i < prototypes.size(); i++) {
@@ -26,7 +24,7 @@ void DeployInst::Build(cyclus::Agent* parent) {
 
     std::stringstream ss;
     ss << proto;
-    
+
     if (lifetimes.size() == prototypes.size()) {
       cyclus::Agent* a = context()->CreateAgent<Agent>(proto);
       if (a->lifetime() != lifetimes[i]) {
@@ -47,15 +45,14 @@ void DeployInst::Build(cyclus::Agent* parent) {
 
     int t_build = build_times[i] + d_t;
 
-    if(t_build < 0){
+    if (t_build < 0) {
       std::stringstream ss;
-      ss << "Deploy year is before simulation start. Adjust deployment time." ;
+      ss << "Deploy year is before simulation start. Adjust deployment time.";
       throw cyclus::ValueError(ss.str());
-    }
-    else if(t_build >= context()->sim_info().duration){
+    } else if (t_build >= context()->sim_info().duration) {
       cyclus::Warn<cyclus::VALUE_WARNING>(
-      "Deployment year must be less than simulation duration;"
-      "A facility will not be deployed during the simulation.");
+          "Deployment year must be less than simulation duration;"
+          "A facility will not be deployed during the simulation.");
     }
 
     for (int j = 0; j < n_build[i]; j++) {
@@ -63,7 +60,6 @@ void DeployInst::Build(cyclus::Agent* parent) {
     }
   }
 }
-
 
 void DeployInst::EnterNotify() {
   cyclus::Institution::EnterNotify();
@@ -101,9 +97,8 @@ void DeployInst::Register_(Agent* a) {
 
   CommodityProducer* cp_cast = dynamic_cast<CommodityProducer*>(a);
   if (cp_cast != NULL) {
-    LOG(cyclus::LEV_INFO3, "mani") << "Registering agent "
-                                   << a->prototype() << a->id()
-                                   << " as a commodity producer.";
+    LOG(cyclus::LEV_INFO3, "mani") << "Registering agent " << a->prototype()
+                                   << a->id() << " as a commodity producer.";
     CommodityProducerManager::Register(cp_cast);
   }
 }
@@ -113,28 +108,26 @@ void DeployInst::Unregister_(Agent* a) {
   using cyclus::toolkit::CommodityProducerManager;
 
   CommodityProducer* cp_cast = dynamic_cast<CommodityProducer*>(a);
-  if (cp_cast != NULL)
-    CommodityProducerManager::Unregister(cp_cast);
+  if (cp_cast != NULL) CommodityProducerManager::Unregister(cp_cast);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void DeployInst::WriteProducerInformation(
-  cyclus::toolkit::CommodityProducer* producer) {
+    cyclus::toolkit::CommodityProducer* producer) {
   using std::set;
-  set<cyclus::toolkit::Commodity,
-      cyclus::toolkit::CommodityCompare> commodities =
-          producer->ProducedCommodities();
-  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>::
-      iterator it;
+  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>
+      commodities = producer->ProducedCommodities();
+  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>::iterator
+      it;
 
-  LOG(cyclus::LEV_DEBUG3, "maninst") << " Clone produces " << commodities.size()
-                                     << " commodities.";
+  LOG(cyclus::LEV_DEBUG3, "maninst")
+      << " Clone produces " << commodities.size() << " commodities.";
   for (it = commodities.begin(); it != commodities.end(); it++) {
     LOG(cyclus::LEV_DEBUG3, "maninst") << " Commodity produced: " << it->name();
-    LOG(cyclus::LEV_DEBUG3, "maninst") << "           capacity: " <<
-                                       producer->Capacity(*it);
-    LOG(cyclus::LEV_DEBUG3, "maninst") << "               cost: " <<
-                                       producer->Cost(*it);
+    LOG(cyclus::LEV_DEBUG3, "maninst")
+        << "           capacity: " << producer->Capacity(*it);
+    LOG(cyclus::LEV_DEBUG3, "maninst")
+        << "               cost: " << producer->Cost(*it);
   }
 }
 

--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -23,18 +23,21 @@ class DeployInst :
   public cyclus::Institution, 
   public cyclus::toolkit::CommodityProducerManager,
   public cyclus::toolkit::Position {
+
+  // clang-format off
   #pragma cyclus note { \
     "doc": \
-      "Builds and manages agents (facilities) according to a manually" \
-      " specified deployment schedule. Deployed agents are automatically" \
-      " decommissioned at the end of their lifetime.  Deployed and" \
-      " decommissioned agents are registered and unregistered with a" \
-      " region. The user specifies a list of prototypes for" \
-      " each and corresponding build times, number to build, and (optionally)" \
-      " lifetimes.  The same prototype can be specified multiple times with" \
-      " any combination of the same or different build times, build number," \
-      " and lifetimes. " \
+      "Builds and manages agents (facilities) according to a manually " \
+      "specified deployment schedule. Deployed agents are automatically " \
+      "decommissioned at the end of their lifetime. Deployed and " \
+      "decommissioned agents are registered and unregistered with a " \
+      "region. The user specifies a list of prototypes for each and " \
+      "corresponding build times, number to build, and (optionally) " \
+      "lifetimes. The same prototype can be specified multiple times " \
+      "with any combination of build times, numbers, and lifetimes.", \
   }
+  // clang-format on
+
  public:
   DeployInst(cyclus::Context* ctx);
 
@@ -55,72 +58,73 @@ class DeployInst :
   void WriteProducerInformation(cyclus::toolkit::CommodityProducer*
                                 producer);
 
-  private:
-  /// register a child
-  void Register_(cyclus::Agent* agent);
-
-  /// unregister a child
-  void Unregister_(cyclus::Agent* agent);
-
  protected:
+  // clang-format off
   #pragma cyclus var { \
     "doc": "Ordered list of prototypes to build.", \
-    "uitype": ("oneormore", "prototype"), \
-    "uilabel": "Prototypes to deploy", \
+    "uitype": ["oneormore", "prototype"], \
+    "uilabel": "Prototypes to deploy" \
   }
   std::vector<std::string> prototypes;
 
   #pragma cyclus var { \
     "doc": "Time step on which to deploy agents given in prototype list " \
-           "(same order).",						\
-    "uilabel": "Deployment times",					\
+           "(same order).", \
+    "uilabel": "Deployment times" \
   }
   std::vector<int> build_times;
 
   #pragma cyclus var { \
     "doc": "Number of each prototype given in prototype list that should be " \
            "deployed (same order).", \
-    "uilabel": "Number to deploy", \
+    "uilabel": "Number to deploy" \
   }
   std::vector<int> n_build;
 
-
-  #pragma cyclus var {							\
-    "doc": "Lifetimes for each prototype in prototype list (same order)." \
-           " These lifetimes override the lifetimes in the original prototype" \
-           " definition." \
-           " If unspecified, lifetimes from the original prototype definitions"\
-           " are used." \
-           " Although a new prototype is created in the Prototypes table for" \
-           " each lifetime with the suffix '_life_[lifetime]'," \
-           " all deployed agents themselves will have the same original" \
-           " prototype name (and so will the Agents tables).", \
+  #pragma cyclus var { \
+    "doc": "Lifetimes for each prototype in prototype list (same order). " \
+           "These lifetimes override the lifetimes in the original " \
+           "prototype definition. If unspecified, lifetimes from the " \
+           "original prototype definitions are used. Although a new " \
+           "prototype is created in the Prototypes table for each " \
+           "lifetime with the suffix '_life_[lifetime]', all deployed " \
+           "agents themselves will have the same original prototype " \
+           "name (and so will the Agents tables).", \
     "default": [], \
     "uilabel": "Lifetimes" \
   }
   std::vector<int> lifetimes;
+  // clang-format on
 
  private:
+  // clang-format off
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
+    "doc": "Latitude of the agent's geographical position. The value " \
+           "should be expressed in degrees as a double." \
   }
   double latitude;
 
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
+    "doc": "Longitude of the agent's geographical position. The value " \
+           "should be expressed in degrees as a double." \
   }
   double longitude;
+  // clang-format on
 
   cyclus::toolkit::Position coordinates;
 
   /// Records an agent's latitude and longitude to the output db
   void RecordPosition();
+
+  /// register a child
+  void Register_(cyclus::Agent* agent);
+
+  /// unregister a child
+  void Unregister_(cyclus::Agent* agent);
 };
 
 }  // namespace cycamore

--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -1,16 +1,16 @@
 #ifndef CYCAMORE_SRC_DEPLOY_INST_H_
 #define CYCAMORE_SRC_DEPLOY_INST_H_
 
-#include <utility>
-#include <set>
 #include <map>
+#include <set>
+#include <utility>
 
-#include "cyclus.h"
 #include "cycamore_version.h"
+#include "cyclus.h"
 
 namespace cycamore {
 
-typedef std::map<int, std::vector<std::string> > BuildSched;
+typedef std::map<int, std::vector<std::string>> BuildSched;
 
 // Builds and manages agents (facilities) according to a manually specified
 // deployment schedule. Deployed agents are automatically decommissioned at
@@ -19,11 +19,9 @@ typedef std::map<int, std::vector<std::string> > BuildSched;
 // lifetimes.  The same prototype can be specified multiple times with any
 // combination of the same or different build times, build number, and
 // lifetimes.
-class DeployInst : 
-  public cyclus::Institution, 
-  public cyclus::toolkit::CommodityProducerManager,
-  public cyclus::toolkit::Position {
-
+class DeployInst : public cyclus::Institution,
+                   public cyclus::toolkit::CommodityProducerManager,
+                   public cyclus::toolkit::Position {
   // clang-format off
   #pragma cyclus note { \
     "doc": \
@@ -45,7 +43,7 @@ class DeployInst :
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-  #pragma cyclus
+#pragma cyclus
 
   virtual void Build(cyclus::Agent* parent);
 
@@ -55,8 +53,7 @@ class DeployInst :
   virtual void DecomNotify(Agent* m);
   /// write information about a commodity producer to a stream
   /// @param producer the producer
-  void WriteProducerInformation(cyclus::toolkit::CommodityProducer*
-                                producer);
+  void WriteProducerInformation(cyclus::toolkit::CommodityProducer* producer);
 
  protected:
   // clang-format off

--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -1,16 +1,16 @@
 #ifndef CYCAMORE_SRC_DEPLOY_INST_H_
 #define CYCAMORE_SRC_DEPLOY_INST_H_
 
-#include <map>
-#include <set>
 #include <utility>
+#include <set>
+#include <map>
 
-#include "cycamore_version.h"
 #include "cyclus.h"
+#include "cycamore_version.h"
 
 namespace cycamore {
 
-typedef std::map<int, std::vector<std::string>> BuildSched;
+typedef std::map<int, std::vector<std::string> > BuildSched;
 
 // Builds and manages agents (facilities) according to a manually specified
 // deployment schedule. Deployed agents are automatically decommissioned at
@@ -19,9 +19,11 @@ typedef std::map<int, std::vector<std::string>> BuildSched;
 // lifetimes.  The same prototype can be specified multiple times with any
 // combination of the same or different build times, build number, and
 // lifetimes.
-class DeployInst : public cyclus::Institution,
-                   public cyclus::toolkit::CommodityProducerManager,
-                   public cyclus::toolkit::Position {
+class DeployInst : 
+  public cyclus::Institution, 
+  public cyclus::toolkit::CommodityProducerManager,
+  public cyclus::toolkit::Position {
+
   // clang-format off
   #pragma cyclus note { \
     "doc": \
@@ -43,7 +45,7 @@ class DeployInst : public cyclus::Institution,
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-#pragma cyclus
+  #pragma cyclus
 
   virtual void Build(cyclus::Agent* parent);
 
@@ -53,7 +55,8 @@ class DeployInst : public cyclus::Institution,
   virtual void DecomNotify(Agent* m);
   /// write information about a commodity producer to a stream
   /// @param producer the producer
-  void WriteProducerInformation(cyclus::toolkit::CommodityProducer* producer);
+  void WriteProducerInformation(cyclus::toolkit::CommodityProducer*
+                                producer);
 
  protected:
   // clang-format off

--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -105,6 +105,11 @@ class DeployInst :
   // clang-format on
 
  private:
+  /// register a child
+  void Register_(cyclus::Agent* agent);
+
+  /// unregister a child
+  void Unregister_(cyclus::Agent* agent);
   // Code Injection:
   #include "toolkit/position.cycpp.h"
 

--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -10,7 +10,7 @@
 
 namespace cycamore {
 
-typedef std::map<int, std::vector<std::string> > BuildSched;
+typedef std::map<int, std::vector<std::string>> BuildSched;
 
 // Builds and manages agents (facilities) according to a manually specified
 // deployment schedule. Deployed agents are automatically decommissioned at
@@ -19,11 +19,9 @@ typedef std::map<int, std::vector<std::string> > BuildSched;
 // lifetimes.  The same prototype can be specified multiple times with any
 // combination of the same or different build times, build number, and
 // lifetimes.
-class DeployInst : 
-  public cyclus::Institution, 
-  public cyclus::toolkit::CommodityProducerManager,
-  public cyclus::toolkit::Position {
-
+class DeployInst : public cyclus::Institution,
+                   public cyclus::toolkit::CommodityProducerManager,
+                   public cyclus::toolkit::Position {
   // clang-format off
   #pragma cyclus note { \
     "doc": \
@@ -45,7 +43,7 @@ class DeployInst :
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-  #pragma cyclus
+#pragma cyclus
 
   virtual void Build(cyclus::Agent* parent);
 
@@ -55,8 +53,7 @@ class DeployInst :
   virtual void DecomNotify(Agent* m);
   /// write information about a commodity producer to a stream
   /// @param producer the producer
-  void WriteProducerInformation(cyclus::toolkit::CommodityProducer*
-                                producer);
+  void WriteProducerInformation(cyclus::toolkit::CommodityProducer* producer);
 
  protected:
   // clang-format off
@@ -110,9 +107,8 @@ class DeployInst :
 
   /// unregister a child
   void Unregister_(cyclus::Agent* agent);
-  // Code Injection:
-  #include "toolkit/position.cycpp.h"
-
+// Code Injection:
+#include "toolkit/position.cycpp.h"
 };
 
 }  // namespace cycamore

--- a/src/deploy_inst_tests.cc
+++ b/src/deploy_inst_tests.cc
@@ -27,44 +27,45 @@ using cyclus::QueryResult;
 
 TEST_F(DeployInstTests, ProtoNames) {
   std::string config =
-      "<prototypes>  <val>foobar</val> </prototypes>"
-      "<build_times> <val>1</val>      </build_times>"
-      "<n_build>     <val>3</val>      </n_build>"
-      "<lifetimes>   <val>2</val>      </lifetimes>";
+     "<prototypes>  <val>foobar</val> </prototypes>"
+     "<build_times> <val>1</val>      </build_times>"
+     "<n_build>     <val>3</val>      </n_build>"
+     "<lifetimes>   <val>2</val>      </lifetimes>"
+     ;
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar';");
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar';"
+      );
   stmt->Step();
   EXPECT_EQ(3, stmt->GetInt(0));
 }
 
 TEST_F(DeployInstTests, BuildTimes) {
   std::string config =
-      "<prototypes>  <val>foobar</val> <val>foobar</val> </prototypes>"
-      "<build_times> <val>1</val>      <val>3</val>      </build_times>"
-      "<n_build>     <val>1</val>      <val>7</val>      </n_build>";
+     "<prototypes>  <val>foobar</val> <val>foobar</val> </prototypes>"
+     "<build_times> <val>1</val>      <val>3</val>      </build_times>"
+     "<n_build>     <val>1</val>      <val>7</val>      </n_build>"
+     ;
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND "
-      "EnterTime = 1;");
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = 1;"
+      );
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND "
-      "EnterTime = 3;");
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = 3;"
+      );
   stmt->Step();
   EXPECT_EQ(7, stmt->GetInt(0));
 }
@@ -73,100 +74,95 @@ TEST_F(DeployInstTests, BuildTimes) {
 // and in decommissioning.
 TEST_F(DeployInstTests, FiniteLifetimes) {
   std::string config =
-      "<prototypes>  <val>foobar</val> <val>foobar</val> <val>foobar</val> "
-      "</prototypes>"
-      "<build_times> <val>1</val>      <val>1</val>      <val>2</val>      "
-      "</build_times>"
-      "<n_build>     <val>1</val>      <val>7</val>      <val>3</val>      "
-      "</n_build>"
-      "<lifetimes>   <val>1</val>      <val>2</val>      <val>-1</val>     "
-      "</lifetimes>";
+     "<prototypes>  <val>foobar</val> <val>foobar</val> <val>foobar</val> </prototypes>"
+     "<build_times> <val>1</val>      <val>1</val>      <val>2</val>      </build_times>"
+     "<n_build>     <val>1</val>      <val>7</val>      <val>3</val>      </n_build>"
+     "<lifetimes>   <val>1</val>      <val>2</val>      <val>-1</val>     </lifetimes>"
+     ;
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
   // check agent deployment
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND "
-      "EnterTime = 1 AND Lifetime = 1;");
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = 1 AND Lifetime = 1;"
+      );
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND "
-      "EnterTime = 1 AND Lifetime = 2;");
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = 1 AND Lifetime = 2;"
+      );
   stmt->Step();
   EXPECT_EQ(7, stmt->GetInt(0));
 
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND "
-      "EnterTime = 2 AND Lifetime = -1;");
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = 2 AND Lifetime = -1;"
+      );
   stmt->Step();
   EXPECT_EQ(3, stmt->GetInt(0));
 
   // check decommissioning
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry As e JOIN AgentExit AS x ON x.AgentId = "
-      "e.AgentId WHERE e.Prototype = 'foobar' AND x.ExitTime = 1;");
+      "SELECT COUNT(*) FROM AgentEntry As e JOIN AgentExit AS x ON x.AgentId = e.AgentId WHERE e.Prototype = 'foobar' AND x.ExitTime = 1;"
+      );
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry As e JOIN AgentExit AS x ON x.AgentId = "
-      "e.AgentId WHERE e.Prototype = 'foobar' AND x.ExitTime = 2;");
+      "SELECT COUNT(*) FROM AgentEntry As e JOIN AgentExit AS x ON x.AgentId = e.AgentId WHERE e.Prototype = 'foobar' AND x.ExitTime = 2;"
+      );
   stmt->Step();
   EXPECT_EQ(7, stmt->GetInt(0));
 
   // agent with -1 lifetime should not be in AgentExit table
-  stmt = sim.db().db().Prepare("SELECT COUNT(*) FROM AgentExit;");
+  stmt = sim.db().db().Prepare(
+      "SELECT COUNT(*) FROM AgentExit;"
+      );
   stmt->Step();
   EXPECT_EQ(8, stmt->GetInt(0));
 }
 
 TEST_F(DeployInstTests, NoDupProtos) {
   std::string config =
-      "<prototypes>  <val>foobar</val> <val>foobar</val> <val>foobar</val> "
-      "</prototypes>"
-      "<build_times> <val>1</val>      <val>1</val>      <val>2</val>      "
-      "</build_times>"
-      "<n_build>     <val>1</val>      <val>7</val>      <val>3</val>      "
-      "</n_build>"
-      "<lifetimes>   <val>1</val>      <val>1</val>      <val>-1</val>     "
-      "</lifetimes>";
+     "<prototypes>  <val>foobar</val> <val>foobar</val> <val>foobar</val> </prototypes>"
+     "<build_times> <val>1</val>      <val>1</val>      <val>2</val>      </build_times>"
+     "<n_build>     <val>1</val>      <val>7</val>      <val>3</val>      </n_build>"
+     "<lifetimes>   <val>1</val>      <val>1</val>      <val>-1</val>     </lifetimes>"
+     ;
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
   // don't duplicate same prototypes with same custom lifetime
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM Prototypes WHERE Prototype = 'foobar_life_1';");
+      "SELECT COUNT(*) FROM Prototypes WHERE Prototype = 'foobar_life_1';"
+      );
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 
   // don't duplicate custom lifetimes that are identical to original prototype
   // lifetime.
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM Prototypes WHERE Prototype = 'foobar';");
+      "SELECT COUNT(*) FROM Prototypes WHERE Prototype = 'foobar';"
+      );
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 }
 
 TEST_F(DeployInstTests, PositionInitialize) {
   std::string config =
-      "<prototypes>  <val>foobar</val> </prototypes>"
-      "<build_times> <val>1</val>      </build_times>"
-      "<n_build>     <val>3</val>      </n_build>"
-      "<lifetimes>   <val>2</val>      </lifetimes>";
+     "<prototypes>  <val>foobar</val> </prototypes>"
+     "<build_times> <val>1</val>      </build_times>"
+     "<n_build>     <val>3</val>      </n_build>"
+     "<lifetimes>   <val>2</val>      </lifetimes>";
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
@@ -177,16 +173,15 @@ TEST_F(DeployInstTests, PositionInitialize) {
 
 TEST_F(DeployInstTests, PositionInitialize2) {
   std::string config =
-      "<prototypes>  <val>foobar</val> </prototypes>"
-      "<longitude>   -20.0             </longitude>"
-      "<latitude>    2.0               </latitude>"
-      "<build_times> <val>1</val>      </build_times>"
-      "<n_build>     <val>3</val>      </n_build>"
-      "<lifetimes>   <val>2</val>      </lifetimes>";
+     "<prototypes>  <val>foobar</val> </prototypes>"
+     "<longitude>   -20.0             </longitude>"
+     "<latitude>    2.0               </latitude>"
+     "<build_times> <val>1</val>      </build_times>"
+     "<n_build>     <val>3</val>      </n_build>"
+     "<lifetimes>   <val>2</val>      </lifetimes>";
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
@@ -199,10 +194,10 @@ TEST_F(DeployInstTests, producerexists) {
   using std::set;
   ctx_->AddPrototype("foop", producer);
   set<cyclus::toolkit::CommodityProducer*>::iterator it;
-  for (it = src_inst->cyclus::toolkit::CommodityProducerManager::producers()
-                .begin();
-       it !=
-       src_inst->cyclus::toolkit::CommodityProducerManager::producers().end();
+  for (it = src_inst->cyclus::toolkit::CommodityProducerManager::
+          producers().begin();
+       it != src_inst->cyclus::toolkit::CommodityProducerManager::
+          producers().end();
        it++) {
     EXPECT_EQ(dynamic_cast<TestProducer*>(*it)->prototype(),
               producer->prototype());
@@ -229,6 +224,6 @@ static int cyclus_agent_tests_connected = ConnectAgentTests();
 #endif  // CYCLUS_AGENT_TESTS_CONNECTED
 
 INSTANTIATE_TEST_SUITE_P(DeployInst, InstitutionTests,
-                         Values(&DeployInstitutionConstructor));
+                        Values(&DeployInstitutionConstructor));
 INSTANTIATE_TEST_SUITE_P(DeployInst, AgentTests,
-                         Values(&DeployInstitutionConstructor));
+                        Values(&DeployInstitutionConstructor));

--- a/src/deploy_inst_tests.cc
+++ b/src/deploy_inst_tests.cc
@@ -27,45 +27,44 @@ using cyclus::QueryResult;
 
 TEST_F(DeployInstTests, ProtoNames) {
   std::string config =
-     "<prototypes>  <val>foobar</val> </prototypes>"
-     "<build_times> <val>1</val>      </build_times>"
-     "<n_build>     <val>3</val>      </n_build>"
-     "<lifetimes>   <val>2</val>      </lifetimes>"
-     ;
+      "<prototypes>  <val>foobar</val> </prototypes>"
+      "<build_times> <val>1</val>      </build_times>"
+      "<n_build>     <val>3</val>      </n_build>"
+      "<lifetimes>   <val>2</val>      </lifetimes>";
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
+                      simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar';"
-      );
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar';");
   stmt->Step();
   EXPECT_EQ(3, stmt->GetInt(0));
 }
 
 TEST_F(DeployInstTests, BuildTimes) {
   std::string config =
-     "<prototypes>  <val>foobar</val> <val>foobar</val> </prototypes>"
-     "<build_times> <val>1</val>      <val>3</val>      </build_times>"
-     "<n_build>     <val>1</val>      <val>7</val>      </n_build>"
-     ;
+      "<prototypes>  <val>foobar</val> <val>foobar</val> </prototypes>"
+      "<build_times> <val>1</val>      <val>3</val>      </build_times>"
+      "<n_build>     <val>1</val>      <val>7</val>      </n_build>";
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
+                      simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = 1;"
-      );
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND "
+      "EnterTime = 1;");
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = 3;"
-      );
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND "
+      "EnterTime = 3;");
   stmt->Step();
   EXPECT_EQ(7, stmt->GetInt(0));
 }
@@ -74,95 +73,100 @@ TEST_F(DeployInstTests, BuildTimes) {
 // and in decommissioning.
 TEST_F(DeployInstTests, FiniteLifetimes) {
   std::string config =
-     "<prototypes>  <val>foobar</val> <val>foobar</val> <val>foobar</val> </prototypes>"
-     "<build_times> <val>1</val>      <val>1</val>      <val>2</val>      </build_times>"
-     "<n_build>     <val>1</val>      <val>7</val>      <val>3</val>      </n_build>"
-     "<lifetimes>   <val>1</val>      <val>2</val>      <val>-1</val>     </lifetimes>"
-     ;
+      "<prototypes>  <val>foobar</val> <val>foobar</val> <val>foobar</val> "
+      "</prototypes>"
+      "<build_times> <val>1</val>      <val>1</val>      <val>2</val>      "
+      "</build_times>"
+      "<n_build>     <val>1</val>      <val>7</val>      <val>3</val>      "
+      "</n_build>"
+      "<lifetimes>   <val>1</val>      <val>2</val>      <val>-1</val>     "
+      "</lifetimes>";
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
+                      simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
   // check agent deployment
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = 1 AND Lifetime = 1;"
-      );
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND "
+      "EnterTime = 1 AND Lifetime = 1;");
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = 1 AND Lifetime = 2;"
-      );
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND "
+      "EnterTime = 1 AND Lifetime = 2;");
   stmt->Step();
   EXPECT_EQ(7, stmt->GetInt(0));
 
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = 2 AND Lifetime = -1;"
-      );
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND "
+      "EnterTime = 2 AND Lifetime = -1;");
   stmt->Step();
   EXPECT_EQ(3, stmt->GetInt(0));
 
   // check decommissioning
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry As e JOIN AgentExit AS x ON x.AgentId = e.AgentId WHERE e.Prototype = 'foobar' AND x.ExitTime = 1;"
-      );
+      "SELECT COUNT(*) FROM AgentEntry As e JOIN AgentExit AS x ON x.AgentId = "
+      "e.AgentId WHERE e.Prototype = 'foobar' AND x.ExitTime = 1;");
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry As e JOIN AgentExit AS x ON x.AgentId = e.AgentId WHERE e.Prototype = 'foobar' AND x.ExitTime = 2;"
-      );
+      "SELECT COUNT(*) FROM AgentEntry As e JOIN AgentExit AS x ON x.AgentId = "
+      "e.AgentId WHERE e.Prototype = 'foobar' AND x.ExitTime = 2;");
   stmt->Step();
   EXPECT_EQ(7, stmt->GetInt(0));
 
   // agent with -1 lifetime should not be in AgentExit table
-  stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentExit;"
-      );
+  stmt = sim.db().db().Prepare("SELECT COUNT(*) FROM AgentExit;");
   stmt->Step();
   EXPECT_EQ(8, stmt->GetInt(0));
 }
 
 TEST_F(DeployInstTests, NoDupProtos) {
   std::string config =
-     "<prototypes>  <val>foobar</val> <val>foobar</val> <val>foobar</val> </prototypes>"
-     "<build_times> <val>1</val>      <val>1</val>      <val>2</val>      </build_times>"
-     "<n_build>     <val>1</val>      <val>7</val>      <val>3</val>      </n_build>"
-     "<lifetimes>   <val>1</val>      <val>1</val>      <val>-1</val>     </lifetimes>"
-     ;
+      "<prototypes>  <val>foobar</val> <val>foobar</val> <val>foobar</val> "
+      "</prototypes>"
+      "<build_times> <val>1</val>      <val>1</val>      <val>2</val>      "
+      "</build_times>"
+      "<n_build>     <val>1</val>      <val>7</val>      <val>3</val>      "
+      "</n_build>"
+      "<lifetimes>   <val>1</val>      <val>1</val>      <val>-1</val>     "
+      "</lifetimes>";
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
+                      simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
   // don't duplicate same prototypes with same custom lifetime
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM Prototypes WHERE Prototype = 'foobar_life_1';"
-      );
+      "SELECT COUNT(*) FROM Prototypes WHERE Prototype = 'foobar_life_1';");
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 
   // don't duplicate custom lifetimes that are identical to original prototype
   // lifetime.
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM Prototypes WHERE Prototype = 'foobar';"
-      );
+      "SELECT COUNT(*) FROM Prototypes WHERE Prototype = 'foobar';");
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 }
 
 TEST_F(DeployInstTests, PositionInitialize) {
   std::string config =
-     "<prototypes>  <val>foobar</val> </prototypes>"
-     "<build_times> <val>1</val>      </build_times>"
-     "<n_build>     <val>3</val>      </n_build>"
-     "<lifetimes>   <val>2</val>      </lifetimes>";
+      "<prototypes>  <val>foobar</val> </prototypes>"
+      "<build_times> <val>1</val>      </build_times>"
+      "<n_build>     <val>3</val>      </n_build>"
+      "<lifetimes>   <val>2</val>      </lifetimes>";
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
+                      simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
@@ -173,15 +177,16 @@ TEST_F(DeployInstTests, PositionInitialize) {
 
 TEST_F(DeployInstTests, PositionInitialize2) {
   std::string config =
-     "<prototypes>  <val>foobar</val> </prototypes>"
-     "<longitude>   -20.0             </longitude>"
-     "<latitude>    2.0               </latitude>"
-     "<build_times> <val>1</val>      </build_times>"
-     "<n_build>     <val>3</val>      </n_build>"
-     "<lifetimes>   <val>2</val>      </lifetimes>";
+      "<prototypes>  <val>foobar</val> </prototypes>"
+      "<longitude>   -20.0             </longitude>"
+      "<latitude>    2.0               </latitude>"
+      "<build_times> <val>1</val>      </build_times>"
+      "<n_build>     <val>3</val>      </n_build>"
+      "<lifetimes>   <val>2</val>      </lifetimes>";
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
+                      simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
@@ -194,10 +199,10 @@ TEST_F(DeployInstTests, producerexists) {
   using std::set;
   ctx_->AddPrototype("foop", producer);
   set<cyclus::toolkit::CommodityProducer*>::iterator it;
-  for (it = src_inst->cyclus::toolkit::CommodityProducerManager::
-          producers().begin();
-       it != src_inst->cyclus::toolkit::CommodityProducerManager::
-          producers().end();
+  for (it = src_inst->cyclus::toolkit::CommodityProducerManager::producers()
+                .begin();
+       it !=
+       src_inst->cyclus::toolkit::CommodityProducerManager::producers().end();
        it++) {
     EXPECT_EQ(dynamic_cast<TestProducer*>(*it)->prototype(),
               producer->prototype());
@@ -224,6 +229,6 @@ static int cyclus_agent_tests_connected = ConnectAgentTests();
 #endif  // CYCLUS_AGENT_TESTS_CONNECTED
 
 INSTANTIATE_TEST_SUITE_P(DeployInst, InstitutionTests,
-                        Values(&DeployInstitutionConstructor));
+                         Values(&DeployInstitutionConstructor));
 INSTANTIATE_TEST_SUITE_P(DeployInst, AgentTests,
-                        Values(&DeployInstitutionConstructor));
+                         Values(&DeployInstitutionConstructor));

--- a/src/deploy_inst_tests.cc
+++ b/src/deploy_inst_tests.cc
@@ -28,45 +28,44 @@ using cyclus::QueryResult;
 
 TEST_F(DeployInstTests, ProtoNames) {
   std::string config =
-     "<prototypes>  <val>foobar</val> </prototypes>"
-     "<build_times> <val>1</val>      </build_times>"
-     "<n_build>     <val>3</val>      </n_build>"
-     "<lifetimes>   <val>2</val>      </lifetimes>"
-     ;
+      "<prototypes>  <val>foobar</val> </prototypes>"
+      "<build_times> <val>1</val>      </build_times>"
+      "<n_build>     <val>3</val>      </n_build>"
+      "<lifetimes>   <val>2</val>      </lifetimes>";
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
+                      simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar';"
-      );
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar';");
   stmt->Step();
   EXPECT_EQ(3, stmt->GetInt(0));
 }
 
 TEST_F(DeployInstTests, BuildTimes) {
   std::string config =
-     "<prototypes>  <val>foobar</val> <val>foobar</val> </prototypes>"
-     "<build_times> <val>1</val>      <val>3</val>      </build_times>"
-     "<n_build>     <val>1</val>      <val>7</val>      </n_build>"
-     ;
+      "<prototypes>  <val>foobar</val> <val>foobar</val> </prototypes>"
+      "<build_times> <val>1</val>      <val>3</val>      </build_times>"
+      "<n_build>     <val>1</val>      <val>7</val>      </n_build>";
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
+                      simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = 1;"
-      );
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND "
+      "EnterTime = 1;");
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = 3;"
-      );
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND "
+      "EnterTime = 3;");
   stmt->Step();
   EXPECT_EQ(7, stmt->GetInt(0));
 }
@@ -75,154 +74,157 @@ TEST_F(DeployInstTests, BuildTimes) {
 // and in decommissioning.
 TEST_F(DeployInstTests, FiniteLifetimes) {
   std::string config =
-     "<prototypes>  <val>foobar</val> <val>foobar</val> <val>foobar</val> </prototypes>"
-     "<build_times> <val>1</val>      <val>1</val>      <val>2</val>      </build_times>"
-     "<n_build>     <val>1</val>      <val>7</val>      <val>3</val>      </n_build>"
-     "<lifetimes>   <val>1</val>      <val>2</val>      <val>-1</val>     </lifetimes>"
-     ;
+      "<prototypes>  <val>foobar</val> <val>foobar</val> <val>foobar</val> "
+      "</prototypes>"
+      "<build_times> <val>1</val>      <val>1</val>      <val>2</val>      "
+      "</build_times>"
+      "<n_build>     <val>1</val>      <val>7</val>      <val>3</val>      "
+      "</n_build>"
+      "<lifetimes>   <val>1</val>      <val>2</val>      <val>-1</val>     "
+      "</lifetimes>";
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
+                      simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
   // check agent deployment
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = 1 AND Lifetime = 1;"
-      );
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND "
+      "EnterTime = 1 AND Lifetime = 1;");
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = 1 AND Lifetime = 2;"
-      );
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND "
+      "EnterTime = 1 AND Lifetime = 2;");
   stmt->Step();
   EXPECT_EQ(7, stmt->GetInt(0));
 
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = 2 AND Lifetime = -1;"
-      );
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND "
+      "EnterTime = 2 AND Lifetime = -1;");
   stmt->Step();
   EXPECT_EQ(3, stmt->GetInt(0));
 
   // check decommissioning
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry As e JOIN AgentExit AS x ON x.AgentId = e.AgentId WHERE e.Prototype = 'foobar' AND x.ExitTime = 1;"
-      );
+      "SELECT COUNT(*) FROM AgentEntry As e JOIN AgentExit AS x ON x.AgentId = "
+      "e.AgentId WHERE e.Prototype = 'foobar' AND x.ExitTime = 1;");
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry As e JOIN AgentExit AS x ON x.AgentId = e.AgentId WHERE e.Prototype = 'foobar' AND x.ExitTime = 2;"
-      );
+      "SELECT COUNT(*) FROM AgentEntry As e JOIN AgentExit AS x ON x.AgentId = "
+      "e.AgentId WHERE e.Prototype = 'foobar' AND x.ExitTime = 2;");
   stmt->Step();
   EXPECT_EQ(7, stmt->GetInt(0));
 
   // agent with -1 lifetime should not be in AgentExit table
-  stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentExit;"
-      );
+  stmt = sim.db().db().Prepare("SELECT COUNT(*) FROM AgentExit;");
   stmt->Step();
   EXPECT_EQ(8, stmt->GetInt(0));
 }
 
 TEST_F(DeployInstTests, NoDupProtos) {
   std::string config =
-     "<prototypes>  <val>foobar</val> <val>foobar</val> <val>foobar</val> </prototypes>"
-     "<build_times> <val>1</val>      <val>1</val>      <val>2</val>      </build_times>"
-     "<n_build>     <val>1</val>      <val>7</val>      <val>3</val>      </n_build>"
-     "<lifetimes>   <val>1</val>      <val>1</val>      <val>-1</val>     </lifetimes>"
-     ;
+      "<prototypes>  <val>foobar</val> <val>foobar</val> <val>foobar</val> "
+      "</prototypes>"
+      "<build_times> <val>1</val>      <val>1</val>      <val>2</val>      "
+      "</build_times>"
+      "<n_build>     <val>1</val>      <val>7</val>      <val>3</val>      "
+      "</n_build>"
+      "<lifetimes>   <val>1</val>      <val>1</val>      <val>-1</val>     "
+      "</lifetimes>";
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
+                      simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
   // don't duplicate same prototypes with same custom lifetime
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM Prototypes WHERE Prototype = 'foobar_life_1';"
-      );
+      "SELECT COUNT(*) FROM Prototypes WHERE Prototype = 'foobar_life_1';");
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 
   // don't duplicate custom lifetimes that are identical to original prototype
   // lifetime.
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM Prototypes WHERE Prototype = 'foobar';"
-      );
+      "SELECT COUNT(*) FROM Prototypes WHERE Prototype = 'foobar';");
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 }
 
 TEST_F(DeployInstTests, DeployYear) {
   std::string config =
-     "<prototypes>  <val>foobar</val> </prototypes>"
-     "<build_times> <val>2</val>      </build_times>"
-     "<n_build>     <val>3</val>      </n_build>"
-     "<deployyear>     2012           </deployyear>"
-     ;
+      "<prototypes>  <val>foobar</val> </prototypes>"
+      "<build_times> <val>2</val>      </build_times>"
+      "<n_build>     <val>3</val>      </n_build>"
+      "<deployyear>     2012           </deployyear>";
 
   int simdur = 30;
-  //MockSim starts in 2010 by default
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  // MockSim starts in 2010 by default
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
+                      simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
-  // 2 years and 2 months after MockSim start is 25 time steps 
+  // 2 years and 2 months after MockSim start is 25 time steps
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = '25';"
-      );
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND "
+      "EnterTime = '25';");
   stmt->Step();
-  EXPECT_EQ(3, stmt->GetInt(0)); 
+  EXPECT_EQ(3, stmt->GetInt(0));
 }
 
 TEST_F(DeployInstTests, DeployYearEarlyError) {
   std::string config =
-     "<prototypes>  <val>foobar</val> </prototypes>"
-     "<build_times> <val>2</val>      </build_times>"
-     "<n_build>     <val>3</val>      </n_build>"
-     "<deployyear>    2000            </deployyear>"
-     ;
+      "<prototypes>  <val>foobar</val> </prototypes>"
+      "<build_times> <val>2</val>      </build_times>"
+      "<n_build>     <val>3</val>      </n_build>"
+      "<deployyear>    2000            </deployyear>";
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
+                      simdur);
 
-  EXPECT_THROW(sim.Run(),cyclus::ValueError); 
+  EXPECT_THROW(sim.Run(), cyclus::ValueError);
 }
 
 TEST_F(DeployInstTests, DeployYearLateWarn) {
   std::string config =
-     "<prototypes>  <val>foobar</val> </prototypes>"
-     "<build_times> <val>2</val>      </build_times>"
-     "<n_build>     <val>3</val>      </n_build>"
-     "<deployyear>    2030          </deployyear>"
-     ;
+      "<prototypes>  <val>foobar</val> </prototypes>"
+      "<build_times> <val>2</val>      </build_times>"
+      "<n_build>     <val>3</val>      </n_build>"
+      "<deployyear>    2030          </deployyear>";
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
+                      simdur);
 
   cyclus::warn_as_error = true;
-  EXPECT_THROW(sim.Run(),
-               cyclus::ValueError);
+  EXPECT_THROW(sim.Run(), cyclus::ValueError);
   cyclus::warn_as_error = false;
 
   int id = sim.Run();
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar';"
-      );
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar';");
   stmt->Step();
   EXPECT_EQ(0, stmt->GetInt(0));
 }
 
 TEST_F(DeployInstTests, PositionInitialize) {
   std::string config =
-     "<prototypes>  <val>foobar</val> </prototypes>"
-     "<build_times> <val>1</val>      </build_times>"
-     "<n_build>     <val>3</val>      </n_build>"
-     "<lifetimes>   <val>2</val>      </lifetimes>";
+      "<prototypes>  <val>foobar</val> </prototypes>"
+      "<build_times> <val>1</val>      </build_times>"
+      "<n_build>     <val>3</val>      </n_build>"
+      "<lifetimes>   <val>2</val>      </lifetimes>";
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
+                      simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
@@ -233,15 +235,16 @@ TEST_F(DeployInstTests, PositionInitialize) {
 
 TEST_F(DeployInstTests, PositionInitialize2) {
   std::string config =
-     "<prototypes>  <val>foobar</val> </prototypes>"
-     "<longitude>   -20.0             </longitude>"
-     "<latitude>    2.0               </latitude>"
-     "<build_times> <val>1</val>      </build_times>"
-     "<n_build>     <val>3</val>      </n_build>"
-     "<lifetimes>   <val>2</val>      </lifetimes>";
+      "<prototypes>  <val>foobar</val> </prototypes>"
+      "<longitude>   -20.0             </longitude>"
+      "<latitude>    2.0               </latitude>"
+      "<build_times> <val>1</val>      </build_times>"
+      "<n_build>     <val>3</val>      </n_build>"
+      "<lifetimes>   <val>2</val>      </lifetimes>";
 
   int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config,
+                      simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
@@ -254,10 +257,10 @@ TEST_F(DeployInstTests, producerexists) {
   using std::set;
   ctx_->AddPrototype("foop", producer);
   set<cyclus::toolkit::CommodityProducer*>::iterator it;
-  for (it = src_inst->cyclus::toolkit::CommodityProducerManager::
-          producers().begin();
-       it != src_inst->cyclus::toolkit::CommodityProducerManager::
-          producers().end();
+  for (it = src_inst->cyclus::toolkit::CommodityProducerManager::producers()
+                .begin();
+       it !=
+       src_inst->cyclus::toolkit::CommodityProducerManager::producers().end();
        it++) {
     EXPECT_EQ(dynamic_cast<TestProducer*>(*it)->prototype(),
               producer->prototype());
@@ -284,6 +287,6 @@ static int cyclus_agent_tests_connected = ConnectAgentTests();
 #endif  // CYCLUS_AGENT_TESTS_CONNECTED
 
 INSTANTIATE_TEST_SUITE_P(DeployInst, InstitutionTests,
-                        Values(&DeployInstitutionConstructor));
+                         Values(&DeployInstitutionConstructor));
 INSTANTIATE_TEST_SUITE_P(DeployInst, AgentTests,
-                        Values(&DeployInstitutionConstructor));
+                         Values(&DeployInstitutionConstructor));

--- a/src/deploy_inst_tests.h
+++ b/src/deploy_inst_tests.h
@@ -3,17 +3,19 @@
 
 #include <gtest/gtest.h>
 
+#include "cyclus.h"
+#include "timer.h"
+#include "test_context.h"
+#include "institution_tests.h"
 #include "agent_tests.h"
 #include "context.h"
-#include "cyclus.h"
 #include "deploy_inst.h"
-#include "institution_tests.h"
-#include "test_context.h"
-#include "timer.h"
+
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-class TestProducer : public cyclus::Facility,
-                     public cyclus::toolkit::CommodityProducer {
+class TestProducer
+    : public cyclus::Facility,
+      public cyclus::toolkit::CommodityProducer {
  public:
   TestProducer(cyclus::Context* ctx);
   ~TestProducer();
@@ -24,7 +26,9 @@ class TestProducer : public cyclus::Facility,
     return m;
   }
 
-  void InitFrom(TestProducer* m) { cyclus::Facility::InitFrom(m); }
+  void InitFrom(TestProducer* m) {
+    cyclus::Facility::InitFrom(m);
+  }
 
   void InitInv(cyclus::Inventories& inv) {}
 

--- a/src/deploy_inst_tests.h
+++ b/src/deploy_inst_tests.h
@@ -3,19 +3,17 @@
 
 #include <gtest/gtest.h>
 
-#include "cyclus.h"
-#include "timer.h"
-#include "test_context.h"
-#include "institution_tests.h"
 #include "agent_tests.h"
 #include "context.h"
+#include "cyclus.h"
 #include "deploy_inst.h"
-
+#include "institution_tests.h"
+#include "test_context.h"
+#include "timer.h"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-class TestProducer
-    : public cyclus::Facility,
-      public cyclus::toolkit::CommodityProducer {
+class TestProducer : public cyclus::Facility,
+                     public cyclus::toolkit::CommodityProducer {
  public:
   TestProducer(cyclus::Context* ctx);
   ~TestProducer();
@@ -26,9 +24,7 @@ class TestProducer
     return m;
   }
 
-  void InitFrom(TestProducer* m) {
-    cyclus::Facility::InitFrom(m);
-  }
+  void InitFrom(TestProducer* m) { cyclus::Facility::InitFrom(m); }
 
   void InitInv(cyclus::Inventories& inv) {}
 

--- a/src/deploy_inst_tests.h
+++ b/src/deploy_inst_tests.h
@@ -11,11 +11,9 @@
 #include "context.h"
 #include "deploy_inst.h"
 
-
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-class TestProducer
-    : public cyclus::Facility,
-      public cyclus::toolkit::CommodityProducer {
+class TestProducer : public cyclus::Facility,
+                     public cyclus::toolkit::CommodityProducer {
  public:
   TestProducer(cyclus::Context* ctx);
   ~TestProducer();
@@ -26,9 +24,7 @@ class TestProducer
     return m;
   }
 
-  void InitFrom(TestProducer* m) {
-    cyclus::Facility::InitFrom(m);
-  }
+  void InitFrom(TestProducer* m) { cyclus::Facility::InitFrom(m); }
 
   void InitInv(cyclus::Inventories& inv) {}
 

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -2,11 +2,12 @@
 #include "enrichment.h"
 
 #include <algorithm>
-#include <boost/lexical_cast.hpp>
 #include <cmath>
 #include <limits>
 #include <sstream>
 #include <vector>
+
+#include <boost/lexical_cast.hpp>
 
 using cyclus::Material;
 
@@ -51,8 +52,8 @@ void Enrichment::Build(cyclus::Agent* parent) {
                                     context()->GetRecipe(feed_recipe)));
   }
 
-  LOG(cyclus::LEV_DEBUG2, "EnrFac")
-      << "Enrichment " << " entering the simuluation: ";
+  LOG(cyclus::LEV_DEBUG2, "EnrFac") << "Enrichment "
+                                    << " entering the simuluation: ";
   LOG(cyclus::LEV_DEBUG2, "EnrFac") << str();
   RecordPosition();
 }
@@ -60,18 +61,19 @@ void Enrichment::Build(cyclus::Agent* parent) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::Tick() {
   current_swu_capacity = SwuCapacity();
+
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::Tock() {
   using cyclus::toolkit::RecordTimeSeries;
-  LOG(cyclus::LEV_INFO4, "EnrFac")
-      << prototype() << " used " << intra_timestep_swu_ << " SWU";
+  LOG(cyclus::LEV_INFO4, "EnrFac") << prototype() << " used "
+                                   << intra_timestep_swu_ << " SWU";
   RecordTimeSeries<cyclus::toolkit::ENRICH_SWU>(this, intra_timestep_swu_);
-  LOG(cyclus::LEV_INFO4, "EnrFac")
-      << prototype() << " used " << intra_timestep_feed_ << " feed";
+  LOG(cyclus::LEV_INFO4, "EnrFac") << prototype() << " used "
+                                   << intra_timestep_feed_ << " feed";
   RecordTimeSeries<cyclus::toolkit::ENRICH_FEED>(this, intra_timestep_feed_);
-  RecordTimeSeries<double>("demand" + feed_commod, this, intra_timestep_feed_);
+  RecordTimeSeries<double>("demand"+feed_commod, this, intra_timestep_feed_);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -93,7 +95,8 @@ Enrichment::GetMatlRequests() {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-bool SortBids(cyclus::Bid<Material>* i, cyclus::Bid<Material>* j) {
+bool SortBids(cyclus::Bid<Material>* i,
+              cyclus::Bid<Material>* j) {
   Material::Ptr mat_i = i->offer();
   Material::Ptr mat_j = j->offer();
 
@@ -106,7 +109,8 @@ bool SortBids(cyclus::Bid<Material>* i, cyclus::Bid<Material>* j) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Sort offers of input material to have higher preference for more
 //  U-235 content
-void Enrichment::AdjustMatlPrefs(cyclus::PrefMap<Material>::type& prefs) {
+void Enrichment::AdjustMatlPrefs(
+    cyclus::PrefMap<Material>::type& prefs) {
   using cyclus::Bid;
 
   if (order_prefs == false) {
@@ -144,17 +148,17 @@ void Enrichment::AdjustMatlPrefs(cyclus::PrefMap<Material>::type& prefs) {
       }
       (reqit->second)[bids_vector[bidit]] = new_pref;
     }  // each bid
-  }  // each Material Request
+  }    // each Material Request
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::AcceptMatlTrades(
-    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>&
-        responses) {
+    const std::vector<std::pair<cyclus::Trade<Material>,
+                                Material::Ptr> >& responses) {
   // see
   // http://stackoverflow.com/questions/5181183/boostshared-ptr-and-inheritance
-  std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>::const_iterator
-      it;
+  std::vector<std::pair<cyclus::Trade<Material>,
+                        Material::Ptr> >::const_iterator it;
   for (it = responses.begin(); it != responses.end(); ++it) {
     AddMat_(it->second);
   }
@@ -173,8 +177,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Enrichment::GetMatlBids(
   std::set<BidPortfolio<Material>::Ptr> ports;
 
   RecordTimeSeries<double>("supply" + tails_commod, this, tails.quantity());
-  RecordTimeSeries<double>("supply" + product_commod, this,
-                           inventory.quantity());
+  RecordTimeSeries<double>("supply" + product_commod, this, inventory.quantity());
   if ((out_requests.count(tails_commod) > 0) && (tails.quantity() > 0)) {
     BidPortfolio<Material>::Ptr tails_port(new BidPortfolio<Material>());
 
@@ -196,9 +199,9 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Enrichment::GetMatlBids(
     // add an overall capacity constraint
     CapacityConstraint<Material> tails_constraint(tails.quantity());
     tails_port->AddConstraint(tails_constraint);
-    LOG(cyclus::LEV_INFO5, "EnrFac")
-        << prototype() << " adding tails capacity constraint of "
-        << tails.capacity();
+    LOG(cyclus::LEV_INFO5, "EnrFac") << prototype()
+                                     << " adding tails capacity constraint of "
+                                     << tails.capacity();
     ports.insert(tails_port);
   }
 
@@ -246,8 +249,9 @@ bool Enrichment::ValidReq(const Material::Ptr mat) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::GetMatlTrades(
-    const std::vector<cyclus::Trade<Material>>& trades,
-    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>& responses) {
+    const std::vector<cyclus::Trade<Material> >& trades,
+    std::vector<std::pair<cyclus::Trade<Material>,
+                          Material::Ptr> >& responses) {
   using cyclus::Trade;
 
   intra_timestep_swu_ = 0;
@@ -262,14 +266,14 @@ void Enrichment::GetMatlTrades(
     // if tails then make transfer of material
     if (commod_type == tails_commod) {
       LOG(cyclus::LEV_INFO5, "EnrFac")
-          << prototype() << " just received an order" << " for " << it->amt
-          << " of " << tails_commod;
+          << prototype() << " just received an order"
+          << " for " << it->amt << " of " << tails_commod;
       double pop_qty = std::min(qty, tails.quantity());
       response = tails.Pop(pop_qty, cyclus::eps_rsrc());
     } else {
       LOG(cyclus::LEV_INFO5, "EnrFac")
-          << prototype() << " just received an order" << " for " << it->amt
-          << " of " << product_commod;
+          << prototype() << " just received an order"
+          << " for " << it->amt << " of " << product_commod;
       response = Enrich_(it->bid->offer(), qty);
     }
     responses.push_back(std::make_pair(*it, response));
@@ -285,6 +289,7 @@ void Enrichment::GetMatlTrades(
                              " is being asked to provide more than" +
                              " its SWU capacity.");
   }
+
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::AddMat_(Material::Ptr mat) {
@@ -332,7 +337,8 @@ void Enrichment::AddMat_(Material::Ptr mat) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Material::Ptr Enrichment::Request_() {
   double qty = std::max(0.0, inventory.capacity() - inventory.quantity());
-  return Material::CreateUntracked(qty, context()->GetRecipe(feed_recipe));
+  return Material::CreateUntracked(qty,
+                                           context()->GetRecipe(feed_recipe));
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -341,16 +347,17 @@ Material::Ptr Enrichment::Offer_(Material::Ptr mat) {
   cyclus::CompMap comp;
   comp[922350000] = q.atom_frac(922350000);
   comp[922380000] = q.atom_frac(922380000);
-  return Material::CreateUntracked(mat->quantity(),
-                                   cyclus::Composition::CreateFromAtom(comp));
+  return Material::CreateUntracked(
+      mat->quantity(), cyclus::Composition::CreateFromAtom(comp));
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Material::Ptr Enrichment::Enrich_(Material::Ptr mat, double qty) {
+Material::Ptr Enrichment::Enrich_(Material::Ptr mat,
+                                          double qty) {
   using cyclus::toolkit::Assays;
-  using cyclus::toolkit::FeedQty;
-  using cyclus::toolkit::SwuRequired;
-  using cyclus::toolkit::TailsQty;
   using cyclus::toolkit::UraniumAssayMass;
+  using cyclus::toolkit::SwuRequired;
+  using cyclus::toolkit::FeedQty;
+  using cyclus::toolkit::TailsQty;
 
   // get enrichment parameters
   Assays assays(FeedAssay(), UraniumAssayMass(mat), tails_assay);
@@ -401,32 +408,32 @@ Material::Ptr Enrichment::Enrich_(Material::Ptr mat, double qty) {
   intra_timestep_feed_ += feed_req;
   RecordEnrichment_(feed_req, swu_req);
 
-  LOG(cyclus::LEV_INFO5, "EnrFac")
-      << prototype() << " has performed an enrichment: ";
+  LOG(cyclus::LEV_INFO5, "EnrFac") << prototype()
+                                   << " has performed an enrichment: ";
   LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Feed Qty: " << feed_req;
-  LOG(cyclus::LEV_INFO5, "EnrFac")
-      << "   * Feed Assay: " << assays.Feed() * 100;
+  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Feed Assay: "
+                                   << assays.Feed() * 100;
   LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Product Qty: " << qty;
-  LOG(cyclus::LEV_INFO5, "EnrFac")
-      << "   * Product Assay: " << assays.Product() * 100;
-  LOG(cyclus::LEV_INFO5, "EnrFac")
-      << "   * Tails Qty: " << TailsQty(qty, assays);
-  LOG(cyclus::LEV_INFO5, "EnrFac")
-      << "   * Tails Assay: " << assays.Tails() * 100;
+  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Product Assay: "
+                                   << assays.Product() * 100;
+  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Tails Qty: "
+                                   << TailsQty(qty, assays);
+  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Tails Assay: "
+                                   << assays.Tails() * 100;
   LOG(cyclus::LEV_INFO5, "EnrFac") << "   * SWU: " << swu_req;
-  LOG(cyclus::LEV_INFO5, "EnrFac")
-      << "   * Current SWU capacity: " << current_swu_capacity;
+  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Current SWU capacity: "
+                                   << current_swu_capacity;
 
   return response;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::RecordEnrichment_(double natural_u, double swu) {
-  using cyclus::Agent;
   using cyclus::Context;
+  using cyclus::Agent;
 
-  LOG(cyclus::LEV_DEBUG1, "EnrFac")
-      << prototype() << " has enriched a material:";
+  LOG(cyclus::LEV_DEBUG1, "EnrFac") << prototype()
+                                    << " has enriched a material:";
   LOG(cyclus::LEV_DEBUG1, "EnrFac") << "  * Amount: " << natural_u;
   LOG(cyclus::LEV_DEBUG1, "EnrFac") << "  *    SWU: " << swu;
 
@@ -444,7 +451,8 @@ double Enrichment::FeedAssay() {
     return 0;
   }
   double pop_qty = inventory.quantity();
-  Material::Ptr fission_matl = inventory.Pop(pop_qty, cyclus::eps_rsrc());
+  Material::Ptr fission_matl =
+      inventory.Pop(pop_qty, cyclus::eps_rsrc());
   inventory.Push(fission_matl);
   return cyclus::toolkit::UraniumAssayMass(fission_matl);
 }

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -2,12 +2,11 @@
 #include "enrichment.h"
 
 #include <algorithm>
+#include <boost/lexical_cast.hpp>
 #include <cmath>
 #include <limits>
 #include <sstream>
 #include <vector>
-
-#include <boost/lexical_cast.hpp>
 
 using cyclus::Material;
 
@@ -52,8 +51,8 @@ void Enrichment::Build(cyclus::Agent* parent) {
                                     context()->GetRecipe(feed_recipe)));
   }
 
-  LOG(cyclus::LEV_DEBUG2, "EnrFac") << "Enrichment "
-                                    << " entering the simuluation: ";
+  LOG(cyclus::LEV_DEBUG2, "EnrFac")
+      << "Enrichment " << " entering the simuluation: ";
   LOG(cyclus::LEV_DEBUG2, "EnrFac") << str();
   RecordPosition();
 }
@@ -61,19 +60,18 @@ void Enrichment::Build(cyclus::Agent* parent) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::Tick() {
   current_swu_capacity = SwuCapacity();
-
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::Tock() {
   using cyclus::toolkit::RecordTimeSeries;
-  LOG(cyclus::LEV_INFO4, "EnrFac") << prototype() << " used "
-                                   << intra_timestep_swu_ << " SWU";
+  LOG(cyclus::LEV_INFO4, "EnrFac")
+      << prototype() << " used " << intra_timestep_swu_ << " SWU";
   RecordTimeSeries<cyclus::toolkit::ENRICH_SWU>(this, intra_timestep_swu_);
-  LOG(cyclus::LEV_INFO4, "EnrFac") << prototype() << " used "
-                                   << intra_timestep_feed_ << " feed";
+  LOG(cyclus::LEV_INFO4, "EnrFac")
+      << prototype() << " used " << intra_timestep_feed_ << " feed";
   RecordTimeSeries<cyclus::toolkit::ENRICH_FEED>(this, intra_timestep_feed_);
-  RecordTimeSeries<double>("demand"+feed_commod, this, intra_timestep_feed_);
+  RecordTimeSeries<double>("demand" + feed_commod, this, intra_timestep_feed_);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -95,8 +93,7 @@ Enrichment::GetMatlRequests() {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-bool SortBids(cyclus::Bid<Material>* i,
-              cyclus::Bid<Material>* j) {
+bool SortBids(cyclus::Bid<Material>* i, cyclus::Bid<Material>* j) {
   Material::Ptr mat_i = i->offer();
   Material::Ptr mat_j = j->offer();
 
@@ -109,8 +106,7 @@ bool SortBids(cyclus::Bid<Material>* i,
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Sort offers of input material to have higher preference for more
 //  U-235 content
-void Enrichment::AdjustMatlPrefs(
-    cyclus::PrefMap<Material>::type& prefs) {
+void Enrichment::AdjustMatlPrefs(cyclus::PrefMap<Material>::type& prefs) {
   using cyclus::Bid;
 
   if (order_prefs == false) {
@@ -148,17 +144,17 @@ void Enrichment::AdjustMatlPrefs(
       }
       (reqit->second)[bids_vector[bidit]] = new_pref;
     }  // each bid
-  }    // each Material Request
+  }  // each Material Request
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::AcceptMatlTrades(
-    const std::vector<std::pair<cyclus::Trade<Material>,
-                                Material::Ptr> >& responses) {
+    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>&
+        responses) {
   // see
   // http://stackoverflow.com/questions/5181183/boostshared-ptr-and-inheritance
-  std::vector<std::pair<cyclus::Trade<Material>,
-                        Material::Ptr> >::const_iterator it;
+  std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>::const_iterator
+      it;
   for (it = responses.begin(); it != responses.end(); ++it) {
     AddMat_(it->second);
   }
@@ -177,7 +173,8 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Enrichment::GetMatlBids(
   std::set<BidPortfolio<Material>::Ptr> ports;
 
   RecordTimeSeries<double>("supply" + tails_commod, this, tails.quantity());
-  RecordTimeSeries<double>("supply" + product_commod, this, inventory.quantity());
+  RecordTimeSeries<double>("supply" + product_commod, this,
+                           inventory.quantity());
   if ((out_requests.count(tails_commod) > 0) && (tails.quantity() > 0)) {
     BidPortfolio<Material>::Ptr tails_port(new BidPortfolio<Material>());
 
@@ -199,9 +196,9 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Enrichment::GetMatlBids(
     // add an overall capacity constraint
     CapacityConstraint<Material> tails_constraint(tails.quantity());
     tails_port->AddConstraint(tails_constraint);
-    LOG(cyclus::LEV_INFO5, "EnrFac") << prototype()
-                                     << " adding tails capacity constraint of "
-                                     << tails.capacity();
+    LOG(cyclus::LEV_INFO5, "EnrFac")
+        << prototype() << " adding tails capacity constraint of "
+        << tails.capacity();
     ports.insert(tails_port);
   }
 
@@ -249,9 +246,8 @@ bool Enrichment::ValidReq(const Material::Ptr mat) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::GetMatlTrades(
-    const std::vector<cyclus::Trade<Material> >& trades,
-    std::vector<std::pair<cyclus::Trade<Material>,
-                          Material::Ptr> >& responses) {
+    const std::vector<cyclus::Trade<Material>>& trades,
+    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>& responses) {
   using cyclus::Trade;
 
   intra_timestep_swu_ = 0;
@@ -266,14 +262,14 @@ void Enrichment::GetMatlTrades(
     // if tails then make transfer of material
     if (commod_type == tails_commod) {
       LOG(cyclus::LEV_INFO5, "EnrFac")
-          << prototype() << " just received an order"
-          << " for " << it->amt << " of " << tails_commod;
+          << prototype() << " just received an order" << " for " << it->amt
+          << " of " << tails_commod;
       double pop_qty = std::min(qty, tails.quantity());
       response = tails.Pop(pop_qty, cyclus::eps_rsrc());
     } else {
       LOG(cyclus::LEV_INFO5, "EnrFac")
-          << prototype() << " just received an order"
-          << " for " << it->amt << " of " << product_commod;
+          << prototype() << " just received an order" << " for " << it->amt
+          << " of " << product_commod;
       response = Enrich_(it->bid->offer(), qty);
     }
     responses.push_back(std::make_pair(*it, response));
@@ -289,7 +285,6 @@ void Enrichment::GetMatlTrades(
                              " is being asked to provide more than" +
                              " its SWU capacity.");
   }
-
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::AddMat_(Material::Ptr mat) {
@@ -337,8 +332,7 @@ void Enrichment::AddMat_(Material::Ptr mat) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Material::Ptr Enrichment::Request_() {
   double qty = std::max(0.0, inventory.capacity() - inventory.quantity());
-  return Material::CreateUntracked(qty,
-                                           context()->GetRecipe(feed_recipe));
+  return Material::CreateUntracked(qty, context()->GetRecipe(feed_recipe));
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -347,17 +341,16 @@ Material::Ptr Enrichment::Offer_(Material::Ptr mat) {
   cyclus::CompMap comp;
   comp[922350000] = q.atom_frac(922350000);
   comp[922380000] = q.atom_frac(922380000);
-  return Material::CreateUntracked(
-      mat->quantity(), cyclus::Composition::CreateFromAtom(comp));
+  return Material::CreateUntracked(mat->quantity(),
+                                   cyclus::Composition::CreateFromAtom(comp));
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Material::Ptr Enrichment::Enrich_(Material::Ptr mat,
-                                          double qty) {
+Material::Ptr Enrichment::Enrich_(Material::Ptr mat, double qty) {
   using cyclus::toolkit::Assays;
-  using cyclus::toolkit::UraniumAssayMass;
-  using cyclus::toolkit::SwuRequired;
   using cyclus::toolkit::FeedQty;
+  using cyclus::toolkit::SwuRequired;
   using cyclus::toolkit::TailsQty;
+  using cyclus::toolkit::UraniumAssayMass;
 
   // get enrichment parameters
   Assays assays(FeedAssay(), UraniumAssayMass(mat), tails_assay);
@@ -408,32 +401,32 @@ Material::Ptr Enrichment::Enrich_(Material::Ptr mat,
   intra_timestep_feed_ += feed_req;
   RecordEnrichment_(feed_req, swu_req);
 
-  LOG(cyclus::LEV_INFO5, "EnrFac") << prototype()
-                                   << " has performed an enrichment: ";
+  LOG(cyclus::LEV_INFO5, "EnrFac")
+      << prototype() << " has performed an enrichment: ";
   LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Feed Qty: " << feed_req;
-  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Feed Assay: "
-                                   << assays.Feed() * 100;
+  LOG(cyclus::LEV_INFO5, "EnrFac")
+      << "   * Feed Assay: " << assays.Feed() * 100;
   LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Product Qty: " << qty;
-  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Product Assay: "
-                                   << assays.Product() * 100;
-  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Tails Qty: "
-                                   << TailsQty(qty, assays);
-  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Tails Assay: "
-                                   << assays.Tails() * 100;
+  LOG(cyclus::LEV_INFO5, "EnrFac")
+      << "   * Product Assay: " << assays.Product() * 100;
+  LOG(cyclus::LEV_INFO5, "EnrFac")
+      << "   * Tails Qty: " << TailsQty(qty, assays);
+  LOG(cyclus::LEV_INFO5, "EnrFac")
+      << "   * Tails Assay: " << assays.Tails() * 100;
   LOG(cyclus::LEV_INFO5, "EnrFac") << "   * SWU: " << swu_req;
-  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Current SWU capacity: "
-                                   << current_swu_capacity;
+  LOG(cyclus::LEV_INFO5, "EnrFac")
+      << "   * Current SWU capacity: " << current_swu_capacity;
 
   return response;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::RecordEnrichment_(double natural_u, double swu) {
-  using cyclus::Context;
   using cyclus::Agent;
+  using cyclus::Context;
 
-  LOG(cyclus::LEV_DEBUG1, "EnrFac") << prototype()
-                                    << " has enriched a material:";
+  LOG(cyclus::LEV_DEBUG1, "EnrFac")
+      << prototype() << " has enriched a material:";
   LOG(cyclus::LEV_DEBUG1, "EnrFac") << "  * Amount: " << natural_u;
   LOG(cyclus::LEV_DEBUG1, "EnrFac") << "  *    SWU: " << swu;
 
@@ -451,8 +444,7 @@ double Enrichment::FeedAssay() {
     return 0;
   }
   double pop_qty = inventory.quantity();
-  Material::Ptr fission_matl =
-      inventory.Pop(pop_qty, cyclus::eps_rsrc());
+  Material::Ptr fission_matl = inventory.Pop(pop_qty, cyclus::eps_rsrc());
   inventory.Push(fission_matl);
   return cyclus::toolkit::UraniumAssayMass(fission_matl);
 }

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -49,8 +49,8 @@ void Enrichment::Build(cyclus::Agent* parent) {
                                     context()->GetRecipe(feed_recipe)));
   }
 
-  LOG(cyclus::LEV_DEBUG2, "EnrFac") << "Enrichment "
-                                    << " entering the simuluation: ";
+  LOG(cyclus::LEV_DEBUG2, "EnrFac")
+      << "Enrichment " << " entering the simuluation: ";
   LOG(cyclus::LEV_DEBUG2, "EnrFac") << str();
 }
 
@@ -62,19 +62,18 @@ void Enrichment::EnterNotify() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::Tick() {
   current_swu_capacity = SwuCapacity();
-
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::Tock() {
   using cyclus::toolkit::RecordTimeSeries;
-  LOG(cyclus::LEV_INFO4, "EnrFac") << prototype() << " used "
-                                   << intra_timestep_swu_ << " SWU";
+  LOG(cyclus::LEV_INFO4, "EnrFac")
+      << prototype() << " used " << intra_timestep_swu_ << " SWU";
   RecordTimeSeries<cyclus::toolkit::ENRICH_SWU>(this, intra_timestep_swu_);
-  LOG(cyclus::LEV_INFO4, "EnrFac") << prototype() << " used "
-                                   << intra_timestep_feed_ << " feed";
+  LOG(cyclus::LEV_INFO4, "EnrFac")
+      << prototype() << " used " << intra_timestep_feed_ << " feed";
   RecordTimeSeries<cyclus::toolkit::ENRICH_FEED>(this, intra_timestep_feed_);
-  RecordTimeSeries<double>("demand"+feed_commod, this, intra_timestep_feed_);
+  RecordTimeSeries<double>("demand" + feed_commod, this, intra_timestep_feed_);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -96,8 +95,7 @@ Enrichment::GetMatlRequests() {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-bool SortBids(cyclus::Bid<Material>* i,
-              cyclus::Bid<Material>* j) {
+bool SortBids(cyclus::Bid<Material>* i, cyclus::Bid<Material>* j) {
   Material::Ptr mat_i = i->offer();
   Material::Ptr mat_j = j->offer();
 
@@ -110,8 +108,7 @@ bool SortBids(cyclus::Bid<Material>* i,
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Sort offers of input material to have higher preference for more
 //  U-235 content
-void Enrichment::AdjustMatlPrefs(
-    cyclus::PrefMap<Material>::type& prefs) {
+void Enrichment::AdjustMatlPrefs(cyclus::PrefMap<Material>::type& prefs) {
   using cyclus::Bid;
 
   if (order_prefs == false) {
@@ -149,17 +146,17 @@ void Enrichment::AdjustMatlPrefs(
       }
       (reqit->second)[bids_vector[bidit]] = new_pref;
     }  // each bid
-  }    // each Material Request
+  }  // each Material Request
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::AcceptMatlTrades(
-    const std::vector<std::pair<cyclus::Trade<Material>,
-                                Material::Ptr> >& responses) {
+    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>&
+        responses) {
   // see
   // http://stackoverflow.com/questions/5181183/boostshared-ptr-and-inheritance
-  std::vector<std::pair<cyclus::Trade<Material>,
-                        Material::Ptr> >::const_iterator it;
+  std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>::const_iterator
+      it;
   for (it = responses.begin(); it != responses.end(); ++it) {
     AddMat_(it->second);
   }
@@ -178,7 +175,8 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Enrichment::GetMatlBids(
   std::set<BidPortfolio<Material>::Ptr> ports;
 
   RecordTimeSeries<double>("supply" + tails_commod, this, tails.quantity());
-  RecordTimeSeries<double>("supply" + product_commod, this, inventory.quantity());
+  RecordTimeSeries<double>("supply" + product_commod, this,
+                           inventory.quantity());
   if ((out_requests.count(tails_commod) > 0) && (tails.quantity() > 0)) {
     BidPortfolio<Material>::Ptr tails_port(new BidPortfolio<Material>());
 
@@ -200,9 +198,9 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Enrichment::GetMatlBids(
     // add an overall capacity constraint
     CapacityConstraint<Material> tails_constraint(tails.quantity());
     tails_port->AddConstraint(tails_constraint);
-    LOG(cyclus::LEV_INFO5, "EnrFac") << prototype()
-                                     << " adding tails capacity constraint of "
-                                     << tails.capacity();
+    LOG(cyclus::LEV_INFO5, "EnrFac")
+        << prototype() << " adding tails capacity constraint of "
+        << tails.capacity();
     ports.insert(tails_port);
   }
 
@@ -250,9 +248,8 @@ bool Enrichment::ValidReq(const Material::Ptr mat) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::GetMatlTrades(
-    const std::vector<cyclus::Trade<Material> >& trades,
-    std::vector<std::pair<cyclus::Trade<Material>,
-                          Material::Ptr> >& responses) {
+    const std::vector<cyclus::Trade<Material>>& trades,
+    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>& responses) {
   using cyclus::Trade;
 
   intra_timestep_swu_ = 0;
@@ -267,14 +264,14 @@ void Enrichment::GetMatlTrades(
     // if tails then make transfer of material
     if (commod_type == tails_commod) {
       LOG(cyclus::LEV_INFO5, "EnrFac")
-          << prototype() << " just received an order"
-          << " for " << it->amt << " of " << tails_commod;
+          << prototype() << " just received an order" << " for " << it->amt
+          << " of " << tails_commod;
       double pop_qty = std::min(qty, tails.quantity());
       response = tails.Pop(pop_qty, cyclus::eps_rsrc());
     } else {
       LOG(cyclus::LEV_INFO5, "EnrFac")
-          << prototype() << " just received an order"
-          << " for " << it->amt << " of " << product_commod;
+          << prototype() << " just received an order" << " for " << it->amt
+          << " of " << product_commod;
       response = Enrich_(it->bid->offer(), qty);
     }
     responses.push_back(std::make_pair(*it, response));
@@ -290,7 +287,6 @@ void Enrichment::GetMatlTrades(
                              " is being asked to provide more than" +
                              " its SWU capacity.");
   }
-
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::AddMat_(Material::Ptr mat) {
@@ -338,8 +334,7 @@ void Enrichment::AddMat_(Material::Ptr mat) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Material::Ptr Enrichment::Request_() {
   double qty = std::max(0.0, inventory.capacity() - inventory.quantity());
-  return Material::CreateUntracked(qty,
-                                           context()->GetRecipe(feed_recipe));
+  return Material::CreateUntracked(qty, context()->GetRecipe(feed_recipe));
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -348,17 +343,16 @@ Material::Ptr Enrichment::Offer_(Material::Ptr mat) {
   cyclus::CompMap comp;
   comp[922350000] = q.atom_frac(922350000);
   comp[922380000] = q.atom_frac(922380000);
-  return Material::CreateUntracked(
-      mat->quantity(), cyclus::Composition::CreateFromAtom(comp));
+  return Material::CreateUntracked(mat->quantity(),
+                                   cyclus::Composition::CreateFromAtom(comp));
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Material::Ptr Enrichment::Enrich_(Material::Ptr mat,
-                                          double qty) {
+Material::Ptr Enrichment::Enrich_(Material::Ptr mat, double qty) {
   using cyclus::toolkit::Assays;
-  using cyclus::toolkit::UraniumAssayMass;
-  using cyclus::toolkit::SwuRequired;
   using cyclus::toolkit::FeedQty;
+  using cyclus::toolkit::SwuRequired;
   using cyclus::toolkit::TailsQty;
+  using cyclus::toolkit::UraniumAssayMass;
 
   // get enrichment parameters
   Assays assays(FeedAssay(), UraniumAssayMass(mat), tails_assay);
@@ -409,32 +403,32 @@ Material::Ptr Enrichment::Enrich_(Material::Ptr mat,
   intra_timestep_feed_ += feed_req;
   RecordEnrichment_(feed_req, swu_req);
 
-  LOG(cyclus::LEV_INFO5, "EnrFac") << prototype()
-                                   << " has performed an enrichment: ";
+  LOG(cyclus::LEV_INFO5, "EnrFac")
+      << prototype() << " has performed an enrichment: ";
   LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Feed Qty: " << feed_req;
-  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Feed Assay: "
-                                   << assays.Feed() * 100;
+  LOG(cyclus::LEV_INFO5, "EnrFac")
+      << "   * Feed Assay: " << assays.Feed() * 100;
   LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Product Qty: " << qty;
-  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Product Assay: "
-                                   << assays.Product() * 100;
-  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Tails Qty: "
-                                   << TailsQty(qty, assays);
-  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Tails Assay: "
-                                   << assays.Tails() * 100;
+  LOG(cyclus::LEV_INFO5, "EnrFac")
+      << "   * Product Assay: " << assays.Product() * 100;
+  LOG(cyclus::LEV_INFO5, "EnrFac")
+      << "   * Tails Qty: " << TailsQty(qty, assays);
+  LOG(cyclus::LEV_INFO5, "EnrFac")
+      << "   * Tails Assay: " << assays.Tails() * 100;
   LOG(cyclus::LEV_INFO5, "EnrFac") << "   * SWU: " << swu_req;
-  LOG(cyclus::LEV_INFO5, "EnrFac") << "   * Current SWU capacity: "
-                                   << current_swu_capacity;
+  LOG(cyclus::LEV_INFO5, "EnrFac")
+      << "   * Current SWU capacity: " << current_swu_capacity;
 
   return response;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::RecordEnrichment_(double natural_u, double swu) {
-  using cyclus::Context;
   using cyclus::Agent;
+  using cyclus::Context;
 
-  LOG(cyclus::LEV_DEBUG1, "EnrFac") << prototype()
-                                    << " has enriched a material:";
+  LOG(cyclus::LEV_DEBUG1, "EnrFac")
+      << prototype() << " has enriched a material:";
   LOG(cyclus::LEV_DEBUG1, "EnrFac") << "  * Amount: " << natural_u;
   LOG(cyclus::LEV_DEBUG1, "EnrFac") << "  *    SWU: " << swu;
 
@@ -452,8 +446,7 @@ double Enrichment::FeedAssay() {
     return 0;
   }
   double pop_qty = inventory.quantity();
-  Material::Ptr fission_matl =
-      inventory.Pop(pop_qty, cyclus::eps_rsrc());
+  Material::Ptr fission_matl = inventory.Pop(pop_qty, cyclus::eps_rsrc());
   inventory.Push(fission_matl);
   return cyclus::toolkit::UraniumAssayMass(fission_matl);
 }

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -6,7 +6,10 @@
 #include "cyclus.h"
 #include "cycamore_version.h"
 
-#pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
+// clang-format off
+#pragma cyclus exec \
+  from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
+// clang-format on
 
 namespace cycamore {
 
@@ -16,16 +19,16 @@ namespace cycamore {
 /// determine the amount of SWU required for their proposed enrichment
 class SWUConverter : public cyclus::Converter<cyclus::Material> {
  public:
-  SWUConverter(double feed_commod, double tails) : feed_(feed_commod),
-    tails_(tails) {}
+  SWUConverter(double feed_commod, double tails)
+      : feed_(feed_commod), tails_(tails) {}
   virtual ~SWUConverter() {}
 
   /// @brief provides a conversion for the SWU required
   virtual double convert(
       cyclus::Material::Ptr m,
-      cyclus::Arc const * a = NULL,
-      cyclus::ExchangeTranslationContext<cyclus::Material>
-          const * ctx = NULL) const {
+      cyclus::Arc const* a = NULL,
+      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx = NULL)
+      const {
     cyclus::toolkit::Assays assays(feed_, cyclus::toolkit::UraniumAssayMass(m),
                                    tails_);
     return cyclus::toolkit::SwuRequired(m->quantity(), assays);
@@ -34,9 +37,7 @@ class SWUConverter : public cyclus::Converter<cyclus::Material> {
   /// @returns true if Converter is a SWUConverter and feed and tails equal
   virtual bool operator==(Converter& other) const {
     SWUConverter* cast = dynamic_cast<SWUConverter*>(&other);
-    return cast != NULL &&
-    feed_ == cast->feed_ &&
-    tails_ == cast->tails_;
+    return cast != NULL && feed_ == cast->feed_ && tails_ == cast->tails_;
   }
 
  private:
@@ -50,8 +51,8 @@ class SWUConverter : public cyclus::Converter<cyclus::Material> {
 /// enrichment
 class NatUConverter : public cyclus::Converter<cyclus::Material> {
  public:
-  NatUConverter(double feed_commod, double tails) : feed_(feed_commod),
-    tails_(tails) {}
+  NatUConverter(double feed_commod, double tails)
+      : feed_(feed_commod), tails_(tails) {}
   virtual ~NatUConverter() {}
 
   virtual std::string version() { return CYCAMORE_VERSION; }
@@ -59,9 +60,9 @@ class NatUConverter : public cyclus::Converter<cyclus::Material> {
   /// @brief provides a conversion for the amount of natural Uranium required
   virtual double convert(
       cyclus::Material::Ptr m,
-      cyclus::Arc const * a = NULL,
-      cyclus::ExchangeTranslationContext<cyclus::Material>
-          const * ctx = NULL) const {
+      cyclus::Arc const* a = NULL,
+      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx = NULL)
+      const {
     cyclus::toolkit::Assays assays(feed_, cyclus::toolkit::UraniumAssayMass(m),
                                    tails_);
     cyclus::toolkit::MatQuery mq(m);
@@ -77,143 +78,129 @@ class NatUConverter : public cyclus::Converter<cyclus::Material> {
   /// @returns true if Converter is a NatUConverter and feed and tails equal
   virtual bool operator==(Converter& other) const {
     NatUConverter* cast = dynamic_cast<NatUConverter*>(&other);
-    return cast != NULL &&
-    feed_ == cast->feed_ &&
-    tails_ == cast->tails_;
+    return cast != NULL && feed_ == cast->feed_ && tails_ == cast->tails_;
   }
 
  private:
   double feed_, tails_;
 };
 
-///  The Enrichment facility is a simple Agent that enriches natural
-///  uranium in a Cyclus simulation. It does not explicitly compute
-///  the physical enrichment process, rather it calculates the SWU
-///  required to convert a source uranium recipe (ie. natural uranium)
-///  into a requested enriched recipe (ie. 4% enriched uranium), given
-///  the natural uranium inventory constraint and its SWU capacity
-///  constraint.
+/// The Enrichment facility is a simple Agent that enriches natural
+/// uranium in a Cyclus simulation. It does not explicitly compute
+/// the physical enrichment process; rather, it calculates the SWU
+/// required to convert a source uranium recipe (ie. natural uranium)
+/// into a requested enriched recipe (ie. 4% enriched uranium), given
+/// the natural uranium inventory constraint and its SWU capacity
+/// constraint.
 ///
-///  The Enrichment facility requests an input commodity and associated recipe
-///  whose quantity is its remaining inventory capacity.  All facilities
-///  trading the same input commodity (even with different recipes) will
-///  offer materials for trade.  The Enrichment facility accepts any input
-///  materials with enrichments less than its tails assay, as long as some
-///  U235 is present, and preference increases with U235 content.  If no
-///  U235 is present in the offered material, the trade preference is set
-///  to -1 and the material is not accepted.  Any material components other
-///  other than U235 and U238 are sent directly to the tails buffer.
+/// The Enrichment facility requests an input commodity and associated
+/// recipe whose quantity is its remaining inventory capacity. All
+/// facilities trading the same input commodity (even with different
+/// recipes) will offer materials for trade. The Enrichment facility
+/// accepts any input materials with enrichments less than its tails
+/// assay, as long as some U235 is present, and preference increases
+/// with U235 content. If no U235 is present in the offered material,
+/// the trade preference is set to -1 and the material is not accepted.
+/// Any material components other than U235 and U238 are sent directly
+/// to the tails buffer.
 ///
-///  The Enrichment facility will bid on any request for its output commodity
-///  up to the maximum allowed enrichment (if not specified, default is 100%)
-///  It bids on either the request quantity, or the maximum quanity allowed
-///  by its SWU constraint or natural uranium inventory, whichever is lower.
-///  If multiple output commodities with different enrichment levels are
-///  requested and the facility does not have the SWU or quantity capacity
-///  to meet all requests, the requests are fully, then partially filled
-///  in unspecified but repeatable order. A request for the product
-///  commodity without an associated requested enriched recipe will not be
-///  fulfilled.
+/// The Enrichment facility will bid on any request for its output
+/// commodity up to the maximum allowed enrichment (if not specified,
+/// default is 100%). It bids on either the request quantity, or
+/// the maximum quantity allowed by its SWU constraint or natural
+/// uranium inventory, whichever is lower. If multiple output
+/// commodities with different enrichment levels are requested and
+/// the facility does not have capacity to meet all requests, the
+/// requests are fully, then partially filled in unspecified but
+/// repeatable order. A request for the product commodity without an
+/// associated requested enriched recipe will not be fulfilled.
 ///
-///  The Enrichment facility also offers its tails as an output commodity with
-///  no associated recipe.  Bids for tails are constrained only by total
-///  tails inventory.
-
+/// The Enrichment facility also offers its tails as an output
+/// commodity with no associated recipe. Bids for tails are
+/// constrained only by total tails inventory.
 class Enrichment
   : public cyclus::Facility,
     public cyclus::toolkit::Position {
-#pragma cyclus note {   	  \
-  "niche": "enrichment facility",				  \
-  "doc":								\
-  "The Enrichment facility is a simple agent that enriches natural "	 \
-  "uranium in a Cyclus simulation. It does not explicitly compute "	\
-  "the physical enrichment process, rather it calculates the SWU "	\
-  "required to convert a source uranium recipe (i.e. natural uranium) " \
-  "into a requested enriched recipe (i.e. 4% enriched uranium), given " \
-  "the natural uranium inventory constraint and its SWU capacity " \
-  "constraint."							\
-  "\n\n"								\
-  "The Enrichment facility requests an input commodity and associated " \
-  "recipe whose quantity is its remaining inventory capacity.  All " \
-  "facilities trading the same input commodity (even with different " \
-  "recipes) will offer materials for trade.  The Enrichment facility " \
-  "accepts any input materials with enrichments less than its tails assay, "\
-  "as long as some U235 is present, and preference increases with U235 " \
-  "content.  If no U235 is present in the offered material, the trade " \
-  "preference is set to -1 and the material is not accepted.  Any material " \
-  "components other than U235 and U238 are sent directly to the tails buffer."\
-  "\n\n"								\
-  "The Enrichment facility will bid on any request for its output commodity "\
-  "up to the maximum allowed enrichment (if not specified, default is 100%) "\
-  "It bids on either the request quantity, or the maximum quanity allowed " \
-  "by its SWU constraint or natural uranium inventory, whichever is lower. " \
-  "If multiple output commodities with different enrichment levels are " \
-  "requested and the facility does not have the SWU or quantity capacity " \
-  "to meet all requests, the requests are fully, then partially filled " \
-  "in unspecified but repeatable order. A request for the product " \
-  "commodity without an associated requested enriched recipe will not be " \
-  "fulfilled."				\
-  "\n\n"								\
-  "Accumulated tails inventory is offered for trading as a specifiable " \
-  "output commodity.", \
-}
+
+  // clang-format off
+  #pragma cyclus note { \
+    "niche": "enrichment facility", \
+    "doc": \
+      "The Enrichment facility is a simple agent that enriches natural " \
+      "uranium in a Cyclus simulation. It does not explicitly compute " \
+      "the physical enrichment process, rather it calculates the SWU " \
+      "required to convert a source uranium recipe (i.e. natural uranium) " \
+      "into a requested enriched recipe (i.e. 4% enriched uranium), given " \
+      "the natural uranium inventory constraint and its SWU capacity " \
+      "constraint.\n\n" \
+      "The Enrichment facility requests an input commodity and associated " \
+      "recipe whose quantity is its remaining inventory capacity. All " \
+      "facilities trading the same input commodity (even with different " \
+      "recipes) will offer materials for trade. The Enrichment facility " \
+      "accepts any input materials with enrichments less than its tails " \
+      "assay, as long as some U235 is present, and preference increases " \
+      "with U235 content. If no U235 is present in the offered material, " \
+      "the trade preference is set to -1 and the material is not accepted. " \
+      "Any material components other than U235 and U238 are sent directly " \
+      "to the tails buffer.\n\n" \
+      "The Enrichment facility will bid on any request for its output " \
+      "commodity up to the maximum allowed enrichment (if not specified, " \
+      "default is 100%). It bids on either the request quantity, or the " \
+      "maximum quantity allowed by its SWU constraint or natural uranium " \
+      "inventory, whichever is lower. If multiple output commodities with " \
+      "different enrichment levels are requested and the facility does not " \
+      "have capacity to meet all requests, the requests are fully, then " \
+      "partially filled in unspecified but repeatable order. A request " \
+      "for the product commodity without an associated requested enriched " \
+      "recipe will not be fulfilled.\n\n" \
+      "The Enrichment facility also offers its tails as an output commodity " \
+      "with no associated recipe. Bids for tails are constrained only by " \
+      "total tails inventory.", \
+  }
+  // clang-format on
+
  public:
-  // --- Module Members ---
-  ///    Constructor for the Enrichment class
-  ///    @param ctx the cyclus context for access to simulation-wide parameters
+  /// Constructor for the Enrichment class
+  /// @param ctx the cyclus context for access to simulation-wide parameters
   Enrichment(cyclus::Context* ctx);
 
-  ///     Destructor for the Enrichment class
+  /// Destructor for the Enrichment class
   virtual ~Enrichment();
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
   #pragma cyclus
 
-  ///     Print information about this agent
+  /// Print information about this agent
   virtual std::string str();
-  // ---
 
-  // --- Facility Members ---
   /// perform module-specific tasks when entering the simulation
   virtual void Build(cyclus::Agent* parent);
-  // ---
 
-  // --- Agent Members ---
-  ///  Each facility is prompted to do its beginning-of-time-step
-  ///  stuff at the tick of the timer.
-
-  ///  @param time is the time to perform the tick
+  /// Each timestep “tick” callback
   virtual void Tick();
 
-  ///  Each facility is prompted to its end-of-time-step
-  ///  stuff on the tock of the timer.
-
-  ///  @param time is the time to perform the tock
+  /// Each timestep “tock” callback
   virtual void Tock();
 
-  /// @brief The Enrichment request Materials of its given
-  /// commodity.
+  /// @brief Requests Materials of its given commodity.
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
       GetMatlRequests();
 
-  /// @brief The Enrichment adjusts preferences for offers of
-  /// natural uranium it has received to maximize U-235 content
+  /// @brief Adjusts preferences for offers to maximize U-235 content.
   /// Any offers that have zero U-235 content are not accepted
   virtual void AdjustMatlPrefs(cyclus::PrefMap<cyclus::Material>::type& prefs);
 
-  /// @brief The Enrichment place accepted trade Materials in their
-  /// Inventory
+  /// @brief Place accepted trade Materials in inventory.
   virtual void AcceptMatlTrades(
-      const std::vector< std::pair<cyclus::Trade<cyclus::Material>,
-      cyclus::Material::Ptr> >& responses);
+      const std::vector<std::pair<cyclus::Trade<cyclus::Material>, 
+                                  cyclus::Material::Ptr>>& responses);
 
   /// @brief Responds to each request for this facility's commodity.  If a given
   /// request is more than this facility's inventory or SWU capacity, it will
   /// offer its minimum of its capacities.
-  virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
-    GetMatlBids(cyclus::CommodMap<cyclus::Material>::type&
-    commod_requests);
+  virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> GetMatlBids(
+      cyclus::CommodMap<cyclus::Material>::type& commod_requests);
 
   /// @brief respond to each trade with a material enriched to the appropriate
   /// level given this facility's inventory
@@ -221,165 +208,170 @@ class Enrichment
   /// @param trades all trades in which this trader is the supplier
   /// @param responses a container to populate with responses to each trade
   virtual void GetMatlTrades(
-    const std::vector< cyclus::Trade<cyclus::Material> >& trades,
-    std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-    cyclus::Material::Ptr> >& responses);
-  // ---
+      const std::vector<cyclus::Trade<cyclus::Material>>& trades,
+      std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                            cyclus::Material::Ptr>>& responses);
 
-  ///  @brief Determines if a particular material is a valid request to respond
-  ///  to.  Valid requests must contain U235 and U238 and must have a relative
-  ///  U235-to-U238 ratio less than this facility's tails_assay().
-  ///  @return true if the above description is met by the material
+  /// @brief Determines if a particular material is a valid request to respond
+  /// to.  Valid requests must contain U235 and U238 and must have a relative
+  /// U235-to-U238 ratio less than this facility's tails_assay().
+  /// @return true if the above description is met by the material
   bool ValidReq(const cyclus::Material::Ptr mat);
 
-   inline void SetMaxInventorySize(double size) {
+  inline void SetMaxInventorySize(double size) {
     max_feed_inventory = size;
     inventory.capacity(size);
   }
-
   inline void SwuCapacity(double capacity) {
     swu_capacity = capacity;
     current_swu_capacity = swu_capacity;
   }
-
   inline double SwuCapacity() const { return swu_capacity; }
-
   inline const cyclus::toolkit::ResBuf<cyclus::Material>& Tails() const {
     return tails;
   }
 
  private:
-  ///   @brief adds a material into the natural uranium inventory
-  ///   @throws if the material is not the same composition as the feed_recipe
+  /// @brief Add a material into the natural uranium inventory.
+  /// @throws if the material is not the same composition as feed_recipe.
   void AddMat_(cyclus::Material::Ptr mat);
 
-  ///   @brief generates a request for this facility given its current state.
-  ///   Quantity of the material will be equal to remaining inventory size.
+  /// @brief generates a request for this facility given its current state.
+  /// Quantity of the material will be equal to remaining inventory size.
   cyclus::Material::Ptr Request_();
 
-  ///  @brief Generates a material offer for a given request. The response
-  ///  composition will be comprised only of U235 and U238 at their relative
-  ///  ratio in the requested material. The response quantity will be the
-  ///  same as the requested commodity.
+  /// @brief Generates a material offer for a given request. The response
+  /// composition will be comprised only of U235 and U238 at their relative
+  /// ratio in the requested material. The response quantity will be the
+  /// same as the requested commodity.
   ///
-  ///  @param req the requested material being responded to
+  /// @param req the requested material being responded to
   cyclus::Material::Ptr Offer_(cyclus::Material::Ptr req);
 
   cyclus::Material::Ptr Enrich_(cyclus::Material::Ptr mat, double qty);
 
-  ///  @brief calculates the feed assay based on the unenriched inventory
+  /// @brief Calculate the feed assay based on the unenriched inventory.
   double FeedAssay();
 
-  ///  @brief records and enrichment with the cyclus::Recorder
+  /// @brief Record an enrichment event to the recorder.
   void RecordEnrichment_(double natural_u, double swu);
 
-  /// Records an agent's latitude and longitude to the output db
+  /// Records an agent's latitude and longitude to the output db.
   void RecordPosition();
 
+  // clang-format off
   #pragma cyclus var { \
-    "tooltip": "feed commodity",					\
-    "doc": "feed commodity that the enrichment facility accepts",	\
-    "uilabel": "Feed Commodity",                                    \
+    "tooltip": "feed commodity", \
+    "doc": "feed commodity that the enrichment facility accepts", \
+    "uilabel": "Feed Commodity", \
     "uitype": "incommodity" \
   }
   std::string feed_commod;
 
   #pragma cyclus var { \
-    "tooltip": "feed recipe",						\
-    "doc": "recipe for enrichment facility feed commodity",		\
-    "uilabel": "Feed Recipe",                                   \
+    "tooltip": "feed recipe", \
+    "doc": "recipe for enrichment facility feed commodity", \
+    "uilabel": "Feed Recipe", \
     "uitype": "inrecipe" \
   }
   std::string feed_recipe;
 
   #pragma cyclus var { \
-    "tooltip": "product commodity",					\
-    "doc": "product commodity that the enrichment facility generates",	 \
-    "uilabel": "Product Commodity",                                     \
+    "tooltip": "product commodity", \
+    "doc": "product commodity that the enrichment facility generates", \
+    "uilabel": "Product Commodity", \
     "uitype": "outcommodity" \
   }
   std::string product_commod;
 
-  #pragma cyclus var {							\
-    "tooltip": "tails commodity",					\
-    "doc": "tails commodity supplied by enrichment facility",		\
-    "uilabel": "Tails Commodity",                                   \
+  #pragma cyclus var { \
+    "tooltip": "tails commodity", \
+    "doc": "tails commodity supplied by enrichment facility", \
+    "uilabel": "Tails Commodity", \
     "uitype": "outcommodity" \
   }
   std::string tails_commod;
 
-  #pragma cyclus var {							\
-    "default": 0.003, "tooltip": "tails assay",				\
-    "uilabel": "Tails Assay",                             \
-    "uitype": "range",                               \
-    "range": [0.0, 0.003],                              \
-    "doc": "tails assay from the enrichment process",       \
+  #pragma cyclus var { \
+    "default": 0.003, \
+    "tooltip": "tails assay", \
+    "uilabel": "Tails Assay", \
+    "uitype": "range", \
+    "range": [0.0, 0.003], \
+    "doc": "tails assay from the enrichment process" \
   }
   double tails_assay;
 
-  #pragma cyclus var {							\
-    "default": 0, "tooltip": "initial uranium reserves (kg)",		\
-    "uilabel": "Initial Feed Inventory",				\
-    "doc": "amount of natural uranium stored at the enrichment "	\
-    "facility at the beginning of the simulation (kg)"			\
+  #pragma cyclus var { \
+    "default": 0, \
+    "tooltip": "initial uranium reserves (kg)", \
+    "uilabel": "Initial Feed Inventory", \
+    "doc": \
+      "amount of natural uranium stored at the enrichment facility " \
+      "at the beginning of the simulation (kg)" \
   }
   double initial_feed;
 
-  #pragma cyclus var {							\
-    "default": CY_LARGE_DOUBLE, "tooltip": "max inventory of feed material (kg)", \
+  #pragma cyclus var { \
+    "default": CY_LARGE_DOUBLE, \
+    "tooltip": "max inventory of feed material (kg)", \
     "uilabel": "Maximum Feed Inventory", \
     "uitype": "range", \
     "range": [0.0, CY_LARGE_DOUBLE], \
-    "doc": "maximum total inventory of natural uranium in "		\
-           "the enrichment facility (kg)"     \
+    "doc": \
+      "maximum total inventory of natural uranium in the enrichment " \
+      "facility (kg)" \
   }
   double max_feed_inventory;
 
   #pragma cyclus var { \
-    "default": 1.0,						\
-    "tooltip": "maximum allowed enrichment fraction",		\
+    "default": 1.0, \
+    "tooltip": "maximum allowed enrichment fraction", \
     "doc": "maximum allowed weight fraction of U235 in product", \
     "uilabel": "Maximum Allowed Enrichment", \
     "uitype": "range", \
     "range": [0.0,1.0], \
-    "schema": '<optional>'				     	   \
-        '          <element name="max_enrich">'			   \
-        '              <data type="double">'			   \
-        '                  <param name="minInclusive">0</param>'   \
-        '                  <param name="maxInclusive">1</param>'   \
-        '              </data>'					   \
-        '          </element>'					   \
-        '      </optional>'					   \
+    "schema": '<optional>' \
+        '          <element name="max_enrich">' \
+        '              <data type="double">' \
+        '                  <param name="minInclusive">0</param>' \
+        '                  <param name="maxInclusive">1</param>' \
+        '              </data>' \
+        '          </element>' \
+        '      </optional>' \
   }
   double max_enrich;
 
   #pragma cyclus var { \
-    "default": 1,		       \
-    "userlevel": 10,							\
-    "tooltip": "Rank Material Requests by U235 Content",		\
-    "uilabel": "Prefer feed with higher U235 content", \
-    "doc": "turn on preference ordering for input material "		\
-           "so that EF chooses higher U235 content first" \
+    "default": 1, \
+    "userlevel": 10, \
+    "tooltip": "Rank material requests by U235 content", \
+    "uilabel": "Prefer Higher U235 Content", \
+    "doc": \
+      "turn on preference ordering for input material so that EF chooses " \
+      "higher U235 content first" \
   }
   bool order_prefs;
 
-  #pragma cyclus var {						       \
-    "default": CY_LARGE_DOUBLE,						       \
-    "tooltip": "SWU capacity (kgSWU/timestep)",			       \
-    "uilabel": "SWU Capacity",                                         \
-    "uitype": "range",                                                  \
-    "range": [0.0, CY_LARGE_DOUBLE],                                               \
-    "doc": "separative work unit (SWU) capacity of enrichment "		\
-           "facility (kgSWU/timestep) "                                     \
+  #pragma cyclus var { \
+    "default": CY_LARGE_DOUBLE, \
+    "tooltip": "SWU capacity (kgSWU/timestep)", \
+    "uilabel": "SWU Capacity", \
+    "uitype": "range", \
+    "range": [0.0, CY_LARGE_DOUBLE], \
+    "doc": \
+      "separative work unit (SWU) capacity of enrichment facility " \
+      "(kgSWU/timestep)" \
   }
   double swu_capacity;
+  // clang-format on
 
   double current_swu_capacity;
 
-  #pragma cyclus var { 'capacity': 'max_feed_inventory' }
+  #pragma cyclus var { "capacity": "max_feed_inventory" }
   cyclus::toolkit::ResBuf<cyclus::Material> inventory;  // natural u
   #pragma cyclus var {}
-  cyclus::toolkit::ResBuf<cyclus::Material> tails;  // depleted u
+  cyclus::toolkit::ResBuf<cyclus::Material> tails;      // depleted u
 
   // used to total intra-timestep swu and natu usage for meeting requests -
   // these help enable time series generation.
@@ -387,27 +379,26 @@ class Enrichment
   double intra_timestep_feed_;
 
   friend class EnrichmentTest;
-  // ---
 
+  // clang-format off
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
+    "doc": "Latitude of the agent's geographical position in degrees." \
   }
   double latitude;
 
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
+    "doc": "Longitude of the agent's geographical position in degrees." \
   }
   double longitude;
+  // clang-format on
 
   cyclus::toolkit::Position coordinates;
 };
 
 }  // namespace cycamore
 
-#endif // CYCAMORE_SRC_ENRICHMENT_FACILITY_H_
+#endif  // CYCAMORE_SRC_ENRICHMENT_H_

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -3,8 +3,8 @@
 
 #include <string>
 
-#include "cyclus.h"
 #include "cycamore_version.h"
+#include "cyclus.h"
 
 // clang-format off
 #pragma cyclus exec \
@@ -27,8 +27,8 @@ class SWUConverter : public cyclus::Converter<cyclus::Material> {
   virtual double convert(
       cyclus::Material::Ptr m,
       cyclus::Arc const* a = NULL,
-      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx = NULL)
-      const {
+      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx =
+          NULL) const {
     cyclus::toolkit::Assays assays(feed_, cyclus::toolkit::UraniumAssayMass(m),
                                    tails_);
     return cyclus::toolkit::SwuRequired(m->quantity(), assays);
@@ -61,8 +61,8 @@ class NatUConverter : public cyclus::Converter<cyclus::Material> {
   virtual double convert(
       cyclus::Material::Ptr m,
       cyclus::Arc const* a = NULL,
-      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx = NULL)
-      const {
+      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx =
+          NULL) const {
     cyclus::toolkit::Assays assays(feed_, cyclus::toolkit::UraniumAssayMass(m),
                                    tails_);
     cyclus::toolkit::MatQuery mq(m);
@@ -118,10 +118,7 @@ class NatUConverter : public cyclus::Converter<cyclus::Material> {
 /// The Enrichment facility also offers its tails as an output
 /// commodity with no associated recipe. Bids for tails are
 /// constrained only by total tails inventory.
-class Enrichment
-  : public cyclus::Facility,
-    public cyclus::toolkit::Position {
-
+class Enrichment : public cyclus::Facility, public cyclus::toolkit::Position {
   // clang-format off
   #pragma cyclus note { \
     "niche": "enrichment facility", \
@@ -169,7 +166,7 @@ class Enrichment
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-  #pragma cyclus
+#pragma cyclus
 
   /// Print information about this agent
   virtual std::string str();
@@ -185,7 +182,7 @@ class Enrichment
 
   /// @brief Requests Materials of its given commodity.
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-      GetMatlRequests();
+  GetMatlRequests();
 
   /// @brief Adjusts preferences for offers to maximize U-235 content.
   /// Any offers that have zero U-235 content are not accepted
@@ -193,7 +190,7 @@ class Enrichment
 
   /// @brief Place accepted trade Materials in inventory.
   virtual void AcceptMatlTrades(
-      const std::vector<std::pair<cyclus::Trade<cyclus::Material>, 
+      const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
                                   cyclus::Material::Ptr>>& responses);
 
   /// @brief Responds to each request for this facility's commodity.  If a given
@@ -367,11 +364,12 @@ class Enrichment
   // clang-format on
 
   double current_swu_capacity;
-
+  // clang-format off
   #pragma cyclus var { "capacity": "max_feed_inventory" }
   cyclus::toolkit::ResBuf<cyclus::Material> inventory;  // natural u
   #pragma cyclus var {}
   cyclus::toolkit::ResBuf<cyclus::Material> tails;      // depleted u
+  // clang-format on
 
   // used to total intra-timestep swu and natu usage for meeting requests -
   // these help enable time series generation.

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -3,8 +3,8 @@
 
 #include <string>
 
-#include "cycamore_version.h"
 #include "cyclus.h"
+#include "cycamore_version.h"
 
 // clang-format off
 #pragma cyclus exec \
@@ -27,8 +27,8 @@ class SWUConverter : public cyclus::Converter<cyclus::Material> {
   virtual double convert(
       cyclus::Material::Ptr m,
       cyclus::Arc const* a = NULL,
-      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx =
-          NULL) const {
+      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx = NULL)
+      const {
     cyclus::toolkit::Assays assays(feed_, cyclus::toolkit::UraniumAssayMass(m),
                                    tails_);
     return cyclus::toolkit::SwuRequired(m->quantity(), assays);
@@ -61,8 +61,8 @@ class NatUConverter : public cyclus::Converter<cyclus::Material> {
   virtual double convert(
       cyclus::Material::Ptr m,
       cyclus::Arc const* a = NULL,
-      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx =
-          NULL) const {
+      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx = NULL)
+      const {
     cyclus::toolkit::Assays assays(feed_, cyclus::toolkit::UraniumAssayMass(m),
                                    tails_);
     cyclus::toolkit::MatQuery mq(m);
@@ -118,7 +118,10 @@ class NatUConverter : public cyclus::Converter<cyclus::Material> {
 /// The Enrichment facility also offers its tails as an output
 /// commodity with no associated recipe. Bids for tails are
 /// constrained only by total tails inventory.
-class Enrichment : public cyclus::Facility, public cyclus::toolkit::Position {
+class Enrichment
+  : public cyclus::Facility,
+    public cyclus::toolkit::Position {
+
   // clang-format off
   #pragma cyclus note { \
     "niche": "enrichment facility", \
@@ -166,7 +169,7 @@ class Enrichment : public cyclus::Facility, public cyclus::toolkit::Position {
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-#pragma cyclus
+  #pragma cyclus
 
   /// Print information about this agent
   virtual std::string str();
@@ -182,7 +185,7 @@ class Enrichment : public cyclus::Facility, public cyclus::toolkit::Position {
 
   /// @brief Requests Materials of its given commodity.
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-  GetMatlRequests();
+      GetMatlRequests();
 
   /// @brief Adjusts preferences for offers to maximize U-235 content.
   /// Any offers that have zero U-235 content are not accepted
@@ -190,7 +193,7 @@ class Enrichment : public cyclus::Facility, public cyclus::toolkit::Position {
 
   /// @brief Place accepted trade Materials in inventory.
   virtual void AcceptMatlTrades(
-      const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+      const std::vector<std::pair<cyclus::Trade<cyclus::Material>, 
                                   cyclus::Material::Ptr>>& responses);
 
   /// @brief Responds to each request for this facility's commodity.  If a given
@@ -364,12 +367,11 @@ class Enrichment : public cyclus::Facility, public cyclus::toolkit::Position {
   // clang-format on
 
   double current_swu_capacity;
-  // clang-format off
+
   #pragma cyclus var { "capacity": "max_feed_inventory" }
   cyclus::toolkit::ResBuf<cyclus::Material> inventory;  // natural u
   #pragma cyclus var {}
   cyclus::toolkit::ResBuf<cyclus::Material> tails;      // depleted u
-  // clang-format on
 
   // used to total intra-timestep swu and natu usage for meeting requests -
   // these help enable time series generation.

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -110,7 +110,7 @@ class NatUConverter : public cyclus::Converter<cyclus::Material> {
 /// the maximum quantity allowed by its SWU constraint or natural
 /// uranium inventory, whichever is lower. If multiple output
 /// commodities with different enrichment levels are requested and
-/// the facility does not have capacity to meet all requests, the
+/// the facility does not have SWU or capacity to meet all requests, the
 /// requests are fully, then partially filled in unspecified but
 /// repeatable order. A request for the product commodity without an
 /// associated requested enriched recipe will not be fulfilled.

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -27,8 +27,8 @@ class SWUConverter : public cyclus::Converter<cyclus::Material> {
   virtual double convert(
       cyclus::Material::Ptr m,
       cyclus::Arc const* a = NULL,
-      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx = NULL)
-      const {
+      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx =
+          NULL) const {
     cyclus::toolkit::Assays assays(feed_, cyclus::toolkit::UraniumAssayMass(m),
                                    tails_);
     return cyclus::toolkit::SwuRequired(m->quantity(), assays);
@@ -61,8 +61,8 @@ class NatUConverter : public cyclus::Converter<cyclus::Material> {
   virtual double convert(
       cyclus::Material::Ptr m,
       cyclus::Arc const* a = NULL,
-      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx = NULL)
-      const {
+      cyclus::ExchangeTranslationContext<cyclus::Material> const* ctx =
+          NULL) const {
     cyclus::toolkit::Assays assays(feed_, cyclus::toolkit::UraniumAssayMass(m),
                                    tails_);
     cyclus::toolkit::MatQuery mq(m);
@@ -118,10 +118,7 @@ class NatUConverter : public cyclus::Converter<cyclus::Material> {
 /// The Enrichment facility also offers its tails as an output
 /// commodity with no associated recipe. Bids for tails are
 /// constrained only by total tails inventory.
-class Enrichment
-  : public cyclus::Facility,
-    public cyclus::toolkit::Position {
-
+class Enrichment : public cyclus::Facility, public cyclus::toolkit::Position {
   // clang-format off
   #pragma cyclus note { \
     "niche": "enrichment facility", \
@@ -171,7 +168,7 @@ class Enrichment
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-  #pragma cyclus
+#pragma cyclus
 
   /// Print information about this agent
   virtual std::string str();
@@ -187,7 +184,7 @@ class Enrichment
 
   /// @brief Requests Materials of its given commodity.
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-      GetMatlRequests();
+  GetMatlRequests();
 
   /// @brief Adjusts preferences for offers to maximize U-235 content.
   /// Any offers that have zero U-235 content are not accepted
@@ -195,7 +192,7 @@ class Enrichment
 
   /// @brief Place accepted trade Materials in inventory.
   virtual void AcceptMatlTrades(
-      const std::vector<std::pair<cyclus::Trade<cyclus::Material>, 
+      const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
                                   cyclus::Material::Ptr>>& responses);
 
   /// @brief Responds to each request for this facility's commodity.  If a given
@@ -234,8 +231,8 @@ class Enrichment
   }
 
  private:
-  // Code Injection:
-  #include "toolkit/position.cycpp.h"
+// Code Injection:
+#include "toolkit/position.cycpp.h"
 
   ///   @brief adds a material into the natural uranium inventory
   ///   @throws if the material is not the same composition as the feed_recipe
@@ -366,22 +363,20 @@ class Enrichment
       "(kgSWU/timestep)" \
   }
   double swu_capacity;
-  // clang-format on
 
   double current_swu_capacity;
 
-  #pragma cyclus var { "capacity": "max_feed_inventory" }
+  #pragma cyclus var {"capacity" : "max_feed_inventory" }
   cyclus::toolkit::ResBuf<cyclus::Material> inventory;  // natural u
   #pragma cyclus var {}
-  cyclus::toolkit::ResBuf<cyclus::Material> tails;      // depleted u
-
+  cyclus::toolkit::ResBuf<cyclus::Material> tails;  // depleted u
+  // clang-format on
   // used to total intra-timestep swu and natu usage for meeting requests -
   // these help enable time series generation.
   double intra_timestep_swu_;
   double intra_timestep_feed_;
 
   friend class EnrichmentTest;
-
 };
 
 }  // namespace cycamore

--- a/src/enrichment_tests.cc
+++ b/src/enrichment_tests.cc
@@ -1,20 +1,20 @@
-#include "enrichment_tests.h"
-
 #include <gtest/gtest.h>
 
 #include <sstream>
 
-#include "agent_tests.h"
-#include "env.h"
 #include "facility_tests.h"
-#include "infile_tree.h"
-#include "resource_helpers.h"
 #include "toolkit/mat_query.h"
+#include "agent_tests.h"
+#include "resource_helpers.h"
+#include "infile_tree.h"
+#include "env.h"
 
-using cyclus::CompMap;
-using cyclus::Cond;
-using cyclus::Material;
+#include "enrichment_tests.h"
+
 using cyclus::QueryResult;
+using cyclus::Cond;
+using cyclus::CompMap;
+using cyclus::Material;
 using pyne::nucname::id;
 
 namespace cycamore {
@@ -55,19 +55,21 @@ TEST_F(EnrichmentTest, RequestQty) {
   // without providing any extra
 
   std::string config =
-      "   <feed_commod>natu</feed_commod> "
-      "   <feed_recipe>natu1</feed_recipe> "
-      "   <product_commod>enr_u</product_commod> "
-      "   <tails_commod>tails</tails_commod> "
-      "   <max_feed_inventory>1.0</max_feed_inventory> "
-      "   <tails_assay>0.003</tails_assay> ";
+    "   <feed_commod>natu</feed_commod> "
+    "   <feed_recipe>natu1</feed_recipe> "
+    "   <product_commod>enr_u</product_commod> "
+    "   <tails_commod>tails</tails_commod> "
+    "   <max_feed_inventory>1.0</max_feed_inventory> "
+    "   <tails_assay>0.003</tails_assay> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Enrichment"), config, simdur);
   sim.AddRecipe("natu1", c_natu1());
 
-  sim.AddSource("natu").recipe("natu1").Finalize();
+  sim.AddSource("natu")
+    .recipe("natu1")
+    .Finalize();
 
   int id = sim.Run();
 
@@ -79,8 +81,8 @@ TEST_F(EnrichmentTest, RequestQty) {
   // Should be only one transaction into the EF,
   // and it should be exactly 1kg of natu
   EXPECT_EQ(1.0, qr.rows.size());
-  EXPECT_NEAR(1.0, m->quantity(), cyclus::CY_NEAR_ZERO)
-      << "matched trade provides the wrong quantity of material";
+  EXPECT_NEAR(1.0, m->quantity(), cyclus::CY_NEAR_ZERO) <<
+    "matched trade provides the wrong quantity of material";
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -91,23 +93,26 @@ TEST_F(EnrichmentTest, CheckSWUConstraint) {
   // 388 SWU = 10kg 80% enriched HEU from 486kg feed matl
 
   std::string config =
-      "   <feed_commod>natu</feed_commod> "
-      "   <feed_recipe>natu1</feed_recipe> "
-      "   <product_commod>enr_u</product_commod> "
-      "   <tails_commod>tails</tails_commod> "
-      "   <tails_assay>0.003</tails_assay> "
-      "   <initial_feed>1000</initial_feed> "
-      "   <swu_capacity>195</swu_capacity> ";
+    "   <feed_commod>natu</feed_commod> "
+    "   <feed_recipe>natu1</feed_recipe> "
+    "   <product_commod>enr_u</product_commod> "
+    "   <tails_commod>tails</tails_commod> "
+    "   <tails_assay>0.003</tails_assay> "
+    "   <initial_feed>1000</initial_feed> "
+    "   <swu_capacity>195</swu_capacity> ";
 
   int simdur = 1;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Enrichment"), config, simdur);
 
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("heu", c_heu());
 
-  sim.AddSink("enr_u").recipe("heu").capacity(10).Finalize();
+  sim.AddSink("enr_u")
+    .recipe("heu")
+    .capacity(10)
+    .Finalize();
 
   int id = sim.Run();
 
@@ -117,8 +122,8 @@ TEST_F(EnrichmentTest, CheckSWUConstraint) {
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
   EXPECT_EQ(1.0, qr.rows.size());
-  EXPECT_NEAR(5.0, m->quantity(), 0.1)
-      << "traded quantity exceeds SWU constraint";
+  EXPECT_NEAR(5.0, m->quantity(), 0.1) <<
+    "traded quantity exceeds SWU constraint";
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -127,22 +132,26 @@ TEST_F(EnrichmentTest, CheckCapConstraint) {
   // inventory is partially filled with only the inventory quantity.
 
   std::string config =
-      "   <feed_commod>natu</feed_commod> "
-      "   <feed_recipe>natu1</feed_recipe> "
-      "   <product_commod>enr_u</product_commod> "
-      "   <tails_commod>tails</tails_commod> "
-      "   <tails_assay>0.003</tails_assay> "
-      "   <initial_feed>243</initial_feed> ";
+    "   <feed_commod>natu</feed_commod> "
+    "   <feed_recipe>natu1</feed_recipe> "
+    "   <product_commod>enr_u</product_commod> "
+    "   <tails_commod>tails</tails_commod> "
+    "   <tails_assay>0.003</tails_assay> "
+    "   <initial_feed>243</initial_feed> ";
 
   int simdur = 1;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Enrichment"), config, simdur);
+
 
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("heu", c_heu());
 
-  sim.AddSink("enr_u").recipe("heu").capacity(10).Finalize();
+  sim.AddSink("enr_u")
+    .recipe("heu")
+    .capacity(10)
+    .Finalize();
 
   int id = sim.Run();
 
@@ -152,8 +161,8 @@ TEST_F(EnrichmentTest, CheckCapConstraint) {
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
   EXPECT_EQ(1.0, qr.rows.size());
-  EXPECT_LE(m->quantity(), 5.0)
-      << "traded quantity exceeds capacity constraint";
+  EXPECT_LE(m->quantity(), 5.0) <<
+    "traded quantity exceeds capacity constraint";
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -162,23 +171,30 @@ TEST_F(EnrichmentTest, RequestEnrich) {
   // the maximum allowed enrichment are not fulfilled.
 
   std::string config =
-      "   <feed_commod>natu</feed_commod> "
-      "   <feed_recipe>natu1</feed_recipe> "
-      "   <product_commod>enr_u</product_commod> "
-      "   <tails_commod>tails</tails_commod> "
-      "   <tails_assay>0.003</tails_assay> "
-      "   <max_enrich>0.19</max_enrich> ";
+    "   <feed_commod>natu</feed_commod> "
+    "   <feed_recipe>natu1</feed_recipe> "
+    "   <product_commod>enr_u</product_commod> "
+    "   <tails_commod>tails</tails_commod> "
+    "   <tails_assay>0.003</tails_assay> "
+    "   <max_enrich>0.19</max_enrich> ";
 
   int simdur = 2;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Enrichment"), config, simdur);
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("leu", c_leu());
   sim.AddRecipe("heu", c_heu());
 
-  sim.AddSource("natu").recipe("natu1").Finalize();
-  sim.AddSink("enr_u").recipe("leu").capacity(1.0).Finalize();
-  sim.AddSink("enr_u").recipe("heu").Finalize();
+  sim.AddSource("natu")
+    .recipe("natu1")
+    .Finalize();
+  sim.AddSink("enr_u")
+    .recipe("leu")
+    .capacity(1.0)
+    .Finalize();
+  sim.AddSink("enr_u")
+    .recipe("heu")
+    .Finalize();
 
   int id = sim.Run();
 
@@ -190,8 +206,8 @@ TEST_F(EnrichmentTest, RequestEnrich) {
   // Should be only one transaction out of the EF,
   // and it should be 1kg of LEU
   EXPECT_EQ(1.0, qr.rows.size());
-  EXPECT_NEAR(1.0, m->quantity(), 0.01)
-      << "Not providing the requested quantity";
+  EXPECT_NEAR(1.0, m->quantity(), 0.01) <<
+    "Not providing the requested quantity" ;
 
   CompMap got = m->comp()->mass();
   CompMap want = c_leu()->mass();
@@ -200,8 +216,8 @@ TEST_F(EnrichmentTest, RequestEnrich) {
 
   CompMap::iterator it;
   for (it = want.begin(); it != want.end(); ++it) {
-    EXPECT_DOUBLE_EQ(it->second, got[it->first])
-        << "nuclide qty off: " << pyne::nucname::name(it->first);
+    EXPECT_DOUBLE_EQ(it->second, got[it->first]) <<
+      "nuclide qty off: " << pyne::nucname::name(it->first);
   }
 }
 
@@ -210,22 +226,27 @@ TEST_F(EnrichmentTest, TradeTails) {
   // this tests whether tails are being traded.
 
   std::string config =
-      "   <feed_commod>natu</feed_commod> "
-      "   <feed_recipe>natu1</feed_recipe> "
-      "   <product_commod>enr_u</product_commod> "
-      "   <tails_commod>tails</tails_commod> "
-      "   <tails_assay>0.003</tails_assay> ";
+    "   <feed_commod>natu</feed_commod> "
+    "   <feed_recipe>natu1</feed_recipe> "
+    "   <product_commod>enr_u</product_commod> "
+    "   <tails_commod>tails</tails_commod> "
+    "   <tails_assay>0.003</tails_assay> ";
 
   // time 1-source to EF, 2-Enrich, add to tails, 3-tails avail. for trade
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Enrichment"), config, simdur);
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("leu", c_leu());
 
-  sim.AddSource("natu").recipe("natu1").Finalize();
-  sim.AddSink("enr_u").recipe("leu").Finalize();
-  sim.AddSink("tails").Finalize();
+  sim.AddSource("natu")
+    .recipe("natu1")
+    .Finalize();
+  sim.AddSink("enr_u")
+    .recipe("leu")
+    .Finalize();
+   sim.AddSink("tails")
+    .Finalize();
 
   int id = sim.Run();
 
@@ -235,30 +256,40 @@ TEST_F(EnrichmentTest, TradeTails) {
 
   // Should be exactly one tails transaction
   EXPECT_EQ(1, qr.rows.size());
+
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(EnrichmentTest, TailsQty) {
+  TEST_F(EnrichmentTest, TailsQty) {
   // this tests whether tails are being traded at correct quantity when
   // requested amount is larger than qty in a single tails-buffer element
 
   std::string config =
-      "   <feed_commod>natu</feed_commod> "
-      "   <feed_recipe>natu1</feed_recipe> "
-      "   <product_commod>enr_u</product_commod> "
-      "   <tails_commod>tails</tails_commod> "
-      "   <tails_assay>0.003</tails_assay> ";
+    "   <feed_commod>natu</feed_commod> "
+    "   <feed_recipe>natu1</feed_recipe> "
+    "   <product_commod>enr_u</product_commod> "
+    "   <tails_commod>tails</tails_commod> "
+    "   <tails_assay>0.003</tails_assay> ";
 
   // time 1-source to EF, 2-Enrich, add to tails, 3-tails avail. for trade
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Enrichment"), config, simdur);
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("leu", c_leu());
 
-  sim.AddSource("natu").recipe("natu1").Finalize();
-  sim.AddSink("enr_u").recipe("leu").capacity(0.5).Finalize();
-  sim.AddSink("enr_u").recipe("leu").capacity(0.5).Finalize();
-  sim.AddSink("tails").Finalize();
+  sim.AddSource("natu")
+    .recipe("natu1")
+    .Finalize();
+  sim.AddSink("enr_u")
+    .recipe("leu")
+    .capacity(0.5)
+    .Finalize();
+  sim.AddSink("enr_u")
+    .recipe("leu")
+    .capacity(0.5)
+    .Finalize();
+  sim.AddSink("tails")
+    .Finalize();
 
   int id = sim.Run();
 
@@ -274,12 +305,13 @@ TEST_F(EnrichmentTest, TailsQty) {
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
       "SELECT SUM(r.Quantity) FROM Transactions AS t"
       " INNER JOIN Resources AS r ON r.ResourceId = t.ResourceId"
-      " WHERE t.Commodity = ?;");
+      " WHERE t.Commodity = ?;"
+      );
 
   stmt->BindText(1, "tails");
   stmt->Step();
-  EXPECT_NEAR(8.25, stmt->GetDouble(0), 0.01)
-      << "Not providing the requested quantity";
+  EXPECT_NEAR(8.25,stmt->GetDouble(0), 0.01) <<
+    "Not providing the requested quantity" ;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -288,22 +320,28 @@ TEST_F(EnrichmentTest, BidPrefs) {
   // U235 content
 
   std::string config =
-      "   <feed_commod>natu</feed_commod> "
-      "   <feed_recipe>natu1</feed_recipe> "
-      "   <product_commod>enr_u</product_commod> "
-      "   <tails_commod>tails</tails_commod> "
-      "   <tails_assay>0.003</tails_assay> "
-      "   <max_feed_inventory>1.0</max_feed_inventory> ";
+    "   <feed_commod>natu</feed_commod> "
+    "   <feed_recipe>natu1</feed_recipe> "
+    "   <product_commod>enr_u</product_commod> "
+    "   <tails_commod>tails</tails_commod> "
+    "   <tails_assay>0.003</tails_assay> "
+    "   <max_feed_inventory>1.0</max_feed_inventory> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Enrichment"), config, simdur);
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("natu2", c_natu2());
 
-  sim.AddSource("natu").recipe("natu1").capacity(1).Finalize();
+  sim.AddSource("natu")
+    .recipe("natu1")
+    .capacity(1)
+    .Finalize();
 
-  sim.AddSource("natu").recipe("natu2").capacity(1).Finalize();
+  sim.AddSource("natu")
+    .recipe("natu2")
+    .capacity(1)
+    .Finalize();
 
   int id = sim.Run();
 
@@ -322,33 +360,40 @@ TEST_F(EnrichmentTest, BidPrefs) {
 
   CompMap::iterator it;
   for (it = want.begin(); it != want.end(); ++it) {
-    EXPECT_DOUBLE_EQ(it->second, got[it->first])
-        << "nuclide qty off: " << pyne::nucname::name(it->first);
+    EXPECT_DOUBLE_EQ(it->second, got[it->first]) <<
+      "nuclide qty off: " << pyne::nucname::name(it->first);
   }
+
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(EnrichmentTest, NoBidPrefs) {
+  TEST_F(EnrichmentTest, NoBidPrefs) {
   // This tests that preference-ordering for sources
   // turns off correctly if flag is used
 
   std::string config =
-      "   <feed_commod>natu</feed_commod> "
-      "   <feed_recipe>natu1</feed_recipe> "
-      "   <product_commod>enr_u</product_commod> "
-      "   <tails_commod>tails</tails_commod> "
-      "   <tails_assay>0.003</tails_assay> "
-      "   <max_feed_inventory>2.0</max_feed_inventory> "
-      "   <order_prefs>0</order_prefs> ";
+    "   <feed_commod>natu</feed_commod> "
+    "   <feed_recipe>natu1</feed_recipe> "
+    "   <product_commod>enr_u</product_commod> "
+    "   <tails_commod>tails</tails_commod> "
+    "   <tails_assay>0.003</tails_assay> "
+    "   <max_feed_inventory>2.0</max_feed_inventory> "
+    "   <order_prefs>0</order_prefs> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Enrichment"), config, simdur);
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("natu2", c_natu2());
 
-  sim.AddSource("natu").recipe("natu1").capacity(1).Finalize();
+  sim.AddSource("natu")
+    .recipe("natu1")
+    .capacity(1)
+    .Finalize();
 
-  sim.AddSource("natu").recipe("natu2").capacity(1).Finalize();
+  sim.AddSource("natu")
+    .recipe("natu2")
+    .capacity(1)
+    .Finalize();
 
   int id = sim.Run();
 
@@ -358,34 +403,38 @@ TEST_F(EnrichmentTest, NoBidPrefs) {
 
   // should trade with both to meet its capacity limit
   EXPECT_EQ(2, qr.rows.size());
-}
+  }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(EnrichmentTest, ZeroU235) {
   // Test that offers of natu with no u235 content are rejected
 
   std::string config =
-      "   <feed_commod>natu</feed_commod> "
-      "   <feed_recipe>natu1</feed_recipe> "
-      "   <product_commod>enr_u</product_commod> "
-      "   <tails_commod>tails</tails_commod> "
-      "   <tails_assay>0.003</tails_assay> "
-      "   <max_feed_inventory>1.0</max_feed_inventory> ";
+    "   <feed_commod>natu</feed_commod> "
+    "   <feed_recipe>natu1</feed_recipe> "
+    "   <product_commod>enr_u</product_commod> "
+    "   <tails_commod>tails</tails_commod> "
+    "   <tails_assay>0.003</tails_assay> "
+    "   <max_feed_inventory>1.0</max_feed_inventory> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Enrichment"), config, simdur);
   sim.AddRecipe("no_u235", c_nou235());
   sim.AddRecipe("natu1", c_natu1());
 
-  sim.AddSource("natu").recipe("no_u235").capacity(1).Finalize();
+  sim.AddSource("natu")
+    .recipe("no_u235")
+    .capacity(1)
+    .Finalize();
 
   int id = sim.Run();
 
   std::vector<Cond> conds;
   conds.push_back(Cond("Commodity", "==", std::string("natu")));
   // DB table should be empty since there are no transactions
-  EXPECT_THROW(sim.db().Query("Transactions", &conds), std::exception);
+  EXPECT_THROW(sim.db().Query("Transactions", &conds),
+         std::exception);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -421,7 +470,7 @@ void EnrichmentTest::InitParameters() {
   ctx->AddRecipe(feed_recipe, recipe);
 
   tails_assay = 0.002;
-  swu_capacity = 100;  //**
+  swu_capacity = 100; //**
   inv_size = 5;
 
   reserves = 105.5;
@@ -442,7 +491,8 @@ void EnrichmentTest::SetUpSource() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Material::Ptr EnrichmentTest::GetMat(double qty) {
-  return Material::CreateUntracked(qty, tc_.get()->GetRecipe(feed_recipe));
+  return Material::CreateUntracked(qty,
+                                           tc_.get()->GetRecipe(feed_recipe));
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -456,12 +506,14 @@ Material::Ptr EnrichmentTest::DoRequest() {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Material::Ptr EnrichmentTest::DoOffer(Material::Ptr mat) {
+Material::Ptr
+EnrichmentTest::DoOffer(Material::Ptr mat) {
   return src_facility->Offer_(mat);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Material::Ptr EnrichmentTest::DoEnrich(Material::Ptr mat, double qty) {
+Material::Ptr
+EnrichmentTest::DoEnrich(Material::Ptr mat, double qty) {
   return src_facility->Enrich_(mat, qty);
 }
 
@@ -498,8 +550,8 @@ TEST_F(EnrichmentTest, ValidReq) {
 
   CompMap v1;
   v1[922350000] = 1;
-  Material::Ptr mat =
-      Material::CreateUntracked(qty, Composition::CreateFromAtom(v1));
+  Material::Ptr mat = Material::CreateUntracked
+    (qty,Composition::CreateFromAtom(v1));
   EXPECT_FALSE(src_facility->ValidReq(mat));  // u238 = 0
 
   CompMap v2;
@@ -517,22 +569,22 @@ TEST_F(EnrichmentTest, ValidReq) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(EnrichmentTest, ConstraintConverters) {
-  // Tests the SWU and NatU converters to make sure that amount of
-  // feed and SWU required are correct to fulfill the enrichment request.
-  using cyclus::Composition;
+  TEST_F(EnrichmentTest, ConstraintConverters) {
+    // Tests the SWU and NatU converters to make sure that amount of
+    // feed and SWU required are correct to fulfill the enrichment request.
   using cyclus::toolkit::MatQuery;
+  using cyclus::Composition;
 
   cyclus::Env::SetNucDataPath();
 
-  double qty = 5;               // 5 kg
+  double qty = 5;  // 5 kg
   double product_assay = 0.05;  // of 5 w/o enriched U
   CompMap v;
   v[922350000] = product_assay;
   v[922380000] = 1 - product_assay;
   v[94239] = 0.5;  // 94239 shouldn't be taken into account
-  Material::Ptr target =
-      Material::CreateUntracked(qty, Composition::CreateFromMass(v));
+  Material::Ptr target = Material::CreateUntracked(
+      qty, Composition::CreateFromMass(v));
 
   std::set<cyclus::Nuc> nucs;
   nucs.insert(922350000);
@@ -556,21 +608,21 @@ TEST_F(EnrichmentTest, Enrich) {
   // of natural uranium required that is exactly its inventory level. that
   // inventory will be comprised of two materials to test the manifest/absorb
   // strategy employed in Enrich_.
+  using cyclus::toolkit::MatQuery;
   using cyclus::Composition;
   using cyclus::toolkit::Assays;
-  using cyclus::toolkit::FeedQty;
-  using cyclus::toolkit::MatQuery;
-  using cyclus::toolkit::SwuRequired;
   using cyclus::toolkit::UraniumAssayMass;
+  using cyclus::toolkit::SwuRequired;
+  using cyclus::toolkit::FeedQty;
 
-  double qty = 5;               // kg
+  double qty = 5;  // kg
   double product_assay = 0.05;  // of 5 w/o enriched U
   CompMap v;
   v[922350000] = product_assay;
   v[922380000] = 1 - product_assay;
   // target qty need not be = to request qty
-  Material::Ptr target =
-      Material::CreateUntracked(qty + 10, Composition::CreateFromMass(v));
+  Material::Ptr target = Material::CreateUntracked(
+      qty + 10, Composition::CreateFromMass(v));
 
   Assays assays(feed_assay, UraniumAssayMass(target), tails_assay);
   double swu_req = SwuRequired(qty, assays);
@@ -615,8 +667,9 @@ TEST_F(EnrichmentTest, Response) {
   using cyclus::toolkit::UraniumAssayMass;
 
   // problem set up
-  std::vector<Trade<Material>> trades;
-  std::vector<std::pair<Trade<Material>, Material::Ptr>> responses;
+  std::vector< Trade<Material> > trades;
+  std::vector<std::pair<Trade<Material>,
+                        Material::Ptr> > responses;
 
   double qty = 5;  // kg
   double trade_qty = qty / 3;
@@ -634,7 +687,7 @@ TEST_F(EnrichmentTest, Response) {
   double natu_req = FeedQty(qty, assays);
 
   src_facility->SetMaxInventorySize(natu_req * 4);  // not capacitated by nat
-  src_facility->SwuCapacity(swu_req);               // swu capacitated
+  src_facility->SwuCapacity(swu_req);  // swu capacitated
 
   src_facility->GetMatlTrades(trades, responses);
 
@@ -650,7 +703,8 @@ TEST_F(EnrichmentTest, Response) {
   trades.push_back(trade);
 
   // 2 trades, SWU = SWU cap
-  ASSERT_GT(src_facility->SwuCapacity() - 2 * swu_req / 3, -1 * cyclus::eps());
+    ASSERT_GT(src_facility->SwuCapacity() - 2 * swu_req / 3,
+              -1 * cyclus::eps());
   trades.push_back(trade);
   responses.clear();
   EXPECT_NO_THROW(src_facility->GetMatlTrades(trades, responses));
@@ -662,19 +716,21 @@ TEST_F(EnrichmentTest, PositionInitialize) {
   // this tests verifies the initialization of the latitude variable
 
   std::string config =
-      "   <feed_commod>natu</feed_commod> "
-      "   <feed_recipe>natu1</feed_recipe> "
-      "   <product_commod>enr_u</product_commod> "
-      "   <tails_commod>tails</tails_commod> "
-      "   <max_feed_inventory>1.0</max_feed_inventory> "
-      "   <tails_assay>0.003</tails_assay> ";
+    "   <feed_commod>natu</feed_commod> "
+    "   <feed_recipe>natu1</feed_recipe> "
+    "   <product_commod>enr_u</product_commod> "
+    "   <tails_commod>tails</tails_commod> "
+    "   <max_feed_inventory>1.0</max_feed_inventory> "
+    "   <tails_assay>0.003</tails_assay> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Enrichment"), config, simdur);
   sim.AddRecipe("natu1", c_natu1());
 
-  sim.AddSource("natu").recipe("natu1").Finalize();
+  sim.AddSource("natu")
+    .recipe("natu1")
+    .Finalize();
 
   int id = sim.Run();
 
@@ -688,21 +744,23 @@ TEST_F(EnrichmentTest, PositionInitialize2) {
   // variable
 
   std::string config =
-      "   <feed_commod>natu</feed_commod> "
-      "   <feed_recipe>natu1</feed_recipe> "
-      "   <product_commod>enr_u</product_commod> "
-      "   <tails_commod>tails</tails_commod> "
-      "   <max_feed_inventory>1.0</max_feed_inventory> "
-      "   <tails_assay>0.003</tails_assay> "
-      "   <latitude>50.0</latitude> "
-      "   <longitude>35.0</longitude> ";
+    "   <feed_commod>natu</feed_commod> "
+    "   <feed_recipe>natu1</feed_recipe> "
+    "   <product_commod>enr_u</product_commod> "
+    "   <tails_commod>tails</tails_commod> "
+    "   <max_feed_inventory>1.0</max_feed_inventory> "
+    "   <tails_assay>0.003</tails_assay> "
+    "   <latitude>50.0</latitude> "
+    "   <longitude>35.0</longitude> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Enrichment"), config, simdur);
   sim.AddRecipe("natu1", c_natu1());
 
-  sim.AddSource("natu").recipe("natu1").Finalize();
+  sim.AddSource("natu")
+    .recipe("natu1")
+    .Finalize();
 
   int id = sim.Run();
 
@@ -710,6 +768,7 @@ TEST_F(EnrichmentTest, PositionInitialize2) {
   EXPECT_EQ(qr.GetVal<double>("Latitude"), 50.0);
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 35.0);
 }
+
 
 }  // namespace cycamore
 
@@ -727,6 +786,6 @@ static int cyclus_agent_tests_connected = ConnectAgentTests();
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_SUITE_P(EnrichmentFac, FacilityTests,
-                         Values(&EnrichmentConstructor));
+                        Values(&EnrichmentConstructor));
 INSTANTIATE_TEST_SUITE_P(EnrichmentFac, AgentTests,
-                         Values(&EnrichmentConstructor));
+                        Values(&EnrichmentConstructor));

--- a/src/enrichment_tests.cc
+++ b/src/enrichment_tests.cc
@@ -1,20 +1,20 @@
+#include "enrichment_tests.h"
+
 #include <gtest/gtest.h>
 
 #include <sstream>
 
-#include "facility_tests.h"
-#include "toolkit/mat_query.h"
 #include "agent_tests.h"
-#include "resource_helpers.h"
-#include "infile_tree.h"
 #include "env.h"
+#include "facility_tests.h"
+#include "infile_tree.h"
+#include "resource_helpers.h"
+#include "toolkit/mat_query.h"
 
-#include "enrichment_tests.h"
-
-using cyclus::QueryResult;
-using cyclus::Cond;
 using cyclus::CompMap;
+using cyclus::Cond;
 using cyclus::Material;
+using cyclus::QueryResult;
 using pyne::nucname::id;
 
 namespace cycamore {
@@ -55,21 +55,19 @@ TEST_F(EnrichmentTest, RequestQty) {
   // without providing any extra
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <max_feed_inventory>1.0</max_feed_inventory> "
-    "   <tails_assay>0.003</tails_assay> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <max_feed_inventory>1.0</max_feed_inventory> "
+      "   <tails_assay>0.003</tails_assay> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("natu1", c_natu1());
 
-  sim.AddSource("natu")
-    .recipe("natu1")
-    .Finalize();
+  sim.AddSource("natu").recipe("natu1").Finalize();
 
   int id = sim.Run();
 
@@ -81,8 +79,8 @@ TEST_F(EnrichmentTest, RequestQty) {
   // Should be only one transaction into the EF,
   // and it should be exactly 1kg of natu
   EXPECT_EQ(1.0, qr.rows.size());
-  EXPECT_NEAR(1.0, m->quantity(), cyclus::CY_NEAR_ZERO) <<
-    "matched trade provides the wrong quantity of material";
+  EXPECT_NEAR(1.0, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "matched trade provides the wrong quantity of material";
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -93,26 +91,23 @@ TEST_F(EnrichmentTest, CheckSWUConstraint) {
   // 388 SWU = 10kg 80% enriched HEU from 486kg feed matl
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <tails_assay>0.003</tails_assay> "
-    "   <initial_feed>1000</initial_feed> "
-    "   <swu_capacity>195</swu_capacity> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <tails_assay>0.003</tails_assay> "
+      "   <initial_feed>1000</initial_feed> "
+      "   <swu_capacity>195</swu_capacity> ";
 
   int simdur = 1;
 
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
 
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("heu", c_heu());
 
-  sim.AddSink("enr_u")
-    .recipe("heu")
-    .capacity(10)
-    .Finalize();
+  sim.AddSink("enr_u").recipe("heu").capacity(10).Finalize();
 
   int id = sim.Run();
 
@@ -122,8 +117,8 @@ TEST_F(EnrichmentTest, CheckSWUConstraint) {
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
   EXPECT_EQ(1.0, qr.rows.size());
-  EXPECT_NEAR(5.0, m->quantity(), 0.1) <<
-    "traded quantity exceeds SWU constraint";
+  EXPECT_NEAR(5.0, m->quantity(), 0.1)
+      << "traded quantity exceeds SWU constraint";
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -132,26 +127,22 @@ TEST_F(EnrichmentTest, CheckCapConstraint) {
   // inventory is partially filled with only the inventory quantity.
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <tails_assay>0.003</tails_assay> "
-    "   <initial_feed>243</initial_feed> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <tails_assay>0.003</tails_assay> "
+      "   <initial_feed>243</initial_feed> ";
 
   int simdur = 1;
 
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
-
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
 
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("heu", c_heu());
 
-  sim.AddSink("enr_u")
-    .recipe("heu")
-    .capacity(10)
-    .Finalize();
+  sim.AddSink("enr_u").recipe("heu").capacity(10).Finalize();
 
   int id = sim.Run();
 
@@ -161,8 +152,8 @@ TEST_F(EnrichmentTest, CheckCapConstraint) {
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
   EXPECT_EQ(1.0, qr.rows.size());
-  EXPECT_LE(m->quantity(), 5.0) <<
-    "traded quantity exceeds capacity constraint";
+  EXPECT_LE(m->quantity(), 5.0)
+      << "traded quantity exceeds capacity constraint";
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -171,30 +162,23 @@ TEST_F(EnrichmentTest, RequestEnrich) {
   // the maximum allowed enrichment are not fulfilled.
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <tails_assay>0.003</tails_assay> "
-    "   <max_enrich>0.19</max_enrich> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <tails_assay>0.003</tails_assay> "
+      "   <max_enrich>0.19</max_enrich> ";
 
   int simdur = 2;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("leu", c_leu());
   sim.AddRecipe("heu", c_heu());
 
-  sim.AddSource("natu")
-    .recipe("natu1")
-    .Finalize();
-  sim.AddSink("enr_u")
-    .recipe("leu")
-    .capacity(1.0)
-    .Finalize();
-  sim.AddSink("enr_u")
-    .recipe("heu")
-    .Finalize();
+  sim.AddSource("natu").recipe("natu1").Finalize();
+  sim.AddSink("enr_u").recipe("leu").capacity(1.0).Finalize();
+  sim.AddSink("enr_u").recipe("heu").Finalize();
 
   int id = sim.Run();
 
@@ -206,8 +190,8 @@ TEST_F(EnrichmentTest, RequestEnrich) {
   // Should be only one transaction out of the EF,
   // and it should be 1kg of LEU
   EXPECT_EQ(1.0, qr.rows.size());
-  EXPECT_NEAR(1.0, m->quantity(), 0.01) <<
-    "Not providing the requested quantity" ;
+  EXPECT_NEAR(1.0, m->quantity(), 0.01)
+      << "Not providing the requested quantity";
 
   CompMap got = m->comp()->mass();
   CompMap want = c_leu()->mass();
@@ -216,8 +200,8 @@ TEST_F(EnrichmentTest, RequestEnrich) {
 
   CompMap::iterator it;
   for (it = want.begin(); it != want.end(); ++it) {
-    EXPECT_DOUBLE_EQ(it->second, got[it->first]) <<
-      "nuclide qty off: " << pyne::nucname::name(it->first);
+    EXPECT_DOUBLE_EQ(it->second, got[it->first])
+        << "nuclide qty off: " << pyne::nucname::name(it->first);
   }
 }
 
@@ -226,27 +210,22 @@ TEST_F(EnrichmentTest, TradeTails) {
   // this tests whether tails are being traded.
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <tails_assay>0.003</tails_assay> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <tails_assay>0.003</tails_assay> ";
 
   // time 1-source to EF, 2-Enrich, add to tails, 3-tails avail. for trade
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("leu", c_leu());
 
-  sim.AddSource("natu")
-    .recipe("natu1")
-    .Finalize();
-  sim.AddSink("enr_u")
-    .recipe("leu")
-    .Finalize();
-   sim.AddSink("tails")
-    .Finalize();
+  sim.AddSource("natu").recipe("natu1").Finalize();
+  sim.AddSink("enr_u").recipe("leu").Finalize();
+  sim.AddSink("tails").Finalize();
 
   int id = sim.Run();
 
@@ -256,40 +235,30 @@ TEST_F(EnrichmentTest, TradeTails) {
 
   // Should be exactly one tails transaction
   EXPECT_EQ(1, qr.rows.size());
-
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  TEST_F(EnrichmentTest, TailsQty) {
+TEST_F(EnrichmentTest, TailsQty) {
   // this tests whether tails are being traded at correct quantity when
   // requested amount is larger than qty in a single tails-buffer element
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <tails_assay>0.003</tails_assay> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <tails_assay>0.003</tails_assay> ";
 
   // time 1-source to EF, 2-Enrich, add to tails, 3-tails avail. for trade
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("leu", c_leu());
 
-  sim.AddSource("natu")
-    .recipe("natu1")
-    .Finalize();
-  sim.AddSink("enr_u")
-    .recipe("leu")
-    .capacity(0.5)
-    .Finalize();
-  sim.AddSink("enr_u")
-    .recipe("leu")
-    .capacity(0.5)
-    .Finalize();
-  sim.AddSink("tails")
-    .Finalize();
+  sim.AddSource("natu").recipe("natu1").Finalize();
+  sim.AddSink("enr_u").recipe("leu").capacity(0.5).Finalize();
+  sim.AddSink("enr_u").recipe("leu").capacity(0.5).Finalize();
+  sim.AddSink("tails").Finalize();
 
   int id = sim.Run();
 
@@ -305,13 +274,12 @@ TEST_F(EnrichmentTest, TradeTails) {
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
       "SELECT SUM(r.Quantity) FROM Transactions AS t"
       " INNER JOIN Resources AS r ON r.ResourceId = t.ResourceId"
-      " WHERE t.Commodity = ?;"
-      );
+      " WHERE t.Commodity = ?;");
 
   stmt->BindText(1, "tails");
   stmt->Step();
-  EXPECT_NEAR(8.25,stmt->GetDouble(0), 0.01) <<
-    "Not providing the requested quantity" ;
+  EXPECT_NEAR(8.25, stmt->GetDouble(0), 0.01)
+      << "Not providing the requested quantity";
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -320,28 +288,22 @@ TEST_F(EnrichmentTest, BidPrefs) {
   // U235 content
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <tails_assay>0.003</tails_assay> "
-    "   <max_feed_inventory>1.0</max_feed_inventory> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <tails_assay>0.003</tails_assay> "
+      "   <max_feed_inventory>1.0</max_feed_inventory> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("natu2", c_natu2());
 
-  sim.AddSource("natu")
-    .recipe("natu1")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("natu").recipe("natu1").capacity(1).Finalize();
 
-  sim.AddSource("natu")
-    .recipe("natu2")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("natu").recipe("natu2").capacity(1).Finalize();
 
   int id = sim.Run();
 
@@ -360,40 +322,33 @@ TEST_F(EnrichmentTest, BidPrefs) {
 
   CompMap::iterator it;
   for (it = want.begin(); it != want.end(); ++it) {
-    EXPECT_DOUBLE_EQ(it->second, got[it->first]) <<
-      "nuclide qty off: " << pyne::nucname::name(it->first);
+    EXPECT_DOUBLE_EQ(it->second, got[it->first])
+        << "nuclide qty off: " << pyne::nucname::name(it->first);
   }
-
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  TEST_F(EnrichmentTest, NoBidPrefs) {
+TEST_F(EnrichmentTest, NoBidPrefs) {
   // This tests that preference-ordering for sources
   // turns off correctly if flag is used
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <tails_assay>0.003</tails_assay> "
-    "   <max_feed_inventory>2.0</max_feed_inventory> "
-    "   <order_prefs>0</order_prefs> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <tails_assay>0.003</tails_assay> "
+      "   <max_feed_inventory>2.0</max_feed_inventory> "
+      "   <order_prefs>0</order_prefs> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("natu2", c_natu2());
 
-  sim.AddSource("natu")
-    .recipe("natu1")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("natu").recipe("natu1").capacity(1).Finalize();
 
-  sim.AddSource("natu")
-    .recipe("natu2")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("natu").recipe("natu2").capacity(1).Finalize();
 
   int id = sim.Run();
 
@@ -403,38 +358,34 @@ TEST_F(EnrichmentTest, BidPrefs) {
 
   // should trade with both to meet its capacity limit
   EXPECT_EQ(2, qr.rows.size());
-  }
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(EnrichmentTest, ZeroU235) {
   // Test that offers of natu with no u235 content are rejected
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <tails_assay>0.003</tails_assay> "
-    "   <max_feed_inventory>1.0</max_feed_inventory> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <tails_assay>0.003</tails_assay> "
+      "   <max_feed_inventory>1.0</max_feed_inventory> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("no_u235", c_nou235());
   sim.AddRecipe("natu1", c_natu1());
 
-  sim.AddSource("natu")
-    .recipe("no_u235")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("natu").recipe("no_u235").capacity(1).Finalize();
 
   int id = sim.Run();
 
   std::vector<Cond> conds;
   conds.push_back(Cond("Commodity", "==", std::string("natu")));
   // DB table should be empty since there are no transactions
-  EXPECT_THROW(sim.db().Query("Transactions", &conds),
-         std::exception);
+  EXPECT_THROW(sim.db().Query("Transactions", &conds), std::exception);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -470,7 +421,7 @@ void EnrichmentTest::InitParameters() {
   ctx->AddRecipe(feed_recipe, recipe);
 
   tails_assay = 0.002;
-  swu_capacity = 100; //**
+  swu_capacity = 100;  //**
   inv_size = 5;
 
   reserves = 105.5;
@@ -491,8 +442,7 @@ void EnrichmentTest::SetUpSource() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Material::Ptr EnrichmentTest::GetMat(double qty) {
-  return Material::CreateUntracked(qty,
-                                           tc_.get()->GetRecipe(feed_recipe));
+  return Material::CreateUntracked(qty, tc_.get()->GetRecipe(feed_recipe));
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -506,14 +456,12 @@ Material::Ptr EnrichmentTest::DoRequest() {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Material::Ptr
-EnrichmentTest::DoOffer(Material::Ptr mat) {
+Material::Ptr EnrichmentTest::DoOffer(Material::Ptr mat) {
   return src_facility->Offer_(mat);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Material::Ptr
-EnrichmentTest::DoEnrich(Material::Ptr mat, double qty) {
+Material::Ptr EnrichmentTest::DoEnrich(Material::Ptr mat, double qty) {
   return src_facility->Enrich_(mat, qty);
 }
 
@@ -550,8 +498,8 @@ TEST_F(EnrichmentTest, ValidReq) {
 
   CompMap v1;
   v1[922350000] = 1;
-  Material::Ptr mat = Material::CreateUntracked
-    (qty,Composition::CreateFromAtom(v1));
+  Material::Ptr mat =
+      Material::CreateUntracked(qty, Composition::CreateFromAtom(v1));
   EXPECT_FALSE(src_facility->ValidReq(mat));  // u238 = 0
 
   CompMap v2;
@@ -569,22 +517,22 @@ TEST_F(EnrichmentTest, ValidReq) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  TEST_F(EnrichmentTest, ConstraintConverters) {
-    // Tests the SWU and NatU converters to make sure that amount of
-    // feed and SWU required are correct to fulfill the enrichment request.
-  using cyclus::toolkit::MatQuery;
+TEST_F(EnrichmentTest, ConstraintConverters) {
+  // Tests the SWU and NatU converters to make sure that amount of
+  // feed and SWU required are correct to fulfill the enrichment request.
   using cyclus::Composition;
+  using cyclus::toolkit::MatQuery;
 
   cyclus::Env::SetNucDataPath();
 
-  double qty = 5;  // 5 kg
+  double qty = 5;               // 5 kg
   double product_assay = 0.05;  // of 5 w/o enriched U
   CompMap v;
   v[922350000] = product_assay;
   v[922380000] = 1 - product_assay;
   v[94239] = 0.5;  // 94239 shouldn't be taken into account
-  Material::Ptr target = Material::CreateUntracked(
-      qty, Composition::CreateFromMass(v));
+  Material::Ptr target =
+      Material::CreateUntracked(qty, Composition::CreateFromMass(v));
 
   std::set<cyclus::Nuc> nucs;
   nucs.insert(922350000);
@@ -608,21 +556,21 @@ TEST_F(EnrichmentTest, Enrich) {
   // of natural uranium required that is exactly its inventory level. that
   // inventory will be comprised of two materials to test the manifest/absorb
   // strategy employed in Enrich_.
-  using cyclus::toolkit::MatQuery;
   using cyclus::Composition;
   using cyclus::toolkit::Assays;
-  using cyclus::toolkit::UraniumAssayMass;
-  using cyclus::toolkit::SwuRequired;
   using cyclus::toolkit::FeedQty;
+  using cyclus::toolkit::MatQuery;
+  using cyclus::toolkit::SwuRequired;
+  using cyclus::toolkit::UraniumAssayMass;
 
-  double qty = 5;  // kg
+  double qty = 5;               // kg
   double product_assay = 0.05;  // of 5 w/o enriched U
   CompMap v;
   v[922350000] = product_assay;
   v[922380000] = 1 - product_assay;
   // target qty need not be = to request qty
-  Material::Ptr target = Material::CreateUntracked(
-      qty + 10, Composition::CreateFromMass(v));
+  Material::Ptr target =
+      Material::CreateUntracked(qty + 10, Composition::CreateFromMass(v));
 
   Assays assays(feed_assay, UraniumAssayMass(target), tails_assay);
   double swu_req = SwuRequired(qty, assays);
@@ -667,9 +615,8 @@ TEST_F(EnrichmentTest, Response) {
   using cyclus::toolkit::UraniumAssayMass;
 
   // problem set up
-  std::vector< Trade<Material> > trades;
-  std::vector<std::pair<Trade<Material>,
-                        Material::Ptr> > responses;
+  std::vector<Trade<Material>> trades;
+  std::vector<std::pair<Trade<Material>, Material::Ptr>> responses;
 
   double qty = 5;  // kg
   double trade_qty = qty / 3;
@@ -687,7 +634,7 @@ TEST_F(EnrichmentTest, Response) {
   double natu_req = FeedQty(qty, assays);
 
   src_facility->SetMaxInventorySize(natu_req * 4);  // not capacitated by nat
-  src_facility->SwuCapacity(swu_req);  // swu capacitated
+  src_facility->SwuCapacity(swu_req);               // swu capacitated
 
   src_facility->GetMatlTrades(trades, responses);
 
@@ -703,8 +650,7 @@ TEST_F(EnrichmentTest, Response) {
   trades.push_back(trade);
 
   // 2 trades, SWU = SWU cap
-    ASSERT_GT(src_facility->SwuCapacity() - 2 * swu_req / 3,
-              -1 * cyclus::eps());
+  ASSERT_GT(src_facility->SwuCapacity() - 2 * swu_req / 3, -1 * cyclus::eps());
   trades.push_back(trade);
   responses.clear();
   EXPECT_NO_THROW(src_facility->GetMatlTrades(trades, responses));
@@ -716,21 +662,19 @@ TEST_F(EnrichmentTest, PositionInitialize) {
   // this tests verifies the initialization of the latitude variable
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <max_feed_inventory>1.0</max_feed_inventory> "
-    "   <tails_assay>0.003</tails_assay> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <max_feed_inventory>1.0</max_feed_inventory> "
+      "   <tails_assay>0.003</tails_assay> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("natu1", c_natu1());
 
-  sim.AddSource("natu")
-    .recipe("natu1")
-    .Finalize();
+  sim.AddSource("natu").recipe("natu1").Finalize();
 
   int id = sim.Run();
 
@@ -744,23 +688,21 @@ TEST_F(EnrichmentTest, PositionInitialize2) {
   // variable
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <max_feed_inventory>1.0</max_feed_inventory> "
-    "   <tails_assay>0.003</tails_assay> "
-    "   <latitude>50.0</latitude> "
-    "   <longitude>35.0</longitude> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <max_feed_inventory>1.0</max_feed_inventory> "
+      "   <tails_assay>0.003</tails_assay> "
+      "   <latitude>50.0</latitude> "
+      "   <longitude>35.0</longitude> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("natu1", c_natu1());
 
-  sim.AddSource("natu")
-    .recipe("natu1")
-    .Finalize();
+  sim.AddSource("natu").recipe("natu1").Finalize();
 
   int id = sim.Run();
 
@@ -768,7 +710,6 @@ TEST_F(EnrichmentTest, PositionInitialize2) {
   EXPECT_EQ(qr.GetVal<double>("Latitude"), 50.0);
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 35.0);
 }
-
 
 }  // namespace cycamore
 
@@ -786,6 +727,6 @@ static int cyclus_agent_tests_connected = ConnectAgentTests();
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_SUITE_P(EnrichmentFac, FacilityTests,
-                        Values(&EnrichmentConstructor));
+                         Values(&EnrichmentConstructor));
 INSTANTIATE_TEST_SUITE_P(EnrichmentFac, AgentTests,
-                        Values(&EnrichmentConstructor));
+                         Values(&EnrichmentConstructor));

--- a/src/enrichment_tests.cc
+++ b/src/enrichment_tests.cc
@@ -11,10 +11,10 @@
 
 #include "enrichment_tests.h"
 
-using cyclus::QueryResult;
-using cyclus::Cond;
 using cyclus::CompMap;
+using cyclus::Cond;
 using cyclus::Material;
+using cyclus::QueryResult;
 using pyne::nucname::id;
 
 namespace cycamore {
@@ -55,21 +55,19 @@ TEST_F(EnrichmentTest, RequestQty) {
   // without providing any extra
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <max_feed_inventory>1.0</max_feed_inventory> "
-    "   <tails_assay>0.003</tails_assay> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <max_feed_inventory>1.0</max_feed_inventory> "
+      "   <tails_assay>0.003</tails_assay> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("natu1", c_natu1());
 
-  sim.AddSource("natu")
-    .recipe("natu1")
-    .Finalize();
+  sim.AddSource("natu").recipe("natu1").Finalize();
 
   int id = sim.Run();
 
@@ -81,8 +79,8 @@ TEST_F(EnrichmentTest, RequestQty) {
   // Should be only one transaction into the EF,
   // and it should be exactly 1kg of natu
   EXPECT_EQ(1.0, qr.rows.size());
-  EXPECT_NEAR(1.0, m->quantity(), cyclus::CY_NEAR_ZERO) <<
-    "matched trade provides the wrong quantity of material";
+  EXPECT_NEAR(1.0, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "matched trade provides the wrong quantity of material";
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -93,26 +91,23 @@ TEST_F(EnrichmentTest, CheckSWUConstraint) {
   // 388 SWU = 10kg 80% enriched HEU from 486kg feed matl
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <tails_assay>0.003</tails_assay> "
-    "   <initial_feed>1000</initial_feed> "
-    "   <swu_capacity>195</swu_capacity> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <tails_assay>0.003</tails_assay> "
+      "   <initial_feed>1000</initial_feed> "
+      "   <swu_capacity>195</swu_capacity> ";
 
   int simdur = 1;
 
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
 
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("heu", c_heu());
 
-  sim.AddSink("enr_u")
-    .recipe("heu")
-    .capacity(10)
-    .Finalize();
+  sim.AddSink("enr_u").recipe("heu").capacity(10).Finalize();
 
   int id = sim.Run();
 
@@ -122,8 +117,8 @@ TEST_F(EnrichmentTest, CheckSWUConstraint) {
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
   EXPECT_EQ(1.0, qr.rows.size());
-  EXPECT_NEAR(5.0, m->quantity(), 0.1) <<
-    "traded quantity exceeds SWU constraint";
+  EXPECT_NEAR(5.0, m->quantity(), 0.1)
+      << "traded quantity exceeds SWU constraint";
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -132,26 +127,22 @@ TEST_F(EnrichmentTest, CheckCapConstraint) {
   // inventory is partially filled with only the inventory quantity.
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <tails_assay>0.003</tails_assay> "
-    "   <initial_feed>243</initial_feed> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <tails_assay>0.003</tails_assay> "
+      "   <initial_feed>243</initial_feed> ";
 
   int simdur = 1;
 
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
-
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
 
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("heu", c_heu());
 
-  sim.AddSink("enr_u")
-    .recipe("heu")
-    .capacity(10)
-    .Finalize();
+  sim.AddSink("enr_u").recipe("heu").capacity(10).Finalize();
 
   int id = sim.Run();
 
@@ -161,8 +152,8 @@ TEST_F(EnrichmentTest, CheckCapConstraint) {
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
   EXPECT_EQ(1.0, qr.rows.size());
-  EXPECT_LE(m->quantity(), 5.0) <<
-    "traded quantity exceeds capacity constraint";
+  EXPECT_LE(m->quantity(), 5.0)
+      << "traded quantity exceeds capacity constraint";
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -171,30 +162,23 @@ TEST_F(EnrichmentTest, RequestEnrich) {
   // the maximum allowed enrichment are not fulfilled.
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <tails_assay>0.003</tails_assay> "
-    "   <max_enrich>0.19</max_enrich> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <tails_assay>0.003</tails_assay> "
+      "   <max_enrich>0.19</max_enrich> ";
 
   int simdur = 2;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("leu", c_leu());
   sim.AddRecipe("heu", c_heu());
 
-  sim.AddSource("natu")
-    .recipe("natu1")
-    .Finalize();
-  sim.AddSink("enr_u")
-    .recipe("leu")
-    .capacity(1.0)
-    .Finalize();
-  sim.AddSink("enr_u")
-    .recipe("heu")
-    .Finalize();
+  sim.AddSource("natu").recipe("natu1").Finalize();
+  sim.AddSink("enr_u").recipe("leu").capacity(1.0).Finalize();
+  sim.AddSink("enr_u").recipe("heu").Finalize();
 
   int id = sim.Run();
 
@@ -206,8 +190,8 @@ TEST_F(EnrichmentTest, RequestEnrich) {
   // Should be only one transaction out of the EF,
   // and it should be 1kg of LEU
   EXPECT_EQ(1.0, qr.rows.size());
-  EXPECT_NEAR(1.0, m->quantity(), 0.01) <<
-    "Not providing the requested quantity" ;
+  EXPECT_NEAR(1.0, m->quantity(), 0.01)
+      << "Not providing the requested quantity";
 
   CompMap got = m->comp()->mass();
   CompMap want = c_leu()->mass();
@@ -216,8 +200,8 @@ TEST_F(EnrichmentTest, RequestEnrich) {
 
   CompMap::iterator it;
   for (it = want.begin(); it != want.end(); ++it) {
-    EXPECT_DOUBLE_EQ(it->second, got[it->first]) <<
-      "nuclide qty off: " << pyne::nucname::name(it->first);
+    EXPECT_DOUBLE_EQ(it->second, got[it->first])
+        << "nuclide qty off: " << pyne::nucname::name(it->first);
   }
 }
 
@@ -226,27 +210,22 @@ TEST_F(EnrichmentTest, TradeTails) {
   // this tests whether tails are being traded.
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <tails_assay>0.003</tails_assay> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <tails_assay>0.003</tails_assay> ";
 
   // time 1-source to EF, 2-Enrich, add to tails, 3-tails avail. for trade
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("leu", c_leu());
 
-  sim.AddSource("natu")
-    .recipe("natu1")
-    .Finalize();
-  sim.AddSink("enr_u")
-    .recipe("leu")
-    .Finalize();
-   sim.AddSink("tails")
-    .Finalize();
+  sim.AddSource("natu").recipe("natu1").Finalize();
+  sim.AddSink("enr_u").recipe("leu").Finalize();
+  sim.AddSink("tails").Finalize();
 
   int id = sim.Run();
 
@@ -256,40 +235,30 @@ TEST_F(EnrichmentTest, TradeTails) {
 
   // Should be exactly one tails transaction
   EXPECT_EQ(1, qr.rows.size());
-
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  TEST_F(EnrichmentTest, TailsQty) {
+TEST_F(EnrichmentTest, TailsQty) {
   // this tests whether tails are being traded at correct quantity when
   // requested amount is larger than qty in a single tails-buffer element
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <tails_assay>0.003</tails_assay> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <tails_assay>0.003</tails_assay> ";
 
   // time 1-source to EF, 2-Enrich, add to tails, 3-tails avail. for trade
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("leu", c_leu());
 
-  sim.AddSource("natu")
-    .recipe("natu1")
-    .Finalize();
-  sim.AddSink("enr_u")
-    .recipe("leu")
-    .capacity(0.5)
-    .Finalize();
-  sim.AddSink("enr_u")
-    .recipe("leu")
-    .capacity(0.5)
-    .Finalize();
-  sim.AddSink("tails")
-    .Finalize();
+  sim.AddSource("natu").recipe("natu1").Finalize();
+  sim.AddSink("enr_u").recipe("leu").capacity(0.5).Finalize();
+  sim.AddSink("enr_u").recipe("leu").capacity(0.5).Finalize();
+  sim.AddSink("tails").Finalize();
 
   int id = sim.Run();
 
@@ -305,13 +274,12 @@ TEST_F(EnrichmentTest, TradeTails) {
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
       "SELECT SUM(r.Quantity) FROM Transactions AS t"
       " INNER JOIN Resources AS r ON r.ResourceId = t.ResourceId"
-      " WHERE t.Commodity = ?;"
-      );
+      " WHERE t.Commodity = ?;");
 
   stmt->BindText(1, "tails");
   stmt->Step();
-  EXPECT_NEAR(8.25,stmt->GetDouble(0), 0.01) <<
-    "Not providing the requested quantity" ;
+  EXPECT_NEAR(8.25, stmt->GetDouble(0), 0.01)
+      << "Not providing the requested quantity";
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -320,28 +288,22 @@ TEST_F(EnrichmentTest, BidPrefs) {
   // U235 content
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <tails_assay>0.003</tails_assay> "
-    "   <max_feed_inventory>1.0</max_feed_inventory> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <tails_assay>0.003</tails_assay> "
+      "   <max_feed_inventory>1.0</max_feed_inventory> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("natu2", c_natu2());
 
-  sim.AddSource("natu")
-    .recipe("natu1")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("natu").recipe("natu1").capacity(1).Finalize();
 
-  sim.AddSource("natu")
-    .recipe("natu2")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("natu").recipe("natu2").capacity(1).Finalize();
 
   int id = sim.Run();
 
@@ -360,40 +322,33 @@ TEST_F(EnrichmentTest, BidPrefs) {
 
   CompMap::iterator it;
   for (it = want.begin(); it != want.end(); ++it) {
-    EXPECT_DOUBLE_EQ(it->second, got[it->first]) <<
-      "nuclide qty off: " << pyne::nucname::name(it->first);
+    EXPECT_DOUBLE_EQ(it->second, got[it->first])
+        << "nuclide qty off: " << pyne::nucname::name(it->first);
   }
-
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  TEST_F(EnrichmentTest, NoBidPrefs) {
+TEST_F(EnrichmentTest, NoBidPrefs) {
   // This tests that preference-ordering for sources
   // turns off correctly if flag is used
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <tails_assay>0.003</tails_assay> "
-    "   <max_feed_inventory>2.0</max_feed_inventory> "
-    "   <order_prefs>0</order_prefs> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <tails_assay>0.003</tails_assay> "
+      "   <max_feed_inventory>2.0</max_feed_inventory> "
+      "   <order_prefs>0</order_prefs> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("natu1", c_natu1());
   sim.AddRecipe("natu2", c_natu2());
 
-  sim.AddSource("natu")
-    .recipe("natu1")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("natu").recipe("natu1").capacity(1).Finalize();
 
-  sim.AddSource("natu")
-    .recipe("natu2")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("natu").recipe("natu2").capacity(1).Finalize();
 
   int id = sim.Run();
 
@@ -403,38 +358,34 @@ TEST_F(EnrichmentTest, BidPrefs) {
 
   // should trade with both to meet its capacity limit
   EXPECT_EQ(2, qr.rows.size());
-  }
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(EnrichmentTest, ZeroU235) {
   // Test that offers of natu with no u235 content are rejected
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <tails_assay>0.003</tails_assay> "
-    "   <max_feed_inventory>1.0</max_feed_inventory> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <tails_assay>0.003</tails_assay> "
+      "   <max_feed_inventory>1.0</max_feed_inventory> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("no_u235", c_nou235());
   sim.AddRecipe("natu1", c_natu1());
 
-  sim.AddSource("natu")
-    .recipe("no_u235")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("natu").recipe("no_u235").capacity(1).Finalize();
 
   int id = sim.Run();
 
   std::vector<Cond> conds;
   conds.push_back(Cond("Commodity", "==", std::string("natu")));
   // DB table should be empty since there are no transactions
-  EXPECT_THROW(sim.db().Query("Transactions", &conds),
-         std::exception);
+  EXPECT_THROW(sim.db().Query("Transactions", &conds), std::exception);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -470,7 +421,7 @@ void EnrichmentTest::InitParameters() {
   ctx->AddRecipe(feed_recipe, recipe);
 
   tails_assay = 0.002;
-  swu_capacity = 100; //**
+  swu_capacity = 100;  //**
   inv_size = 5;
 
   reserves = 105.5;
@@ -491,8 +442,7 @@ void EnrichmentTest::SetUpSource() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Material::Ptr EnrichmentTest::GetMat(double qty) {
-  return Material::CreateUntracked(qty,
-                                           tc_.get()->GetRecipe(feed_recipe));
+  return Material::CreateUntracked(qty, tc_.get()->GetRecipe(feed_recipe));
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -506,14 +456,12 @@ Material::Ptr EnrichmentTest::DoRequest() {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Material::Ptr
-EnrichmentTest::DoOffer(Material::Ptr mat) {
+Material::Ptr EnrichmentTest::DoOffer(Material::Ptr mat) {
   return src_facility->Offer_(mat);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Material::Ptr
-EnrichmentTest::DoEnrich(Material::Ptr mat, double qty) {
+Material::Ptr EnrichmentTest::DoEnrich(Material::Ptr mat, double qty) {
   return src_facility->Enrich_(mat, qty);
 }
 
@@ -550,8 +498,8 @@ TEST_F(EnrichmentTest, ValidReq) {
 
   CompMap v1;
   v1[922350000] = 1;
-  Material::Ptr mat = Material::CreateUntracked
-    (qty,Composition::CreateFromAtom(v1));
+  Material::Ptr mat =
+      Material::CreateUntracked(qty, Composition::CreateFromAtom(v1));
   EXPECT_FALSE(src_facility->ValidReq(mat));  // u238 = 0
 
   CompMap v2;
@@ -569,22 +517,22 @@ TEST_F(EnrichmentTest, ValidReq) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  TEST_F(EnrichmentTest, ConstraintConverters) {
-    // Tests the SWU and NatU converters to make sure that amount of
-    // feed and SWU required are correct to fulfill the enrichment request.
-  using cyclus::toolkit::MatQuery;
+TEST_F(EnrichmentTest, ConstraintConverters) {
+  // Tests the SWU and NatU converters to make sure that amount of
+  // feed and SWU required are correct to fulfill the enrichment request.
   using cyclus::Composition;
+  using cyclus::toolkit::MatQuery;
 
   cyclus::Env::SetNucDataPath();
 
-  double qty = 5;  // 5 kg
+  double qty = 5;               // 5 kg
   double product_assay = 0.05;  // of 5 w/o enriched U
   CompMap v;
   v[922350000] = product_assay;
   v[922380000] = 1 - product_assay;
   v[94239] = 0.5;  // 94239 shouldn't be taken into account
-  Material::Ptr target = Material::CreateUntracked(
-      qty, Composition::CreateFromMass(v));
+  Material::Ptr target =
+      Material::CreateUntracked(qty, Composition::CreateFromMass(v));
 
   std::set<cyclus::Nuc> nucs;
   nucs.insert(922350000);
@@ -608,21 +556,21 @@ TEST_F(EnrichmentTest, Enrich) {
   // of natural uranium required that is exactly its inventory level. that
   // inventory will be comprised of two materials to test the manifest/absorb
   // strategy employed in Enrich_.
-  using cyclus::toolkit::MatQuery;
   using cyclus::Composition;
   using cyclus::toolkit::Assays;
-  using cyclus::toolkit::UraniumAssayMass;
-  using cyclus::toolkit::SwuRequired;
   using cyclus::toolkit::FeedQty;
+  using cyclus::toolkit::MatQuery;
+  using cyclus::toolkit::SwuRequired;
+  using cyclus::toolkit::UraniumAssayMass;
 
-  double qty = 5;  // kg
+  double qty = 5;               // kg
   double product_assay = 0.05;  // of 5 w/o enriched U
   CompMap v;
   v[922350000] = product_assay;
   v[922380000] = 1 - product_assay;
   // target qty need not be = to request qty
-  Material::Ptr target = Material::CreateUntracked(
-      qty + 10, Composition::CreateFromMass(v));
+  Material::Ptr target =
+      Material::CreateUntracked(qty + 10, Composition::CreateFromMass(v));
 
   Assays assays(feed_assay, UraniumAssayMass(target), tails_assay);
   double swu_req = SwuRequired(qty, assays);
@@ -667,9 +615,8 @@ TEST_F(EnrichmentTest, Response) {
   using cyclus::toolkit::UraniumAssayMass;
 
   // problem set up
-  std::vector< Trade<Material> > trades;
-  std::vector<std::pair<Trade<Material>,
-                        Material::Ptr> > responses;
+  std::vector<Trade<Material>> trades;
+  std::vector<std::pair<Trade<Material>, Material::Ptr>> responses;
 
   double qty = 5;  // kg
   double trade_qty = qty / 3;
@@ -687,7 +634,7 @@ TEST_F(EnrichmentTest, Response) {
   double natu_req = FeedQty(qty, assays);
 
   src_facility->SetMaxInventorySize(natu_req * 4);  // not capacitated by nat
-  src_facility->SwuCapacity(swu_req);  // swu capacitated
+  src_facility->SwuCapacity(swu_req);               // swu capacitated
 
   src_facility->GetMatlTrades(trades, responses);
 
@@ -703,8 +650,7 @@ TEST_F(EnrichmentTest, Response) {
   trades.push_back(trade);
 
   // 2 trades, SWU = SWU cap
-    ASSERT_GT(src_facility->SwuCapacity() - 2 * swu_req / 3,
-              -1 * cyclus::eps());
+  ASSERT_GT(src_facility->SwuCapacity() - 2 * swu_req / 3, -1 * cyclus::eps());
   trades.push_back(trade);
   responses.clear();
   EXPECT_NO_THROW(src_facility->GetMatlTrades(trades, responses));
@@ -716,21 +662,19 @@ TEST_F(EnrichmentTest, PositionInitialize) {
   // this tests verifies the initialization of the latitude variable
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <max_feed_inventory>1.0</max_feed_inventory> "
-    "   <tails_assay>0.003</tails_assay> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <max_feed_inventory>1.0</max_feed_inventory> "
+      "   <tails_assay>0.003</tails_assay> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("natu1", c_natu1());
 
-  sim.AddSource("natu")
-    .recipe("natu1")
-    .Finalize();
+  sim.AddSource("natu").recipe("natu1").Finalize();
 
   int id = sim.Run();
 
@@ -744,23 +688,21 @@ TEST_F(EnrichmentTest, PositionInitialize2) {
   // variable
 
   std::string config =
-    "   <feed_commod>natu</feed_commod> "
-    "   <feed_recipe>natu1</feed_recipe> "
-    "   <product_commod>enr_u</product_commod> "
-    "   <tails_commod>tails</tails_commod> "
-    "   <max_feed_inventory>1.0</max_feed_inventory> "
-    "   <tails_assay>0.003</tails_assay> "
-    "   <latitude>50.0</latitude> "
-    "   <longitude>35.0</longitude> ";
+      "   <feed_commod>natu</feed_commod> "
+      "   <feed_recipe>natu1</feed_recipe> "
+      "   <product_commod>enr_u</product_commod> "
+      "   <tails_commod>tails</tails_commod> "
+      "   <max_feed_inventory>1.0</max_feed_inventory> "
+      "   <tails_assay>0.003</tails_assay> "
+      "   <latitude>50.0</latitude> "
+      "   <longitude>35.0</longitude> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Enrichment"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Enrichment"), config,
+                      simdur);
   sim.AddRecipe("natu1", c_natu1());
 
-  sim.AddSource("natu")
-    .recipe("natu1")
-    .Finalize();
+  sim.AddSource("natu").recipe("natu1").Finalize();
 
   int id = sim.Run();
 
@@ -768,7 +710,6 @@ TEST_F(EnrichmentTest, PositionInitialize2) {
   EXPECT_EQ(qr.GetVal<double>("Latitude"), 50.0);
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 35.0);
 }
-
 
 }  // namespace cycamore
 
@@ -786,6 +727,6 @@ static int cyclus_agent_tests_connected = ConnectAgentTests();
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_SUITE_P(EnrichmentFac, FacilityTests,
-                        Values(&EnrichmentConstructor));
+                         Values(&EnrichmentConstructor));
 INSTANTIATE_TEST_SUITE_P(EnrichmentFac, AgentTests,
-                        Values(&EnrichmentConstructor));
+                         Values(&EnrichmentConstructor));

--- a/src/enrichment_tests.h
+++ b/src/enrichment_tests.h
@@ -5,12 +5,11 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include "test_context.h"
+#include "enrichment.h"
 #include "env.h"
 #include "exchange_context.h"
 #include "material.h"
-
-#include "enrichment.h"
+#include "test_context.h"
 
 namespace cycamore {
 
@@ -43,8 +42,8 @@ class EnrichmentTest : public ::testing::Test {
   cyclus::Material::Ptr DoEnrich(cyclus::Material::Ptr mat, double qty);
   /// @param nreqs the total number of requests
   /// @param nvalid the number of requests that are valid
-  boost::shared_ptr< cyclus::ExchangeContext<cyclus::Material> >
-      GetContext(int nreqs, int nvalid);
+  boost::shared_ptr<cyclus::ExchangeContext<cyclus::Material>> GetContext(
+      int nreqs, int nvalid);
 };
 
 }  // namespace cycamore

--- a/src/enrichment_tests.h
+++ b/src/enrichment_tests.h
@@ -5,11 +5,12 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include "enrichment.h"
+#include "test_context.h"
 #include "env.h"
 #include "exchange_context.h"
 #include "material.h"
-#include "test_context.h"
+
+#include "enrichment.h"
 
 namespace cycamore {
 
@@ -42,8 +43,8 @@ class EnrichmentTest : public ::testing::Test {
   cyclus::Material::Ptr DoEnrich(cyclus::Material::Ptr mat, double qty);
   /// @param nreqs the total number of requests
   /// @param nvalid the number of requests that are valid
-  boost::shared_ptr<cyclus::ExchangeContext<cyclus::Material>> GetContext(
-      int nreqs, int nvalid);
+  boost::shared_ptr< cyclus::ExchangeContext<cyclus::Material> >
+      GetContext(int nreqs, int nvalid);
 };
 
 }  // namespace cycamore

--- a/src/enrichment_tests.h
+++ b/src/enrichment_tests.h
@@ -43,8 +43,8 @@ class EnrichmentTest : public ::testing::Test {
   cyclus::Material::Ptr DoEnrich(cyclus::Material::Ptr mat, double qty);
   /// @param nreqs the total number of requests
   /// @param nvalid the number of requests that are valid
-  boost::shared_ptr< cyclus::ExchangeContext<cyclus::Material> >
-      GetContext(int nreqs, int nvalid);
+  boost::shared_ptr<cyclus::ExchangeContext<cyclus::Material>> GetContext(
+      int nreqs, int nvalid);
 };
 
 }  // namespace cycamore

--- a/src/fuel_fab.cc
+++ b/src/fuel_fab.cc
@@ -2,8 +2,8 @@
 
 #include <sstream>
 
-using cyclus::Composition;
 using cyclus::Material;
+using cyclus::Composition;
 using pyne::simple_xs;
 
 #define SHOW(X)                                                     \
@@ -26,7 +26,8 @@ class FissConverter : public cyclus::Converter<Material> {
 
   virtual double convert(
       Material::Ptr m, cyclus::Arc const* a = NULL,
-      cyclus::ExchangeTranslationContext<Material> const* ctx = NULL) const {
+      cyclus::ExchangeTranslationContext<Material> const* ctx =
+          NULL) const {
     double w_tgt = CosiWeight(m->comp(), spec_);
     if (ValidWeights(w_fill_, w_tgt, w_fiss_)) {
       double frac = HighFrac(w_fill_, w_tgt, w_fiss_);
@@ -65,7 +66,8 @@ class FillConverter : public cyclus::Converter<Material> {
 
   virtual double convert(
       Material::Ptr m, cyclus::Arc const* a = NULL,
-      cyclus::ExchangeTranslationContext<Material> const* ctx = NULL) const {
+      cyclus::ExchangeTranslationContext<Material> const* ctx =
+          NULL) const {
     double w_tgt = CosiWeight(m->comp(), spec_);
     if (ValidWeights(w_fill_, w_tgt, w_fiss_)) {
       double frac = LowFrac(w_fill_, w_tgt, w_fiss_);
@@ -103,7 +105,8 @@ class TopupConverter : public cyclus::Converter<Material> {
 
   virtual double convert(
       Material::Ptr m, cyclus::Arc const* a = NULL,
-      cyclus::ExchangeTranslationContext<Material> const* ctx = NULL) const {
+      cyclus::ExchangeTranslationContext<Material> const* ctx =
+          NULL) const {
     double w_tgt = CosiWeight(m->comp(), spec_);
     if (ValidWeights(w_fill_, w_tgt, w_fiss_)) {
       return 0;
@@ -237,10 +240,10 @@ bool Contains(std::vector<std::string> vec, std::string s) {
 }
 
 void FuelFab::AcceptMatlTrades(
-    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>&
+    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
         responses) {
-  std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>::const_iterator
-      trade;
+  std::vector<std::pair<cyclus::Trade<Material>,
+                        Material::Ptr> >::const_iterator trade;
 
   for (trade = responses.begin(); trade != responses.end(); ++trade) {
     std::string commod = trade->first.request->commodity();
@@ -372,12 +375,12 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> FuelFab::GetMatlBids(
       new TopupConverter(c_fill, c_fiss, c_topup, spectrum));
   // important! - the std::max calls prevent CapacityConstraint throwing a zero
   // cap exception
-  cyclus::CapacityConstraint<Material> fissc(
-      std::max(fiss.quantity(), cyclus::CY_NEAR_ZERO), fissconv);
-  cyclus::CapacityConstraint<Material> fillc(
-      std::max(fill.quantity(), cyclus::CY_NEAR_ZERO), fillconv);
-  cyclus::CapacityConstraint<Material> topupc(
-      std::max(topup.quantity(), cyclus::CY_NEAR_ZERO), topupconv);
+  cyclus::CapacityConstraint<Material> fissc(std::max(fiss.quantity(), cyclus::CY_NEAR_ZERO),
+                                             fissconv);
+  cyclus::CapacityConstraint<Material> fillc(std::max(fill.quantity(), cyclus::CY_NEAR_ZERO),
+                                             fillconv);
+  cyclus::CapacityConstraint<Material> topupc(std::max(topup.quantity(), cyclus::CY_NEAR_ZERO),
+                                              topupconv);
   port->AddConstraint(fillc);
   port->AddConstraint(fissc);
   port->AddConstraint(topupc);
@@ -389,8 +392,9 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> FuelFab::GetMatlBids(
 }
 
 void FuelFab::GetMatlTrades(
-    const std::vector<cyclus::Trade<Material>>& trades,
-    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>& responses) {
+    const std::vector<cyclus::Trade<Material> >& trades,
+    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
+        responses) {
   using cyclus::Trade;
 
   // guard against cases where a buffer is empty - this is okay because some
@@ -408,7 +412,7 @@ void FuelFab::GetMatlTrades(
     w_fiss = CosiWeight(fiss.Peek()->comp(), spectrum);
   }
 
-  std::vector<cyclus::Trade<Material>>::const_iterator it;
+  std::vector<cyclus::Trade<Material> >::const_iterator it;
   double tot = 0;
   for (int i = 0; i < trades.size(); i++) {
     Material::Ptr tgt = trades[i].request->target();

--- a/src/fuel_fab.cc
+++ b/src/fuel_fab.cc
@@ -2,8 +2,8 @@
 
 #include <sstream>
 
-using cyclus::Material;
 using cyclus::Composition;
+using cyclus::Material;
 using pyne::simple_xs;
 
 #define SHOW(X)                                                     \
@@ -26,8 +26,7 @@ class FissConverter : public cyclus::Converter<Material> {
 
   virtual double convert(
       Material::Ptr m, cyclus::Arc const* a = NULL,
-      cyclus::ExchangeTranslationContext<Material> const* ctx =
-          NULL) const {
+      cyclus::ExchangeTranslationContext<Material> const* ctx = NULL) const {
     double w_tgt = CosiWeight(m->comp(), spec_);
     if (ValidWeights(w_fill_, w_tgt, w_fiss_)) {
       double frac = HighFrac(w_fill_, w_tgt, w_fiss_);
@@ -66,8 +65,7 @@ class FillConverter : public cyclus::Converter<Material> {
 
   virtual double convert(
       Material::Ptr m, cyclus::Arc const* a = NULL,
-      cyclus::ExchangeTranslationContext<Material> const* ctx =
-          NULL) const {
+      cyclus::ExchangeTranslationContext<Material> const* ctx = NULL) const {
     double w_tgt = CosiWeight(m->comp(), spec_);
     if (ValidWeights(w_fill_, w_tgt, w_fiss_)) {
       double frac = LowFrac(w_fill_, w_tgt, w_fiss_);
@@ -105,8 +103,7 @@ class TopupConverter : public cyclus::Converter<Material> {
 
   virtual double convert(
       Material::Ptr m, cyclus::Arc const* a = NULL,
-      cyclus::ExchangeTranslationContext<Material> const* ctx =
-          NULL) const {
+      cyclus::ExchangeTranslationContext<Material> const* ctx = NULL) const {
     double w_tgt = CosiWeight(m->comp(), spec_);
     if (ValidWeights(w_fill_, w_tgt, w_fiss_)) {
       return 0;
@@ -240,10 +237,10 @@ bool Contains(std::vector<std::string> vec, std::string s) {
 }
 
 void FuelFab::AcceptMatlTrades(
-    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
+    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>&
         responses) {
-  std::vector<std::pair<cyclus::Trade<Material>,
-                        Material::Ptr> >::const_iterator trade;
+  std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>::const_iterator
+      trade;
 
   for (trade = responses.begin(); trade != responses.end(); ++trade) {
     std::string commod = trade->first.request->commodity();
@@ -375,12 +372,12 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> FuelFab::GetMatlBids(
       new TopupConverter(c_fill, c_fiss, c_topup, spectrum));
   // important! - the std::max calls prevent CapacityConstraint throwing a zero
   // cap exception
-  cyclus::CapacityConstraint<Material> fissc(std::max(fiss.quantity(), cyclus::CY_NEAR_ZERO),
-                                             fissconv);
-  cyclus::CapacityConstraint<Material> fillc(std::max(fill.quantity(), cyclus::CY_NEAR_ZERO),
-                                             fillconv);
-  cyclus::CapacityConstraint<Material> topupc(std::max(topup.quantity(), cyclus::CY_NEAR_ZERO),
-                                              topupconv);
+  cyclus::CapacityConstraint<Material> fissc(
+      std::max(fiss.quantity(), cyclus::CY_NEAR_ZERO), fissconv);
+  cyclus::CapacityConstraint<Material> fillc(
+      std::max(fill.quantity(), cyclus::CY_NEAR_ZERO), fillconv);
+  cyclus::CapacityConstraint<Material> topupc(
+      std::max(topup.quantity(), cyclus::CY_NEAR_ZERO), topupconv);
   port->AddConstraint(fillc);
   port->AddConstraint(fissc);
   port->AddConstraint(topupc);
@@ -392,9 +389,8 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> FuelFab::GetMatlBids(
 }
 
 void FuelFab::GetMatlTrades(
-    const std::vector<cyclus::Trade<Material> >& trades,
-    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
-        responses) {
+    const std::vector<cyclus::Trade<Material>>& trades,
+    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>& responses) {
   using cyclus::Trade;
 
   // guard against cases where a buffer is empty - this is okay because some
@@ -412,7 +408,7 @@ void FuelFab::GetMatlTrades(
     w_fiss = CosiWeight(fiss.Peek()->comp(), spectrum);
   }
 
-  std::vector<cyclus::Trade<Material> >::const_iterator it;
+  std::vector<cyclus::Trade<Material>>::const_iterator it;
   double tot = 0;
   for (int i = 0; i < trades.size(); i++) {
     Material::Ptr tgt = trades[i].request->target();

--- a/src/fuel_fab.cc
+++ b/src/fuel_fab.cc
@@ -2,8 +2,8 @@
 
 #include <sstream>
 
-using cyclus::Material;
 using cyclus::Composition;
+using cyclus::Material;
 using pyne::simple_xs;
 
 #define SHOW(X)                                                     \
@@ -26,8 +26,7 @@ class FissConverter : public cyclus::Converter<Material> {
 
   virtual double convert(
       Material::Ptr m, cyclus::Arc const* a = NULL,
-      cyclus::ExchangeTranslationContext<Material> const* ctx =
-          NULL) const {
+      cyclus::ExchangeTranslationContext<Material> const* ctx = NULL) const {
     double w_tgt = CosiWeight(m->comp(), spec_);
     if (ValidWeights(w_fill_, w_tgt, w_fiss_)) {
       double frac = HighFrac(w_fill_, w_tgt, w_fiss_);
@@ -66,8 +65,7 @@ class FillConverter : public cyclus::Converter<Material> {
 
   virtual double convert(
       Material::Ptr m, cyclus::Arc const* a = NULL,
-      cyclus::ExchangeTranslationContext<Material> const* ctx =
-          NULL) const {
+      cyclus::ExchangeTranslationContext<Material> const* ctx = NULL) const {
     double w_tgt = CosiWeight(m->comp(), spec_);
     if (ValidWeights(w_fill_, w_tgt, w_fiss_)) {
       double frac = LowFrac(w_fill_, w_tgt, w_fiss_);
@@ -105,8 +103,7 @@ class TopupConverter : public cyclus::Converter<Material> {
 
   virtual double convert(
       Material::Ptr m, cyclus::Arc const* a = NULL,
-      cyclus::ExchangeTranslationContext<Material> const* ctx =
-          NULL) const {
+      cyclus::ExchangeTranslationContext<Material> const* ctx = NULL) const {
     double w_tgt = CosiWeight(m->comp(), spec_);
     if (ValidWeights(w_fill_, w_tgt, w_fiss_)) {
       return 0;
@@ -131,10 +128,7 @@ class TopupConverter : public cyclus::Converter<Material> {
 };
 
 FuelFab::FuelFab(cyclus::Context* ctx)
-    : cyclus::Facility(ctx),
-      fill_size(0),
-      fiss_size(0),
-      throughput(0) {}
+    : cyclus::Facility(ctx), fill_size(0), fiss_size(0), throughput(0) {}
 
 void FuelFab::EnterNotify() {
   cyclus::Facility::EnterNotify();
@@ -238,10 +232,10 @@ bool Contains(std::vector<std::string> vec, std::string s) {
 }
 
 void FuelFab::AcceptMatlTrades(
-    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
+    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>&
         responses) {
-  std::vector<std::pair<cyclus::Trade<Material>,
-                        Material::Ptr> >::const_iterator trade;
+  std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>::const_iterator
+      trade;
 
   for (trade = responses.begin(); trade != responses.end(); ++trade) {
     std::string commod = trade->first.request->commodity();
@@ -373,12 +367,12 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> FuelFab::GetMatlBids(
       new TopupConverter(c_fill, c_fiss, c_topup, spectrum));
   // important! - the std::max calls prevent CapacityConstraint throwing a zero
   // cap exception
-  cyclus::CapacityConstraint<Material> fissc(std::max(fiss.quantity(), cyclus::CY_NEAR_ZERO),
-                                             fissconv);
-  cyclus::CapacityConstraint<Material> fillc(std::max(fill.quantity(), cyclus::CY_NEAR_ZERO),
-                                             fillconv);
-  cyclus::CapacityConstraint<Material> topupc(std::max(topup.quantity(), cyclus::CY_NEAR_ZERO),
-                                              topupconv);
+  cyclus::CapacityConstraint<Material> fissc(
+      std::max(fiss.quantity(), cyclus::CY_NEAR_ZERO), fissconv);
+  cyclus::CapacityConstraint<Material> fillc(
+      std::max(fill.quantity(), cyclus::CY_NEAR_ZERO), fillconv);
+  cyclus::CapacityConstraint<Material> topupc(
+      std::max(topup.quantity(), cyclus::CY_NEAR_ZERO), topupconv);
   port->AddConstraint(fillc);
   port->AddConstraint(fissc);
   port->AddConstraint(topupc);
@@ -390,9 +384,8 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> FuelFab::GetMatlBids(
 }
 
 void FuelFab::GetMatlTrades(
-    const std::vector<cyclus::Trade<Material> >& trades,
-    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
-        responses) {
+    const std::vector<cyclus::Trade<Material>>& trades,
+    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>& responses) {
   using cyclus::Trade;
 
   // guard against cases where a buffer is empty - this is okay because some
@@ -410,7 +403,7 @@ void FuelFab::GetMatlTrades(
     w_fiss = CosiWeight(fiss.Peek()->comp(), spectrum);
   }
 
-  std::vector<cyclus::Trade<Material> >::const_iterator it;
+  std::vector<cyclus::Trade<Material>>::const_iterator it;
   double tot = 0;
   for (int i = 0; i < trades.size(); i++) {
     Material::Ptr tgt = trades[i].request->target();

--- a/src/fuel_fab.h
+++ b/src/fuel_fab.h
@@ -5,68 +5,68 @@
 #include "cyclus.h"
 #include "cycamore_version.h"
 
-#pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
+// clang-format off
+#pragma cyclus exec \
+  from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
+// clang-format on
 
 namespace cycamore {
 
-/// FuelFab takes in 2 streams of material and mixes them in ratios in order to
-/// supply material that matches some neutronics properties of reqeusted
-/// material.  It uses an equivalence type method [1]
-/// inspired by a similar approach in the COSI fuel cycle simulator.
+/// FuelFab takes in two streams of material and mixes them in ratios in order
+/// to supply material that matches some neutronics properties of requested
+/// material. It uses an equivalence-type method [1] inspired by a similar
+/// approach in the COSI fuel cycle simulator.
 ///
-/// The FuelFab has 3 input inventories: fissile stream, filler stream, and an
-/// optional top-up inventory.  All materials received into each inventory are
-/// always combined into a single material (i.e. a single fissile material, a
-/// single filler material, etc.).  The input streams and requested fuel
-/// composition are each assigned weights based on summing:
+/// The FuelFab has three input inventories: fissile stream, filler stream,
+/// and an optional top-up inventory. All materials received into each
+/// inventory are always combined into a single material (i.e., a single
+/// fissile material, a single filler material, etc.). The input streams and
+/// requested fuel composition are each assigned weights based on summing:
 ///
 ///     N * (p_i - p_U238) / (p_Pu239 - p_U238)
 ///
 /// for each nuclide where:
+///   - p = nu*sigma_f - sigma_a   for the nuclide  
+///   - p_U238 is p for pure U238  
+///   - p_Pu239 is p for pure Pu239  
+///   - N is the nuclide's atom fraction  
+///   - nu is the average number of neutrons per fission  
+///   - sigma_f is the microscopic fission cross-section  
+///   - sigma_a is the microscopic neutron absorption cross-section  
 ///
-///     - p = nu*sigma_f - sigma_a   for the nuclide
-///     - p_U238 is p for pure U238
-///     - p_Pu239 is p for pure Pu239
-///     - N is the nuclide's atom fraction
-///     - nu is the average # neutrons per fission
-///     - sigma_f is the microscopic fission cross-section
-///     - sigma_a is the microscopic neutron absorption cross-section
-///
-/// The cross sections are from the simple cross section library in PyNE. They
-/// can be set to either a thermal or fast neutron spectrum.  A linear
+/// The cross sections are from the simple cross section library in PyNE.
+/// They can be set to either a thermal or fast neutron spectrum. A linear
 /// interpolation is performed using the weights of the fissile, filler, and
-/// target streams. The interpolation is used to compute a mixing ratio of the
-/// input streams that matches the target weight.  In the event that the target
-/// weight is higher than the fissile stream weight, the FuelFab will attempt
-/// to use the top-up and fissile input streams together instead of the fissile
-/// and filler streams.  All supplied material will always have the same weight
-/// as the requested material.
+/// target streams. That interpolation computes a mixing ratio matching the
+/// target weight. If the target weight exceeds the fissile-stream weight,
+/// FuelFab uses top-up + fissile instead of fissile + filler. All supplied
+/// material retains the requested weight.
 ///
-/// The supplying of mixed material is constrained by available inventory
-/// quantities and a per time step throughput limit.  Requests for fuel
-/// material larger than the throughput can never be met.  Fissile inventory
-/// can be requested/received via one or more commodities.  The DRE request
-/// preference for each of these commodities can also optionally be specified.
-/// By default, the top-up inventory size is zero, and it is not used for
-/// mixing.
+/// The supply of mixed material is constrained by inventory quantities and a
+/// per-time-step throughput limit. Requests larger than throughput cannot
+/// be met. Fissile inventory can be requested/received via one or more
+/// commodities; DRE preference for each can be specified. By default, the
+/// top-up inventory size is zero and not used for mixing.
 ///
 /// @code
 /// [1] Baker, A. R., and R. W. Ross. "Comparison of the value of plutonium and
 ///     uranium isotopes in fast reactors." Proceedings of the Conference on
-///     Breeding. Economics, and Safety in Large Fast Power Reactors. 1963.
+///     Breeding, Economics, and Safety in Large Fast Power Reactors. 1963.
 /// @endcode
 class FuelFab
   : public cyclus::Facility,
     public cyclus::toolkit::Position {
-#pragma cyclus note { \
-"niche": "fabrication", \
-"doc": \
-  "FuelFab takes in 2 streams of material and mixes them in ratios in order to" \
-  " supply material that matches some neutronics properties of reqeusted" \
-  " material.  It uses an equivalence type method [1]" \
+
+  // clang-format off
+  #pragma cyclus note { \
+    "niche": "fabrication", \
+    "doc": \
+  "FuelFab takes in two streams of material and mixes them in ratios in order" \
+  " to supply material that matches some neutronics properties of reqeusted" \
+  " material. It uses an equivalence-type method [1]" \
   " inspired by a similar approach in the COSI fuel cycle simulator." \
   "\n\n" \
-  "The FuelFab has 3 input inventories: fissile stream, filler stream, and an" \
+  "The FuelFab has three input inventories: fissile stream, filler stream, and an" \
   " optional top-up inventory.  All materials received into each inventory are" \
   " always combined into a single material (i.e. a single fissile material, a" \
   " single filler material, etc.).  The input streams and requested fuel" \
@@ -106,14 +106,16 @@ class FuelFab
   "    uranium isotopes in fast reactors.\" Proceedings of the Conference on" \
   "    Breeding. Economics, and Safety in Large Fast Power Reactors. 1963." \
   "", \
-}
+  }
+  // clang-format on
+
  public:
   FuelFab(cyclus::Context* ctx);
   virtual ~FuelFab(){};
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-#pragma cyclus
+  #pragma cyclus
 
   virtual void Tick(){};
   virtual void Tock(){};
@@ -123,167 +125,189 @@ class FuelFab
       cyclus::CommodMap<cyclus::Material>::type& commod_requests);
 
   virtual void GetMatlTrades(
-      const std::vector<cyclus::Trade<cyclus::Material> >& trades,
+      const std::vector<cyclus::Trade<cyclus::Material>>& trades,
       std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                            cyclus::Material::Ptr> >& responses);
+                            cyclus::Material::Ptr>>& responses);
 
-  virtual void AcceptMatlTrades(const std::vector<std::pair<
-      cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr> >& responses);
+  virtual void AcceptMatlTrades(
+      const std::vector<std::pair<
+          cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr>>& responses);
 
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-  GetMatlRequests();
+      GetMatlRequests();
 
  private:
+  // clang-format off
   #pragma cyclus var { \
-    "doc": "Ordered list of commodities on which to requesting filler stream material.", \
+    "doc": \
+      "Ordered list of commodities on which to request filler stream material.", \
     "uilabel": "Filler Stream Commodities", \
-    "uitype": ["oneormore", "incommodity"], \
+    "uitype": ["oneormore", "incommodity"] \
   }
   std::vector<std::string> fill_commods;
+
   #pragma cyclus var { \
     "default": [], \
     "uilabel": "Filler Stream Preferences", \
-    "doc": "Filler stream commodity request preferences for each of the given filler commodities (same order)." \
-           " If unspecified, default is to use 1.0 for all preferences.", \
+    "doc": \
+      "Filler stream request preferences for each filler commodity " \
+      "(same order). Defaults to 1.0 if unspecified." \
   }
   std::vector<double> fill_commod_prefs;
+
   #pragma cyclus var { \
-    "doc": "Name of recipe to be used in filler material stream requests.", \
+    "doc": "Recipe name for filler material stream requests.", \
     "uilabel": "Filler Stream Recipe", \
-    "uitype": "inrecipe", \
+    "uitype": "inrecipe" \
   }
   std::string fill_recipe;
+
   #pragma cyclus var { \
-    "doc": "Size of filler material stream inventory.", \
+    "doc": "Capacity of filler material stream inventory (kg).", \
     "uilabel": "Filler Stream Inventory Capacity", \
-    "units": "kg", \
+    "units": "kg" \
   }
   double fill_size;
-  #pragma cyclus var {"capacity": "fill_size"}
+
+  #pragma cyclus var { "capacity": "fill_size" }
   cyclus::toolkit::ResBuf<cyclus::Material> fill;
 
   #pragma cyclus var { \
-    "doc": "Ordered list of commodities on which to requesting fissile stream material.", \
+    "doc": \
+      "Ordered list of commodities on which to request fissile stream material.", \
     "uilabel": "Fissile Stream Commodities", \
-    "uitype": ["oneormore", "incommodity"], \
+    "uitype": ["oneormore", "incommodity"] \
   }
   std::vector<std::string> fiss_commods;
+
   #pragma cyclus var { \
     "default": [], \
     "uilabel": "Fissile Stream Preferences", \
-    "doc": "Fissile stream commodity request preferences for each of the given fissile commodities (same order)." \
-           " If unspecified, default is to use 1.0 for all preferences.", \
+    "doc": \
+      "Fissile stream request preferences for each fissile commodity " \
+      "(same order). Defaults to 1.0 if unspecified." \
   }
   std::vector<double> fiss_commod_prefs;
+
   #pragma cyclus var { \
-    "doc": "Name for recipe to be used in fissile stream requests." \
-           " Empty string results in use of an empty dummy recipe.", \
-    "uitype": "inrecipe", \
+    "doc": \
+      "Recipe name for fissile stream requests. Empty string uses dummy recipe.", \
     "uilabel": "Fissile Stream Recipe", \
-    "default": "", \
+    "uitype": "inrecipe", \
+    "default": "" \
   }
   std::string fiss_recipe;
+
   #pragma cyclus var { \
-    "doc": "Size of fissile material stream inventory.", \
+    "doc": "Capacity of fissile stream inventory (kg).", \
     "uilabel": "Fissile Stream Inventory Capacity", \
-    "units": "kg", \
+    "units": "kg" \
   }
   double fiss_size;
-  #pragma cyclus var {"capacity": "fiss_size"}
+
+  #pragma cyclus var { "capacity": "fiss_size" }
   cyclus::toolkit::ResBuf<cyclus::Material> fiss;
 
   #pragma cyclus var { \
-    "doc": "Commodity on which to request material for top-up stream." \
-           " This MUST be set if 'topup_size > 0'.", \
+    "doc": \
+      "Top-up commodity for material stream. Must be set if topup_size > 0.", \
     "uilabel": "Top-up Stream Commodity", \
     "default": "", \
-    "uitype": "incommodity", \
+    "uitype": "incommodity" \
   }
   std::string topup_commod;
-  #pragma cyclus var { \
-    "doc": "Top-up material stream request preference.", \
-    "uilabel": "Top-up Stream Preference", \
-    "default": 1.0, \
-  }
-  double topup_pref; // default must be in range (0, cyclus::kDefaultPref)
 
   #pragma cyclus var { \
-    "doc": "Name of recipe to be used in top-up material stream requests." \
-           " This MUST be set if 'topup_size > 0'.", \
+    "doc": "Top-up stream request preference.", \
+    "uilabel": "Top-up Stream Preference", \
+    "default": 1.0 \
+  }
+  double topup_pref;
+
+  #pragma cyclus var { \
+    "doc": \
+      "Recipe name for top-up stream requests. Must be set if topup_size > 0.", \
     "uilabel": "Top-up Stream Recipe", \
     "uitype": "inrecipe", \
-    "default": "", \
+    "default": "" \
   }
   std::string topup_recipe;
+
   #pragma cyclus var { \
-    "doc": "Size of top-up material stream inventory.", \
+    "doc": "Capacity of top-up stream inventory (kg).", \
     "uilabel": "Top-up Stream Inventory Capacity", \
     "units": "kg", \
-    "default": 0, \
+    "default": 0 \
   }
   double topup_size;
-  #pragma cyclus var {"capacity": "topup_size"}
+
+  #pragma cyclus var { "capacity": "topup_size" }
   cyclus::toolkit::ResBuf<cyclus::Material> topup;
 
   #pragma cyclus var { \
-    "doc": "Commodity on which to offer/supply mixed fuel material.", \
+    "doc": "Output commodity for mixed fuel material.", \
     "uilabel": "Output Commodity", \
-    "uitype": "outcommodity", \
+    "uitype": "outcommodity" \
   }
   std::string outcommod;
 
   #pragma cyclus var { \
-    "doc": "Maximum number of kg of fuel material that can be supplied per time step.", \
+    "doc": \
+      "Maximum kg of fuel material supply per time step.", \
     "uilabel": "Maximum Throughput", \
     "units": "kg", \
     "default": CY_LARGE_DOUBLE, \
     "uitype": "range", \
-    "range": [0.0, CY_LARGE_DOUBLE], \
+    "range": [0.0, CY_LARGE_DOUBLE] \
   }
   double throughput;
 
-  #pragma cyclus var {		\
+  #pragma cyclus var { \
     "uilabel": "Spectrum type", \
     "uitype": "combobox", \
     "categorical": ["fission_spectrum_ave", "thermal"], \
-    "doc": "The type of cross-sections to use for composition property calculation." \
-           " Use 'fission_spectrum_ave' for fast reactor compositions or 'thermal' for thermal reactors.", \
+    "doc": \
+      "Cross-section spectrum for calculations: 'fast' or 'thermal'." \
   }
   std::string spectrum;
+  // clang-format on
 
-  // intra-time-step state - no need to be a state var
-  // map<request, inventory name>
+  // intra-time-step state (not persisted)
   std::map<cyclus::Request<cyclus::Material>*, std::string> req_inventories_;
 
+  // clang-format off
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
+    "doc": \
+      "Latitude of the agent's geographical position in degrees." \
   }
   double latitude;
 
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
+    "doc": \
+      "Longitude of the agent's geographical position in degrees." \
   }
   double longitude;
+  // clang-format on
 
   cyclus::toolkit::Position coordinates;
 
-  /// Records an agent's latitude and longitude to the output db
+  /// Records an agent’s latitude and longitude to the output database.
   void RecordPosition();
 };
 
 double CosiWeight(cyclus::Composition::Ptr c, const std::string& spectrum);
 bool ValidWeights(double w_low, double w_tgt, double w_high);
-double LowFrac(double w_low, double w_tgt, double w_high, double eps = cyclus::CY_NEAR_ZERO);
-double HighFrac(double w_low, double w_tgt, double w_high, double eps = cyclus::CY_NEAR_ZERO);
-double AtomToMassFrac(double atomfrac, cyclus::Composition::Ptr c1, cyclus::Composition::Ptr c2);
+double LowFrac(double w_low, double w_tgt, double w_high,
+               double eps = cyclus::CY_NEAR_ZERO);
+double HighFrac(double w_low, double w_tgt, double w_high,
+                double eps = cyclus::CY_NEAR_ZERO);
+double AtomToMassFrac(double atomfrac, cyclus::Composition::Ptr c1,
+                      cyclus::Composition::Ptr c2);
 
-} // namespace cycamore
-
+}  // namespace cycamore
 
 #endif  // CYCAMORE_SRC_FUEL_FAB_H_

--- a/src/fuel_fab.h
+++ b/src/fuel_fab.h
@@ -2,9 +2,8 @@
 #define CYCAMORE_SRC_FUEL_FAB_H_
 
 #include <string>
-
-#include "cycamore_version.h"
 #include "cyclus.h"
+#include "cycamore_version.h"
 
 // clang-format off
 #pragma cyclus exec \
@@ -27,13 +26,13 @@ namespace cycamore {
 ///     N * (p_i - p_U238) / (p_Pu239 - p_U238)
 ///
 /// for each nuclide where:
-///   - p = nu*sigma_f - sigma_a   for the nuclide
-///   - p_U238 is p for pure U238
-///   - p_Pu239 is p for pure Pu239
-///   - N is the nuclide's atom fraction
-///   - nu is the average number of neutrons per fission
-///   - sigma_f is the microscopic fission cross-section
-///   - sigma_a is the microscopic neutron absorption cross-section
+///   - p = nu*sigma_f - sigma_a   for the nuclide  
+///   - p_U238 is p for pure U238  
+///   - p_Pu239 is p for pure Pu239  
+///   - N is the nuclide's atom fraction  
+///   - nu is the average number of neutrons per fission  
+///   - sigma_f is the microscopic fission cross-section  
+///   - sigma_a is the microscopic neutron absorption cross-section  
 ///
 /// The cross sections are from the simple cross section library in PyNE.
 /// They can be set to either a thermal or fast neutron spectrum. A linear
@@ -54,7 +53,10 @@ namespace cycamore {
 ///     uranium isotopes in fast reactors." Proceedings of the Conference on
 ///     Breeding, Economics, and Safety in Large Fast Power Reactors. 1963.
 /// @endcode
-class FuelFab : public cyclus::Facility, public cyclus::toolkit::Position {
+class FuelFab
+  : public cyclus::Facility,
+    public cyclus::toolkit::Position {
+
   // clang-format off
   #pragma cyclus note { \
     "niche": "fabrication", \
@@ -113,10 +115,10 @@ class FuelFab : public cyclus::Facility, public cyclus::toolkit::Position {
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-#pragma cyclus
+  #pragma cyclus
 
-  virtual void Tick() {};
-  virtual void Tock() {};
+  virtual void Tick(){};
+  virtual void Tock(){};
   virtual void EnterNotify();
 
   virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> GetMatlBids(
@@ -128,11 +130,11 @@ class FuelFab : public cyclus::Facility, public cyclus::toolkit::Position {
                             cyclus::Material::Ptr>>& responses);
 
   virtual void AcceptMatlTrades(
-      const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                                  cyclus::Material::Ptr>>& responses);
+      const std::vector<std::pair<
+          cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr>>& responses);
 
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-  GetMatlRequests();
+      GetMatlRequests();
 
  private:
   // clang-format off

--- a/src/fuel_fab.h
+++ b/src/fuel_fab.h
@@ -2,8 +2,9 @@
 #define CYCAMORE_SRC_FUEL_FAB_H_
 
 #include <string>
-#include "cyclus.h"
+
 #include "cycamore_version.h"
+#include "cyclus.h"
 
 // clang-format off
 #pragma cyclus exec \
@@ -26,13 +27,13 @@ namespace cycamore {
 ///     N * (p_i - p_U238) / (p_Pu239 - p_U238)
 ///
 /// for each nuclide where:
-///   - p = nu*sigma_f - sigma_a   for the nuclide  
-///   - p_U238 is p for pure U238  
-///   - p_Pu239 is p for pure Pu239  
-///   - N is the nuclide's atom fraction  
-///   - nu is the average number of neutrons per fission  
-///   - sigma_f is the microscopic fission cross-section  
-///   - sigma_a is the microscopic neutron absorption cross-section  
+///   - p = nu*sigma_f - sigma_a   for the nuclide
+///   - p_U238 is p for pure U238
+///   - p_Pu239 is p for pure Pu239
+///   - N is the nuclide's atom fraction
+///   - nu is the average number of neutrons per fission
+///   - sigma_f is the microscopic fission cross-section
+///   - sigma_a is the microscopic neutron absorption cross-section
 ///
 /// The cross sections are from the simple cross section library in PyNE.
 /// They can be set to either a thermal or fast neutron spectrum. A linear
@@ -53,10 +54,7 @@ namespace cycamore {
 ///     uranium isotopes in fast reactors." Proceedings of the Conference on
 ///     Breeding, Economics, and Safety in Large Fast Power Reactors. 1963.
 /// @endcode
-class FuelFab
-  : public cyclus::Facility,
-    public cyclus::toolkit::Position {
-
+class FuelFab : public cyclus::Facility, public cyclus::toolkit::Position {
   // clang-format off
   #pragma cyclus note { \
     "niche": "fabrication", \
@@ -115,10 +113,10 @@ class FuelFab
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-  #pragma cyclus
+#pragma cyclus
 
-  virtual void Tick(){};
-  virtual void Tock(){};
+  virtual void Tick() {};
+  virtual void Tock() {};
   virtual void EnterNotify();
 
   virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> GetMatlBids(
@@ -130,11 +128,11 @@ class FuelFab
                             cyclus::Material::Ptr>>& responses);
 
   virtual void AcceptMatlTrades(
-      const std::vector<std::pair<
-          cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr>>& responses);
+      const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                                  cyclus::Material::Ptr>>& responses);
 
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-      GetMatlRequests();
+  GetMatlRequests();
 
  private:
   // clang-format off

--- a/src/fuel_fab.h
+++ b/src/fuel_fab.h
@@ -275,7 +275,8 @@ class FuelFab
   std::string spectrum;
   // clang-format on
 
-  // intra-time-step state (not persisted)
+  // intra-time-step state - no need to be a state var
+  // map<request, inventory name>
   std::map<cyclus::Request<cyclus::Material>*, std::string> req_inventories_;
 
 };

--- a/src/fuel_fab.h
+++ b/src/fuel_fab.h
@@ -26,13 +26,13 @@ namespace cycamore {
 ///     N * (p_i - p_U238) / (p_Pu239 - p_U238)
 ///
 /// for each nuclide where:
-///   - p = nu*sigma_f - sigma_a   for the nuclide  
-///   - p_U238 is p for pure U238  
-///   - p_Pu239 is p for pure Pu239  
-///   - N is the nuclide's atom fraction  
-///   - nu is the average number of neutrons per fission  
-///   - sigma_f is the microscopic fission cross-section  
-///   - sigma_a is the microscopic neutron absorption cross-section  
+///   - p = nu*sigma_f - sigma_a   for the nuclide
+///   - p_U238 is p for pure U238
+///   - p_Pu239 is p for pure Pu239
+///   - N is the nuclide's atom fraction
+///   - nu is the average number of neutrons per fission
+///   - sigma_f is the microscopic fission cross-section
+///   - sigma_a is the microscopic neutron absorption cross-section
 ///
 /// The cross sections are from the simple cross section library in PyNE.
 /// They can be set to either a thermal or fast neutron spectrum. A linear
@@ -53,10 +53,7 @@ namespace cycamore {
 ///     uranium isotopes in fast reactors." Proceedings of the Conference on
 ///     Breeding, Economics, and Safety in Large Fast Power Reactors. 1963.
 /// @endcode
-class FuelFab
-  : public cyclus::Facility,
-    public cyclus::toolkit::Position {
-
+class FuelFab : public cyclus::Facility, public cyclus::toolkit::Position {
   // clang-format off
   #pragma cyclus note { \
     "niche": "fabrication", \
@@ -115,10 +112,10 @@ class FuelFab
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-  #pragma cyclus
+#pragma cyclus
 
-  virtual void Tick(){};
-  virtual void Tock(){};
+  virtual void Tick() {};
+  virtual void Tock() {};
   virtual void EnterNotify();
 
   virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> GetMatlBids(
@@ -130,11 +127,11 @@ class FuelFab
                             cyclus::Material::Ptr>>& responses);
 
   virtual void AcceptMatlTrades(
-      const std::vector<std::pair<
-          cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr>>& responses);
+      const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                                  cyclus::Material::Ptr>>& responses);
 
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-      GetMatlRequests();
+  GetMatlRequests();
 
  private:
   // clang-format off
@@ -278,7 +275,6 @@ class FuelFab
   // intra-time-step state - no need to be a state var
   // map<request, inventory name>
   std::map<cyclus::Request<cyclus::Material>*, std::string> req_inventories_;
-
 };
 
 double CosiWeight(cyclus::Composition::Ptr c, const std::string& spectrum);

--- a/src/fuel_fab_tests.cc
+++ b/src/fuel_fab_tests.cc
@@ -1,16 +1,15 @@
-#include <gtest/gtest.h>
-
-#include <sstream>
-
-#include "cyclus.h"
 #include "fuel_fab.h"
 
-using cyclus::CompMap;
+#include <gtest/gtest.h>
+#include <sstream>
+#include "cyclus.h"
+
+using pyne::nucname::id;
 using cyclus::Composition;
-using cyclus::Cond;
+using cyclus::CompMap;
 using cyclus::Material;
 using cyclus::QueryResult;
-using pyne::nucname::id;
+using cyclus::Cond;
 
 namespace cycamore {
 namespace fuelfabtests {
@@ -32,8 +31,8 @@ Composition::Ptr c_mox() {
 
 Composition::Ptr c_natu() {
   CompMap m;
-  m[id("u235")] = .007;
-  m[id("u238")] = .993;
+  m[id("u235")] =  .007;
+  m[id("u238")] =  .993;
   return Composition::CreateFromMass(m);
 };
 
@@ -66,8 +65,8 @@ Composition::Ptr c_pustreambad() {
 
 Composition::Ptr c_water() {
   CompMap m;
-  m[id("O16")] = 1;
-  m[id("H1")] = 2;
+  m[id("O16")] =  1;
+  m[id("H1")] =  2;
   return Composition::CreateFromAtom(m);
 };
 
@@ -138,8 +137,7 @@ TEST(FuelFabTests, CosiWeight_Mixed) {
   Material::Ptr m2 = Material::CreateUntracked(fill_frac, c_natu());
   m1->Absorb(m2);
   double got = CosiWeight(m1->comp(), "thermal");
-  EXPECT_LT(std::abs((w_target - got) / w_target), 0.00001)
-      << "mixed composition not within 0.001% of target";
+  EXPECT_LT(std::abs((w_target-got)/w_target), 0.00001) << "mixed composition not within 0.001% of target";
 }
 
 TEST(FuelFabTests, HighFrac) {
@@ -153,7 +151,7 @@ TEST(FuelFabTests, HighFrac) {
   EXPECT_THROW(HighFrac(w_target, w_fiss, w_fill), cyclus::ValueError);
 
   double f = HighFrac(w_fill, w_target, w_fiss);
-  EXPECT_DOUBLE_EQ((w_target - w_fill) / (w_fiss - w_fill), f);
+  EXPECT_DOUBLE_EQ((w_target-w_fill)/(w_fiss-w_fill), f);
 }
 
 TEST(FuelFabTests, LowFrac) {
@@ -167,7 +165,7 @@ TEST(FuelFabTests, LowFrac) {
   EXPECT_THROW(LowFrac(w_target, w_fiss, w_fill), cyclus::ValueError);
 
   double f = LowFrac(w_fill, w_target, w_fiss);
-  EXPECT_DOUBLE_EQ((w_fiss - w_target) / (w_fiss - w_fill), f);
+  EXPECT_DOUBLE_EQ((w_fiss-w_target)/(w_fiss-w_fill), f);
 }
 
 TEST(FuelFabTests, ValidWeights) {
@@ -187,18 +185,18 @@ TEST(FuelFabTests, ValidWeights) {
 // request (and receive) a specific recipe for fissile stream correctly.
 TEST(FuelFabTests, FissRecipe) {
   std::string config =
-      "<fill_commods> <val>dummy</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>1</fill_size>"
-      ""
-      "<fiss_commods> <val>stream1</val> <val>stream2</val> <val>stream3</val> "
-      "</fiss_commods>"
-      "<fiss_size>2.5</fiss_size>"
-      "<fiss_recipe>spentuox</fiss_recipe>"
-      ""
-      "<outcommod>dummyout</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>0</throughput>";
+     "<fill_commods> <val>dummy</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>1</fill_size>"
+     ""
+     "<fiss_commods> <val>stream1</val> <val>stream2</val> <val>stream3</val> </fiss_commods>"
+     "<fiss_size>2.5</fiss_size>"
+     "<fiss_recipe>spentuox</fiss_recipe>"
+     ""
+     "<outcommod>dummyout</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>0</throughput>"
+     ;
 
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
@@ -214,8 +212,7 @@ TEST(FuelFabTests, FissRecipe) {
   cyclus::compmath::Normalize(&want);
   CompMap::iterator it;
   for (it = want.begin(); it != want.end(); ++it) {
-    EXPECT_DOUBLE_EQ(it->second, got[it->first])
-        << "nuclide qty off: " << pyne::nucname::name(it->first);
+    EXPECT_DOUBLE_EQ(it->second, got[it->first]) << "nuclide qty off: " << pyne::nucname::name(it->first);
   }
 }
 
@@ -223,17 +220,17 @@ TEST(FuelFabTests, FissRecipe) {
 // fissile material inventory.
 TEST(FuelFabTests, MultipleFissStreams) {
   std::string config =
-      "<fill_commods> <val>dummy</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>1</fill_size>"
-      ""
-      "<fiss_commods> <val>stream1</val> <val>stream2</val> <val>stream3</val> "
-      "</fiss_commods>"
-      "<fiss_size>2.5</fiss_size>"
-      ""
-      "<outcommod>dummyout</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>0</throughput>";
+     "<fill_commods> <val>dummy</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>1</fill_size>"
+     ""
+     "<fiss_commods> <val>stream1</val> <val>stream2</val> <val>stream3</val> </fiss_commods>"
+     "<fiss_size>2.5</fiss_size>"
+     ""
+     "<outcommod>dummyout</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>0</throughput>"
+     ;
 
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
@@ -264,19 +261,18 @@ TEST(FuelFabTests, MultipleFissStreams) {
 // fissile stream preferences can be specified.
 TEST(FuelFabTests, FissStreamPrefs) {
   std::string config =
-      "<fill_commods> <val>dummy</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>1</fill_size>"
-      ""
-      "<fiss_commods>      <val>stream1</val> <val>stream2</val> "
-      "<val>stream3</val> </fiss_commods>"
-      "<fiss_commod_prefs> <val>1.0</val>     <val>0.1</val>     "
-      "<val>2.0</val> </fiss_commod_prefs>"
-      "<fiss_size>1.5</fiss_size>"
-      ""
-      "<outcommod>dummyout</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>0</throughput>";
+     "<fill_commods> <val>dummy</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>1</fill_size>"
+     ""
+     "<fiss_commods>      <val>stream1</val> <val>stream2</val> <val>stream3</val> </fiss_commods>"
+     "<fiss_commod_prefs> <val>1.0</val>     <val>0.1</val>     <val>2.0</val> </fiss_commod_prefs>"
+     "<fiss_size>1.5</fiss_size>"
+     ""
+     "<outcommod>dummyout</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>0</throughput>"
+     ;
 
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
@@ -306,21 +302,22 @@ TEST(FuelFabTests, FissStreamPrefs) {
 // zero throughput must not result in a zero capacity constraint excception.
 TEST(FuelFabTests, ZeroThroughput) {
   std::string config =
-      "<fill_commods> <val>natu</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>3.9</fill_size>"
-      ""
-      "<fiss_commods> <val>spentuox</val> </fiss_commods>"
-      "<fiss_recipe>spentuox</fiss_recipe>"
-      "<fiss_size>3.5</fiss_size>"
-      ""
-      "<topup_commod>uox</topup_commod>"
-      "<topup_recipe>uox</topup_recipe>"
-      "<topup_size>3.3</topup_size>"
-      ""
-      "<outcommod>dummyout</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>0</throughput>";
+     "<fill_commods> <val>natu</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>3.9</fill_size>"
+     ""
+     "<fiss_commods> <val>spentuox</val> </fiss_commods>"
+     "<fiss_recipe>spentuox</fiss_recipe>"
+     "<fiss_size>3.5</fiss_size>"
+     ""
+     "<topup_commod>uox</topup_commod>"
+     "<topup_recipe>uox</topup_recipe>"
+     "<topup_size>3.3</topup_size>"
+     ""
+     "<outcommod>dummyout</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>0</throughput>"
+     ;
 
   int simdur = 10;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
@@ -338,21 +335,22 @@ TEST(FuelFabTests, ZeroThroughput) {
 // enforced after they are full.
 TEST(FuelFabTests, FillAllInventories) {
   std::string config =
-      "<fill_commods> <val>natu</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>3.9</fill_size>"
-      ""
-      "<fiss_commods> <val>spentuox</val> </fiss_commods>"
-      "<fiss_recipe>spentuox</fiss_recipe>"
-      "<fiss_size>3.5</fiss_size>"
-      ""
-      "<topup_commod>uox</topup_commod>"
-      "<topup_recipe>uox</topup_recipe>"
-      "<topup_size>3.3</topup_size>"
-      ""
-      "<outcommod>dummyout</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>1</throughput>";
+     "<fill_commods> <val>natu</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>3.9</fill_size>"
+     ""
+     "<fiss_commods> <val>spentuox</val> </fiss_commods>"
+     "<fiss_recipe>spentuox</fiss_recipe>"
+     "<fiss_size>3.5</fiss_size>"
+     ""
+     "<topup_commod>uox</topup_commod>"
+     "<topup_recipe>uox</topup_recipe>"
+     "<topup_size>3.3</topup_size>"
+     ""
+     "<outcommod>dummyout</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>1</throughput>"
+     ;
 
   int simdur = 10;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
@@ -367,7 +365,8 @@ TEST(FuelFabTests, FillAllInventories) {
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
       "SELECT SUM(r.Quantity) FROM Transactions AS t"
       " INNER JOIN Resources AS r ON r.ResourceId = t.ResourceId"
-      " WHERE t.Commodity = ?;");
+      " WHERE t.Commodity = ?;"
+      );
 
   stmt->BindText(1, "natu");
   stmt->Step();
@@ -386,17 +385,18 @@ TEST(FuelFabTests, FillAllInventories) {
 // inventory quantity.
 TEST(FuelFabTests, ProvideStraightFiss_WithZeroFill) {
   std::string config =
-      "<fill_commods> <val>nothing</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>100</fill_size>"
-      ""
-      "<fiss_commods> <val>anything</val> </fiss_commods>"
-      "<fiss_recipe>spentuox</fiss_recipe>"
-      "<fiss_size>100</fiss_size>"
-      ""
-      "<outcommod>recyclefuel</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>100</throughput>";
+     "<fill_commods> <val>nothing</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>100</fill_size>"
+     ""
+     "<fiss_commods> <val>anything</val> </fiss_commods>"
+     "<fiss_recipe>spentuox</fiss_recipe>"
+     "<fiss_size>100</fiss_size>"
+     ""
+     "<outcommod>recyclefuel</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>100</throughput>"
+     ;
   int simdur = 6;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
   sim.AddSource("anything").Finalize();
@@ -415,17 +415,18 @@ TEST(FuelFabTests, ProvideStraightFiss_WithZeroFill) {
 
 TEST(FuelFabTests, ProvideStraightFill_ZeroFiss) {
   std::string config =
-      "<fill_commods> <val>anything</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>100</fill_size>"
-      ""
-      "<fiss_commods> <val>nothing</val> </fiss_commods>"
-      "<fiss_recipe>spentuox</fiss_recipe>"
-      "<fiss_size>100</fiss_size>"
-      ""
-      "<outcommod>recyclefuel</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>100</throughput>";
+     "<fill_commods> <val>anything</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>100</fill_size>"
+     ""
+     "<fiss_commods> <val>nothing</val> </fiss_commods>"
+     "<fiss_recipe>spentuox</fiss_recipe>"
+     "<fiss_size>100</fiss_size>"
+     ""
+     "<outcommod>recyclefuel</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>100</throughput>"
+     ;
   int simdur = 6;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
   sim.AddSource("anything").Finalize();
@@ -446,23 +447,24 @@ TEST(FuelFabTests, ProvideStraightFill_ZeroFiss) {
 // requests and with ample material inventory.
 TEST(FuelFabTests, ThroughputLimit) {
   std::string config =
-      "<fill_commods> <val>anything</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>100</fill_size>"
-      ""
-      "<fiss_commods> <val>anything</val> </fiss_commods>"
-      "<fiss_recipe>pustream</fiss_recipe>"
-      "<fiss_size>100</fiss_size>"
-      ""
-      "<outcommod>recyclefuel</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>3</throughput>";
+     "<fill_commods> <val>anything</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>100</fill_size>"
+     ""
+     "<fiss_commods> <val>anything</val> </fiss_commods>"
+     "<fiss_recipe>pustream</fiss_recipe>"
+     "<fiss_size>100</fiss_size>"
+     ""
+     "<outcommod>recyclefuel</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>3</throughput>"
+     ;
   double throughput = 3;
 
   int simdur = 5;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
   sim.AddSource("anything").lifetime(1).Finalize();
-  sim.AddSink("recyclefuel").recipe("uox").capacity(2 * throughput).Finalize();
+  sim.AddSink("recyclefuel").recipe("uox").capacity(2*throughput).Finalize();
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("pustream", c_pustream());
   sim.AddRecipe("natu", c_natu());
@@ -474,32 +476,35 @@ TEST(FuelFabTests, ThroughputLimit) {
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
       "SELECT SUM(r.Quantity) FROM Transactions AS t"
       " INNER JOIN Resources AS r ON r.ResourceId = t.ResourceId"
-      " WHERE t.Commodity = 'recyclefuel';");
+      " WHERE t.Commodity = 'recyclefuel';"
+      );
 
   stmt->Step();
-  EXPECT_DOUBLE_EQ(throughput * (simdur - 1), stmt->GetDouble(0));
+  EXPECT_DOUBLE_EQ(throughput * (simdur-1), stmt->GetDouble(0));
 
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM Transactions WHERE Commodity = 'recyclefuel';");
+      "SELECT COUNT(*) FROM Transactions WHERE Commodity = 'recyclefuel';"
+      );
 
   stmt->Step();
-  EXPECT_DOUBLE_EQ(simdur - 1, stmt->GetDouble(0));
+  EXPECT_DOUBLE_EQ(simdur-1, stmt->GetDouble(0));
 }
 
 // supplied fuel has proper equivalence weights as requested.
 TEST(FuelFabTests, CorrectMixing) {
   std::string config =
-      "<fill_commods> <val>natu</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>100</fill_size>"
-      ""
-      "<fiss_commods> <val>pustream</val> </fiss_commods>"
-      "<fiss_recipe>pustream</fiss_recipe>"
-      "<fiss_size>100</fiss_size>"
-      ""
-      "<outcommod>recyclefuel</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>100</throughput>";
+     "<fill_commods> <val>natu</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>100</fill_size>"
+     ""
+     "<fiss_commods> <val>pustream</val> </fiss_commods>"
+     "<fiss_recipe>pustream</fiss_recipe>"
+     "<fiss_size>100</fiss_size>"
+     ""
+     "<outcommod>recyclefuel</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>100</throughput>"
+     ;
   int simdur = 3;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
   sim.AddSource("pustream").Finalize();
@@ -518,24 +523,20 @@ TEST(FuelFabTests, CorrectMixing) {
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
   double got = CosiWeight(m->comp(), "thermal");
   double w_target = CosiWeight(c_uox(), "thermal");
-  EXPECT_LT(std::abs((w_target - got) / w_target), 0.00001)
-      << "mixed composition not within 0.001% of target";
+  EXPECT_LT(std::abs((w_target-got)/w_target), 0.00001) << "mixed composition not within 0.001% of target";
 
   conds.push_back(Cond("Time", "==", 2));
 
-  // TODO: do hand calcs to verify expected vals below - they are just
-  // regression values currently.
+  // TODO: do hand calcs to verify expected vals below - they are just regression values currently.
   conds[0] = Cond("Commodity", "==", std::string("natu"));
   qr = sim.db().Query("Transactions", &conds);
   m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
-  EXPECT_NEAR(9.7463873197, m->quantity(), cyclus::CY_NEAR_ZERO)
-      << "mixed wrong amount of Nat. U stream";
+  EXPECT_NEAR(9.7463873197, m->quantity(), cyclus::CY_NEAR_ZERO) << "mixed wrong amount of Nat. U stream";
 
   conds[0] = Cond("Commodity", "==", std::string("pustream"));
   qr = sim.db().Query("Transactions", &conds);
   m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
-  EXPECT_NEAR(0.25361268029, m->quantity(), cyclus::CY_NEAR_ZERO)
-      << "mixed wrong amount of Pu stream";
+  EXPECT_NEAR(0.25361268029, m->quantity(), cyclus::CY_NEAR_ZERO) << "mixed wrong amount of Pu stream";
 }
 
 // fuel is requested requiring more filler than is available with plenty of
@@ -543,17 +544,18 @@ TEST(FuelFabTests, CorrectMixing) {
 TEST(FuelFabTests, FillConstrained) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-      "<fill_commods> <val>natu</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>1</fill_size>"
-      ""
-      "<fiss_commods> <val>pustream</val> </fiss_commods>"
-      "<fiss_recipe>pustream</fiss_recipe>"
-      "<fiss_size>10000</fiss_size>"
-      ""
-      "<outcommod>recyclefuel</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>10000</throughput>";
+     "<fill_commods> <val>natu</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>1</fill_size>"
+     ""
+     "<fiss_commods> <val>pustream</val> </fiss_commods>"
+     "<fiss_recipe>pustream</fiss_recipe>"
+     "<fiss_size>10000</fiss_size>"
+     ""
+     "<outcommod>recyclefuel</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>10000</throughput>"
+     ;
   double fillinv = 1;
   int simdur = 2;
 
@@ -580,8 +582,7 @@ TEST(FuelFabTests, FillConstrained) {
   QueryResult qr = sim.db().Query("Transactions", &conds);
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
-  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO)
-      << "matched trade uses more fill than available";
+  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO) << "matched trade uses more fill than available";
 }
 
 // fuel is requested requiring more fissile material than is available with
@@ -589,17 +590,18 @@ TEST(FuelFabTests, FillConstrained) {
 TEST(FuelFabTests, FissConstrained) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-      "<fill_commods> <val>natu</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>10000</fill_size>"
-      ""
-      "<fiss_commods> <val>pustream</val> </fiss_commods>"
-      "<fiss_recipe>pustream</fiss_recipe>"
-      "<fiss_size>1</fiss_size>"
-      ""
-      "<outcommod>recyclefuel</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>10000</throughput>";
+     "<fill_commods> <val>natu</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>10000</fill_size>"
+     ""
+     "<fiss_commods> <val>pustream</val> </fiss_commods>"
+     "<fiss_recipe>pustream</fiss_recipe>"
+     "<fiss_size>1</fiss_size>"
+     ""
+     "<outcommod>recyclefuel</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>10000</throughput>"
+     ;
   double fissinv = 1;
   int simdur = 2;
 
@@ -626,28 +628,28 @@ TEST(FuelFabTests, FissConstrained) {
   QueryResult qr = sim.db().Query("Transactions", &conds);
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
-  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO)
-      << "matched trade uses more fill than available";
+  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO) << "matched trade uses more fill than available";
 }
 
 // swap to topup inventory because fissile has too low reactivity.
 TEST(FuelFabTests, SwapTopup) {
   std::string config =
-      "<fill_commods> <val>natu</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>10000</fill_size>"
-      ""
-      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-      "<fiss_recipe>pustreambad</fiss_recipe>"
-      "<fiss_size>10000</fiss_size>"
-      ""
-      "<topup_commod>pustream</topup_commod>"
-      "<topup_recipe>pustream</topup_recipe>"
-      "<topup_size>10000</topup_size>"
-      ""
-      "<outcommod>recyclefuel</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>10000</throughput>";
+     "<fill_commods> <val>natu</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>10000</fill_size>"
+     ""
+     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+     "<fiss_recipe>pustreambad</fiss_recipe>"
+     "<fiss_size>10000</fiss_size>"
+     ""
+     "<topup_commod>pustream</topup_commod>"
+     "<topup_recipe>pustream</topup_recipe>"
+     "<topup_size>10000</topup_size>"
+     ""
+     "<outcommod>recyclefuel</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>10000</throughput>"
+     ;
   int simdur = 3;
   double sink_cap = 10;
 
@@ -655,11 +657,7 @@ TEST(FuelFabTests, SwapTopup) {
   sim.AddSource("pustream").Finalize();
   sim.AddSource("pustreambad").Finalize();
   sim.AddSource("natu").Finalize();
-  sim.AddSink("recyclefuel")
-      .recipe("uox")
-      .capacity(sink_cap)
-      .lifetime(2)
-      .Finalize();
+  sim.AddSink("recyclefuel").recipe("uox").capacity(sink_cap).lifetime(2).Finalize();
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("pustream", c_pustream());
   sim.AddRecipe("pustreambad", c_pustreambad());
@@ -671,39 +669,37 @@ TEST(FuelFabTests, SwapTopup) {
   QueryResult qr = sim.db().Query("Transactions", &conds);
   ASSERT_EQ(1, qr.rows.size()) << "failed to meet fuel request";
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
-  EXPECT_NEAR(sink_cap, m->quantity(), cyclus::CY_NEAR_ZERO)
-      << "supplied fuel was constrained too much";
+  EXPECT_NEAR(sink_cap, m->quantity(), cyclus::CY_NEAR_ZERO) << "supplied fuel was constrained too much";
 
   conds[0] = Cond("Commodity", "==", std::string("natu"));
   conds.push_back(Cond("Time", "==", 2));
   qr = sim.db().Query("Transactions", &conds);
-  ASSERT_EQ(0, qr.rows.size())
-      << "failed to swith to topup - used fill - uh oh";
+  ASSERT_EQ(0, qr.rows.size()) << "failed to swith to topup - used fill - uh oh";
 
   conds[0] = Cond("Commodity", "==", std::string("pustream"));
   conds.push_back(Cond("Time", "==", 2));
   qr = sim.db().Query("Transactions", &conds);
-  ASSERT_EQ(1, qr.rows.size())
-      << "didn't get more topup after supposedly using it - why?";
+  ASSERT_EQ(1, qr.rows.size()) << "didn't get more topup after supposedly using it - why?";
 }
 
 TEST(FuelFabTests, SwapTopup_ZeroFill) {
   std::string config =
-      "<fill_commods> <val>natu</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>0</fill_size>"
-      ""
-      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-      "<fiss_recipe>pustreambad</fiss_recipe>"
-      "<fiss_size>10000</fiss_size>"
-      ""
-      "<topup_commod>pustream</topup_commod>"
-      "<topup_recipe>pustream</topup_recipe>"
-      "<topup_size>10000</topup_size>"
-      ""
-      "<outcommod>recyclefuel</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>10000</throughput>";
+     "<fill_commods> <val>natu</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>0</fill_size>"
+     ""
+     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+     "<fiss_recipe>pustreambad</fiss_recipe>"
+     "<fiss_size>10000</fiss_size>"
+     ""
+     "<topup_commod>pustream</topup_commod>"
+     "<topup_recipe>pustream</topup_recipe>"
+     "<topup_size>10000</topup_size>"
+     ""
+     "<outcommod>recyclefuel</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>10000</throughput>"
+     ;
   int simdur = 3;
   double sink_cap = 10;
 
@@ -711,11 +707,7 @@ TEST(FuelFabTests, SwapTopup_ZeroFill) {
   sim.AddSource("pustream").Finalize();
   sim.AddSource("pustreambad").Finalize();
   sim.AddSource("natu").Finalize();
-  sim.AddSink("recyclefuel")
-      .recipe("uox")
-      .capacity(sink_cap)
-      .lifetime(2)
-      .Finalize();
+  sim.AddSink("recyclefuel").recipe("uox").capacity(sink_cap).lifetime(2).Finalize();
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("pustream", c_pustream());
   sim.AddRecipe("pustreambad", c_pustreambad());
@@ -727,8 +719,7 @@ TEST(FuelFabTests, SwapTopup_ZeroFill) {
   QueryResult qr = sim.db().Query("Transactions", &conds);
   ASSERT_EQ(1, qr.rows.size()) << "failed to meet fuel request";
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
-  EXPECT_NEAR(sink_cap, m->quantity(), cyclus::CY_NEAR_ZERO)
-      << "supplied fuel was constrained too much";
+  EXPECT_NEAR(sink_cap, m->quantity(), cyclus::CY_NEAR_ZERO) << "supplied fuel was constrained too much";
 
   conds[0] = Cond("Commodity", "==", std::string("pustream"));
   conds.push_back(Cond("Time", "==", 2));
@@ -749,21 +740,22 @@ TEST(FuelFabTests, SwapTopup_ZeroFill) {
 TEST(FuelFabTests, SwapTopup_TopupConstrained) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-      "<fill_commods> <val>natu</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>10000</fill_size>"
-      ""
-      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-      "<fiss_recipe>pustreambad</fiss_recipe>"
-      "<fiss_size>10000</fiss_size>"
-      ""
-      "<topup_commod>pustream</topup_commod>"
-      "<topup_recipe>pustream</topup_recipe>"
-      "<topup_size>1</topup_size>"
-      ""
-      "<outcommod>recyclefuel</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>10000</throughput>";
+     "<fill_commods> <val>natu</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>10000</fill_size>"
+     ""
+     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+     "<fiss_recipe>pustreambad</fiss_recipe>"
+     "<fiss_size>10000</fiss_size>"
+     ""
+     "<topup_commod>pustream</topup_commod>"
+     "<topup_recipe>pustream</topup_recipe>"
+     "<topup_size>1</topup_size>"
+     ""
+     "<outcommod>recyclefuel</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>10000</throughput>"
+     ;
   double topupinv = 1;
   int simdur = 2;
 
@@ -794,8 +786,7 @@ TEST(FuelFabTests, SwapTopup_TopupConstrained) {
   ASSERT_EQ(1, qr.rows.size()) << "failed to meet fuel request";
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
-  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO)
-      << "matched trade uses more fiss than available";
+  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO) << "matched trade uses more fiss than available";
 }
 
 // swap to topup inventory but are limited by fiss inventory quantity.  This
@@ -804,21 +795,22 @@ TEST(FuelFabTests, SwapTopup_TopupConstrained) {
 TEST(FuelFabTests, SwapTopup_FissConstrained) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-      "<fill_commods> <val>natu</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>0</fill_size>"
-      ""
-      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-      "<fiss_recipe>pustreambad</fiss_recipe>"
-      "<fiss_size>1</fiss_size>"
-      ""
-      "<topup_commod>pustream</topup_commod>"
-      "<topup_recipe>pustream</topup_recipe>"
-      "<topup_size>10000</topup_size>"
-      ""
-      "<outcommod>recyclefuel</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>10000</throughput>";
+     "<fill_commods> <val>natu</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>0</fill_size>"
+     ""
+     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+     "<fiss_recipe>pustreambad</fiss_recipe>"
+     "<fiss_size>1</fiss_size>"
+     ""
+     "<topup_commod>pustream</topup_commod>"
+     "<topup_recipe>pustream</topup_recipe>"
+     "<topup_size>10000</topup_size>"
+     ""
+     "<outcommod>recyclefuel</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>10000</throughput>"
+     ;
   double fissinv = 1;
   int simdur = 2;
 
@@ -849,31 +841,31 @@ TEST(FuelFabTests, SwapTopup_FissConstrained) {
   ASSERT_EQ(1, qr.rows.size()) << "failed to meet fuel request";
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
-  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO)
-      << "matched trade uses more fiss than available";
+  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO) << "matched trade uses more fiss than available";
 }
 
-// Before this test and a fix, the fuel fab (partially) assumed each entire
-// material buffer had the same composition as the material on top of the buffer
-// when calculating stream mixing ratios for material to supply.  This problem
-// was compounded by the fact that material weights are computed on an atom
-// basis and mixing is done on a mass basis - corresponding conversions resulted
-// in the fab being matched for more than it could actually supply - due to
+// Before this test and a fix, the fuel fab (partially) assumed each entire material
+// buffer had the same composition as the material on top of the buffer when
+// calculating stream mixing ratios for material to supply.  This problem was
+// compounded by the fact that material weights are computed on an atom basis
+// and mixing is done on a mass basis - corresponding conversions resulted in
+// the fab being matched for more than it could actually supply - due to
 // thinking it had an inventory of higher quality material than was actually
 // the case.  This test makes sure that doesn't happen again.
 TEST(FuelFabTests, HomogenousBuffers) {
   std::string config =
-      "<fill_commods> <val>natu</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>40</fill_size>"
-      ""
-      "<fiss_commods> <val>stream1</val> </fiss_commods>"
-      "<fiss_size>4</fiss_size>"
-      "<fiss_recipe>spentuox</fiss_recipe>"
-      ""
-      "<outcommod>out</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>1e10</throughput>";
+     "<fill_commods> <val>natu</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>40</fill_size>"
+     ""
+     "<fiss_commods> <val>stream1</val> </fiss_commods>"
+     "<fiss_size>4</fiss_size>"
+     "<fiss_recipe>spentuox</fiss_recipe>"
+     ""
+     "<outcommod>out</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>1e10</throughput>"
+     ;
 
   CompMap m;
   m[id("u235")] = 7;
@@ -885,18 +877,8 @@ TEST(FuelFabTests, HomogenousBuffers) {
 
   int simdur = 5;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
-  sim.AddSource("stream1")
-      .start(0)
-      .lifetime(1)
-      .capacity(.01)
-      .recipe("special")
-      .Finalize();
-  sim.AddSource("stream1")
-      .start(1)
-      .lifetime(1)
-      .capacity(3.98)
-      .recipe("natu")
-      .Finalize();
+  sim.AddSource("stream1").start(0).lifetime(1).capacity(.01).recipe("special").Finalize();
+  sim.AddSource("stream1").start(1).lifetime(1).capacity(3.98).recipe("natu").Finalize();
   sim.AddSource("natu").lifetime(1).Finalize();
   sim.AddSink("out").start(2).capacity(4).lifetime(1).recipe("uox").Finalize();
   sim.AddSink("out").start(2).capacity(4).lifetime(1).recipe("uox").Finalize();
@@ -911,21 +893,21 @@ TEST(FuelFabTests, HomogenousBuffers) {
 TEST(FuelFabTests, PositionInitialize) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-      "<fill_commods> <val>natu</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>0</fill_size>"
-      ""
-      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-      "<fiss_recipe>pustreambad</fiss_recipe>"
-      "<fiss_size>1</fiss_size>"
-      ""
-      "<topup_commod>pustream</topup_commod>"
-      "<topup_recipe>pustream</topup_recipe>"
-      "<topup_size>10000</topup_size>"
-      ""
-      "<outcommod>recyclefuel</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>10000</throughput>";
+     "<fill_commods> <val>natu</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>0</fill_size>"
+     ""
+     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+     "<fiss_recipe>pustreambad</fiss_recipe>"
+     "<fiss_size>1</fiss_size>"
+     ""
+     "<topup_commod>pustream</topup_commod>"
+     "<topup_recipe>pustream</topup_recipe>"
+     "<topup_size>10000</topup_size>"
+     ""
+     "<outcommod>recyclefuel</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>10000</throughput>";
   double fillinv = 1;
   int simdur = 2;
 
@@ -957,23 +939,24 @@ TEST(FuelFabTests, PositionInitialize) {
 TEST(FuelFabTests, PositionInitialize2) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-      "<fill_commods> <val>natu</val> </fill_commods>"
-      "<fill_recipe>natu</fill_recipe>"
-      "<fill_size>0</fill_size>"
-      ""
-      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-      "<fiss_recipe>pustreambad</fiss_recipe>"
-      "<fiss_size>1</fiss_size>"
-      ""
-      "<topup_commod>pustream</topup_commod>"
-      "<topup_recipe>pustream</topup_recipe>"
-      "<topup_size>10000</topup_size>"
-      ""
-      "<outcommod>recyclefuel</outcommod>"
-      "<spectrum>thermal</spectrum>"
-      "<throughput>10000</throughput>"
-      "<latitude>-90.0</latitude> "
-      "<longitude>-120.0</longitude> ";
+     "<fill_commods> <val>natu</val> </fill_commods>"
+     "<fill_recipe>natu</fill_recipe>"
+     "<fill_size>0</fill_size>"
+     ""
+     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+     "<fiss_recipe>pustreambad</fiss_recipe>"
+     "<fiss_size>1</fiss_size>"
+     ""
+     "<topup_commod>pustream</topup_commod>"
+     "<topup_recipe>pustream</topup_recipe>"
+     "<topup_size>10000</topup_size>"
+     ""
+     "<outcommod>recyclefuel</outcommod>"
+     "<spectrum>thermal</spectrum>"
+     "<throughput>10000</throughput>"
+     "<latitude>-90.0</latitude> "
+     "<longitude>-120.0</longitude> "
+     ;
   double fillinv = 1;
   int simdur = 2;
 
@@ -1002,5 +985,5 @@ TEST(FuelFabTests, PositionInitialize2) {
   EXPECT_EQ(qr.GetVal<double>("Longitude"), -120.0);
 }
 
-}  // namespace fuelfabtests
-}  // namespace cycamore
+} // namespace fuelfabtests
+} // namespace cycamore

--- a/src/fuel_fab_tests.cc
+++ b/src/fuel_fab_tests.cc
@@ -1,15 +1,16 @@
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+#include "cyclus.h"
 #include "fuel_fab.h"
 
-#include <gtest/gtest.h>
-#include <sstream>
-#include "cyclus.h"
-
-using pyne::nucname::id;
-using cyclus::Composition;
 using cyclus::CompMap;
+using cyclus::Composition;
+using cyclus::Cond;
 using cyclus::Material;
 using cyclus::QueryResult;
-using cyclus::Cond;
+using pyne::nucname::id;
 
 namespace cycamore {
 namespace fuelfabtests {
@@ -31,8 +32,8 @@ Composition::Ptr c_mox() {
 
 Composition::Ptr c_natu() {
   CompMap m;
-  m[id("u235")] =  .007;
-  m[id("u238")] =  .993;
+  m[id("u235")] = .007;
+  m[id("u238")] = .993;
   return Composition::CreateFromMass(m);
 };
 
@@ -65,8 +66,8 @@ Composition::Ptr c_pustreambad() {
 
 Composition::Ptr c_water() {
   CompMap m;
-  m[id("O16")] =  1;
-  m[id("H1")] =  2;
+  m[id("O16")] = 1;
+  m[id("H1")] = 2;
   return Composition::CreateFromAtom(m);
 };
 
@@ -137,7 +138,8 @@ TEST(FuelFabTests, CosiWeight_Mixed) {
   Material::Ptr m2 = Material::CreateUntracked(fill_frac, c_natu());
   m1->Absorb(m2);
   double got = CosiWeight(m1->comp(), "thermal");
-  EXPECT_LT(std::abs((w_target-got)/w_target), 0.00001) << "mixed composition not within 0.001% of target";
+  EXPECT_LT(std::abs((w_target - got) / w_target), 0.00001)
+      << "mixed composition not within 0.001% of target";
 }
 
 TEST(FuelFabTests, HighFrac) {
@@ -151,7 +153,7 @@ TEST(FuelFabTests, HighFrac) {
   EXPECT_THROW(HighFrac(w_target, w_fiss, w_fill), cyclus::ValueError);
 
   double f = HighFrac(w_fill, w_target, w_fiss);
-  EXPECT_DOUBLE_EQ((w_target-w_fill)/(w_fiss-w_fill), f);
+  EXPECT_DOUBLE_EQ((w_target - w_fill) / (w_fiss - w_fill), f);
 }
 
 TEST(FuelFabTests, LowFrac) {
@@ -165,7 +167,7 @@ TEST(FuelFabTests, LowFrac) {
   EXPECT_THROW(LowFrac(w_target, w_fiss, w_fill), cyclus::ValueError);
 
   double f = LowFrac(w_fill, w_target, w_fiss);
-  EXPECT_DOUBLE_EQ((w_fiss-w_target)/(w_fiss-w_fill), f);
+  EXPECT_DOUBLE_EQ((w_fiss - w_target) / (w_fiss - w_fill), f);
 }
 
 TEST(FuelFabTests, ValidWeights) {
@@ -185,18 +187,18 @@ TEST(FuelFabTests, ValidWeights) {
 // request (and receive) a specific recipe for fissile stream correctly.
 TEST(FuelFabTests, FissRecipe) {
   std::string config =
-     "<fill_commods> <val>dummy</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>1</fill_size>"
-     ""
-     "<fiss_commods> <val>stream1</val> <val>stream2</val> <val>stream3</val> </fiss_commods>"
-     "<fiss_size>2.5</fiss_size>"
-     "<fiss_recipe>spentuox</fiss_recipe>"
-     ""
-     "<outcommod>dummyout</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>0</throughput>"
-     ;
+      "<fill_commods> <val>dummy</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>1</fill_size>"
+      ""
+      "<fiss_commods> <val>stream1</val> <val>stream2</val> <val>stream3</val> "
+      "</fiss_commods>"
+      "<fiss_size>2.5</fiss_size>"
+      "<fiss_recipe>spentuox</fiss_recipe>"
+      ""
+      "<outcommod>dummyout</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>0</throughput>";
 
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
@@ -212,7 +214,8 @@ TEST(FuelFabTests, FissRecipe) {
   cyclus::compmath::Normalize(&want);
   CompMap::iterator it;
   for (it = want.begin(); it != want.end(); ++it) {
-    EXPECT_DOUBLE_EQ(it->second, got[it->first]) << "nuclide qty off: " << pyne::nucname::name(it->first);
+    EXPECT_DOUBLE_EQ(it->second, got[it->first])
+        << "nuclide qty off: " << pyne::nucname::name(it->first);
   }
 }
 
@@ -220,17 +223,17 @@ TEST(FuelFabTests, FissRecipe) {
 // fissile material inventory.
 TEST(FuelFabTests, MultipleFissStreams) {
   std::string config =
-     "<fill_commods> <val>dummy</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>1</fill_size>"
-     ""
-     "<fiss_commods> <val>stream1</val> <val>stream2</val> <val>stream3</val> </fiss_commods>"
-     "<fiss_size>2.5</fiss_size>"
-     ""
-     "<outcommod>dummyout</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>0</throughput>"
-     ;
+      "<fill_commods> <val>dummy</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>1</fill_size>"
+      ""
+      "<fiss_commods> <val>stream1</val> <val>stream2</val> <val>stream3</val> "
+      "</fiss_commods>"
+      "<fiss_size>2.5</fiss_size>"
+      ""
+      "<outcommod>dummyout</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>0</throughput>";
 
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
@@ -261,18 +264,19 @@ TEST(FuelFabTests, MultipleFissStreams) {
 // fissile stream preferences can be specified.
 TEST(FuelFabTests, FissStreamPrefs) {
   std::string config =
-     "<fill_commods> <val>dummy</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>1</fill_size>"
-     ""
-     "<fiss_commods>      <val>stream1</val> <val>stream2</val> <val>stream3</val> </fiss_commods>"
-     "<fiss_commod_prefs> <val>1.0</val>     <val>0.1</val>     <val>2.0</val> </fiss_commod_prefs>"
-     "<fiss_size>1.5</fiss_size>"
-     ""
-     "<outcommod>dummyout</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>0</throughput>"
-     ;
+      "<fill_commods> <val>dummy</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>1</fill_size>"
+      ""
+      "<fiss_commods>      <val>stream1</val> <val>stream2</val> "
+      "<val>stream3</val> </fiss_commods>"
+      "<fiss_commod_prefs> <val>1.0</val>     <val>0.1</val>     "
+      "<val>2.0</val> </fiss_commod_prefs>"
+      "<fiss_size>1.5</fiss_size>"
+      ""
+      "<outcommod>dummyout</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>0</throughput>";
 
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
@@ -302,22 +306,21 @@ TEST(FuelFabTests, FissStreamPrefs) {
 // zero throughput must not result in a zero capacity constraint excception.
 TEST(FuelFabTests, ZeroThroughput) {
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>3.9</fill_size>"
-     ""
-     "<fiss_commods> <val>spentuox</val> </fiss_commods>"
-     "<fiss_recipe>spentuox</fiss_recipe>"
-     "<fiss_size>3.5</fiss_size>"
-     ""
-     "<topup_commod>uox</topup_commod>"
-     "<topup_recipe>uox</topup_recipe>"
-     "<topup_size>3.3</topup_size>"
-     ""
-     "<outcommod>dummyout</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>0</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>3.9</fill_size>"
+      ""
+      "<fiss_commods> <val>spentuox</val> </fiss_commods>"
+      "<fiss_recipe>spentuox</fiss_recipe>"
+      "<fiss_size>3.5</fiss_size>"
+      ""
+      "<topup_commod>uox</topup_commod>"
+      "<topup_recipe>uox</topup_recipe>"
+      "<topup_size>3.3</topup_size>"
+      ""
+      "<outcommod>dummyout</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>0</throughput>";
 
   int simdur = 10;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
@@ -335,22 +338,21 @@ TEST(FuelFabTests, ZeroThroughput) {
 // enforced after they are full.
 TEST(FuelFabTests, FillAllInventories) {
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>3.9</fill_size>"
-     ""
-     "<fiss_commods> <val>spentuox</val> </fiss_commods>"
-     "<fiss_recipe>spentuox</fiss_recipe>"
-     "<fiss_size>3.5</fiss_size>"
-     ""
-     "<topup_commod>uox</topup_commod>"
-     "<topup_recipe>uox</topup_recipe>"
-     "<topup_size>3.3</topup_size>"
-     ""
-     "<outcommod>dummyout</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>1</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>3.9</fill_size>"
+      ""
+      "<fiss_commods> <val>spentuox</val> </fiss_commods>"
+      "<fiss_recipe>spentuox</fiss_recipe>"
+      "<fiss_size>3.5</fiss_size>"
+      ""
+      "<topup_commod>uox</topup_commod>"
+      "<topup_recipe>uox</topup_recipe>"
+      "<topup_size>3.3</topup_size>"
+      ""
+      "<outcommod>dummyout</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>1</throughput>";
 
   int simdur = 10;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
@@ -365,8 +367,7 @@ TEST(FuelFabTests, FillAllInventories) {
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
       "SELECT SUM(r.Quantity) FROM Transactions AS t"
       " INNER JOIN Resources AS r ON r.ResourceId = t.ResourceId"
-      " WHERE t.Commodity = ?;"
-      );
+      " WHERE t.Commodity = ?;");
 
   stmt->BindText(1, "natu");
   stmt->Step();
@@ -385,18 +386,17 @@ TEST(FuelFabTests, FillAllInventories) {
 // inventory quantity.
 TEST(FuelFabTests, ProvideStraightFiss_WithZeroFill) {
   std::string config =
-     "<fill_commods> <val>nothing</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>100</fill_size>"
-     ""
-     "<fiss_commods> <val>anything</val> </fiss_commods>"
-     "<fiss_recipe>spentuox</fiss_recipe>"
-     "<fiss_size>100</fiss_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>100</throughput>"
-     ;
+      "<fill_commods> <val>nothing</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>100</fill_size>"
+      ""
+      "<fiss_commods> <val>anything</val> </fiss_commods>"
+      "<fiss_recipe>spentuox</fiss_recipe>"
+      "<fiss_size>100</fiss_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>100</throughput>";
   int simdur = 6;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
   sim.AddSource("anything").Finalize();
@@ -415,18 +415,17 @@ TEST(FuelFabTests, ProvideStraightFiss_WithZeroFill) {
 
 TEST(FuelFabTests, ProvideStraightFill_ZeroFiss) {
   std::string config =
-     "<fill_commods> <val>anything</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>100</fill_size>"
-     ""
-     "<fiss_commods> <val>nothing</val> </fiss_commods>"
-     "<fiss_recipe>spentuox</fiss_recipe>"
-     "<fiss_size>100</fiss_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>100</throughput>"
-     ;
+      "<fill_commods> <val>anything</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>100</fill_size>"
+      ""
+      "<fiss_commods> <val>nothing</val> </fiss_commods>"
+      "<fiss_recipe>spentuox</fiss_recipe>"
+      "<fiss_size>100</fiss_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>100</throughput>";
   int simdur = 6;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
   sim.AddSource("anything").Finalize();
@@ -447,24 +446,23 @@ TEST(FuelFabTests, ProvideStraightFill_ZeroFiss) {
 // requests and with ample material inventory.
 TEST(FuelFabTests, ThroughputLimit) {
   std::string config =
-     "<fill_commods> <val>anything</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>100</fill_size>"
-     ""
-     "<fiss_commods> <val>anything</val> </fiss_commods>"
-     "<fiss_recipe>pustream</fiss_recipe>"
-     "<fiss_size>100</fiss_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>3</throughput>"
-     ;
+      "<fill_commods> <val>anything</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>100</fill_size>"
+      ""
+      "<fiss_commods> <val>anything</val> </fiss_commods>"
+      "<fiss_recipe>pustream</fiss_recipe>"
+      "<fiss_size>100</fiss_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>3</throughput>";
   double throughput = 3;
 
   int simdur = 5;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
   sim.AddSource("anything").lifetime(1).Finalize();
-  sim.AddSink("recyclefuel").recipe("uox").capacity(2*throughput).Finalize();
+  sim.AddSink("recyclefuel").recipe("uox").capacity(2 * throughput).Finalize();
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("pustream", c_pustream());
   sim.AddRecipe("natu", c_natu());
@@ -476,35 +474,32 @@ TEST(FuelFabTests, ThroughputLimit) {
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
       "SELECT SUM(r.Quantity) FROM Transactions AS t"
       " INNER JOIN Resources AS r ON r.ResourceId = t.ResourceId"
-      " WHERE t.Commodity = 'recyclefuel';"
-      );
+      " WHERE t.Commodity = 'recyclefuel';");
 
   stmt->Step();
-  EXPECT_DOUBLE_EQ(throughput * (simdur-1), stmt->GetDouble(0));
+  EXPECT_DOUBLE_EQ(throughput * (simdur - 1), stmt->GetDouble(0));
 
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM Transactions WHERE Commodity = 'recyclefuel';"
-      );
+      "SELECT COUNT(*) FROM Transactions WHERE Commodity = 'recyclefuel';");
 
   stmt->Step();
-  EXPECT_DOUBLE_EQ(simdur-1, stmt->GetDouble(0));
+  EXPECT_DOUBLE_EQ(simdur - 1, stmt->GetDouble(0));
 }
 
 // supplied fuel has proper equivalence weights as requested.
 TEST(FuelFabTests, CorrectMixing) {
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>100</fill_size>"
-     ""
-     "<fiss_commods> <val>pustream</val> </fiss_commods>"
-     "<fiss_recipe>pustream</fiss_recipe>"
-     "<fiss_size>100</fiss_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>100</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>100</fill_size>"
+      ""
+      "<fiss_commods> <val>pustream</val> </fiss_commods>"
+      "<fiss_recipe>pustream</fiss_recipe>"
+      "<fiss_size>100</fiss_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>100</throughput>";
   int simdur = 3;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
   sim.AddSource("pustream").Finalize();
@@ -523,20 +518,24 @@ TEST(FuelFabTests, CorrectMixing) {
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
   double got = CosiWeight(m->comp(), "thermal");
   double w_target = CosiWeight(c_uox(), "thermal");
-  EXPECT_LT(std::abs((w_target-got)/w_target), 0.00001) << "mixed composition not within 0.001% of target";
+  EXPECT_LT(std::abs((w_target - got) / w_target), 0.00001)
+      << "mixed composition not within 0.001% of target";
 
   conds.push_back(Cond("Time", "==", 2));
 
-  // TODO: do hand calcs to verify expected vals below - they are just regression values currently.
+  // TODO: do hand calcs to verify expected vals below - they are just
+  // regression values currently.
   conds[0] = Cond("Commodity", "==", std::string("natu"));
   qr = sim.db().Query("Transactions", &conds);
   m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
-  EXPECT_NEAR(9.7463873197, m->quantity(), cyclus::CY_NEAR_ZERO) << "mixed wrong amount of Nat. U stream";
+  EXPECT_NEAR(9.7463873197, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "mixed wrong amount of Nat. U stream";
 
   conds[0] = Cond("Commodity", "==", std::string("pustream"));
   qr = sim.db().Query("Transactions", &conds);
   m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
-  EXPECT_NEAR(0.25361268029, m->quantity(), cyclus::CY_NEAR_ZERO) << "mixed wrong amount of Pu stream";
+  EXPECT_NEAR(0.25361268029, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "mixed wrong amount of Pu stream";
 }
 
 // fuel is requested requiring more filler than is available with plenty of
@@ -544,18 +543,17 @@ TEST(FuelFabTests, CorrectMixing) {
 TEST(FuelFabTests, FillConstrained) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>1</fill_size>"
-     ""
-     "<fiss_commods> <val>pustream</val> </fiss_commods>"
-     "<fiss_recipe>pustream</fiss_recipe>"
-     "<fiss_size>10000</fiss_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>10000</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>1</fill_size>"
+      ""
+      "<fiss_commods> <val>pustream</val> </fiss_commods>"
+      "<fiss_recipe>pustream</fiss_recipe>"
+      "<fiss_size>10000</fiss_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>10000</throughput>";
   double fillinv = 1;
   int simdur = 2;
 
@@ -582,7 +580,8 @@ TEST(FuelFabTests, FillConstrained) {
   QueryResult qr = sim.db().Query("Transactions", &conds);
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
-  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO) << "matched trade uses more fill than available";
+  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "matched trade uses more fill than available";
 }
 
 // fuel is requested requiring more fissile material than is available with
@@ -590,18 +589,17 @@ TEST(FuelFabTests, FillConstrained) {
 TEST(FuelFabTests, FissConstrained) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>10000</fill_size>"
-     ""
-     "<fiss_commods> <val>pustream</val> </fiss_commods>"
-     "<fiss_recipe>pustream</fiss_recipe>"
-     "<fiss_size>1</fiss_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>10000</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>10000</fill_size>"
+      ""
+      "<fiss_commods> <val>pustream</val> </fiss_commods>"
+      "<fiss_recipe>pustream</fiss_recipe>"
+      "<fiss_size>1</fiss_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>10000</throughput>";
   double fissinv = 1;
   int simdur = 2;
 
@@ -628,28 +626,28 @@ TEST(FuelFabTests, FissConstrained) {
   QueryResult qr = sim.db().Query("Transactions", &conds);
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
-  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO) << "matched trade uses more fill than available";
+  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "matched trade uses more fill than available";
 }
 
 // swap to topup inventory because fissile has too low reactivity.
 TEST(FuelFabTests, SwapTopup) {
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>10000</fill_size>"
-     ""
-     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-     "<fiss_recipe>pustreambad</fiss_recipe>"
-     "<fiss_size>10000</fiss_size>"
-     ""
-     "<topup_commod>pustream</topup_commod>"
-     "<topup_recipe>pustream</topup_recipe>"
-     "<topup_size>10000</topup_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>10000</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>10000</fill_size>"
+      ""
+      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+      "<fiss_recipe>pustreambad</fiss_recipe>"
+      "<fiss_size>10000</fiss_size>"
+      ""
+      "<topup_commod>pustream</topup_commod>"
+      "<topup_recipe>pustream</topup_recipe>"
+      "<topup_size>10000</topup_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>10000</throughput>";
   int simdur = 3;
   double sink_cap = 10;
 
@@ -657,7 +655,11 @@ TEST(FuelFabTests, SwapTopup) {
   sim.AddSource("pustream").Finalize();
   sim.AddSource("pustreambad").Finalize();
   sim.AddSource("natu").Finalize();
-  sim.AddSink("recyclefuel").recipe("uox").capacity(sink_cap).lifetime(2).Finalize();
+  sim.AddSink("recyclefuel")
+      .recipe("uox")
+      .capacity(sink_cap)
+      .lifetime(2)
+      .Finalize();
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("pustream", c_pustream());
   sim.AddRecipe("pustreambad", c_pustreambad());
@@ -669,37 +671,39 @@ TEST(FuelFabTests, SwapTopup) {
   QueryResult qr = sim.db().Query("Transactions", &conds);
   ASSERT_EQ(1, qr.rows.size()) << "failed to meet fuel request";
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
-  EXPECT_NEAR(sink_cap, m->quantity(), cyclus::CY_NEAR_ZERO) << "supplied fuel was constrained too much";
+  EXPECT_NEAR(sink_cap, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "supplied fuel was constrained too much";
 
   conds[0] = Cond("Commodity", "==", std::string("natu"));
   conds.push_back(Cond("Time", "==", 2));
   qr = sim.db().Query("Transactions", &conds);
-  ASSERT_EQ(0, qr.rows.size()) << "failed to swith to topup - used fill - uh oh";
+  ASSERT_EQ(0, qr.rows.size())
+      << "failed to swith to topup - used fill - uh oh";
 
   conds[0] = Cond("Commodity", "==", std::string("pustream"));
   conds.push_back(Cond("Time", "==", 2));
   qr = sim.db().Query("Transactions", &conds);
-  ASSERT_EQ(1, qr.rows.size()) << "didn't get more topup after supposedly using it - why?";
+  ASSERT_EQ(1, qr.rows.size())
+      << "didn't get more topup after supposedly using it - why?";
 }
 
 TEST(FuelFabTests, SwapTopup_ZeroFill) {
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>0</fill_size>"
-     ""
-     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-     "<fiss_recipe>pustreambad</fiss_recipe>"
-     "<fiss_size>10000</fiss_size>"
-     ""
-     "<topup_commod>pustream</topup_commod>"
-     "<topup_recipe>pustream</topup_recipe>"
-     "<topup_size>10000</topup_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>10000</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>0</fill_size>"
+      ""
+      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+      "<fiss_recipe>pustreambad</fiss_recipe>"
+      "<fiss_size>10000</fiss_size>"
+      ""
+      "<topup_commod>pustream</topup_commod>"
+      "<topup_recipe>pustream</topup_recipe>"
+      "<topup_size>10000</topup_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>10000</throughput>";
   int simdur = 3;
   double sink_cap = 10;
 
@@ -707,7 +711,11 @@ TEST(FuelFabTests, SwapTopup_ZeroFill) {
   sim.AddSource("pustream").Finalize();
   sim.AddSource("pustreambad").Finalize();
   sim.AddSource("natu").Finalize();
-  sim.AddSink("recyclefuel").recipe("uox").capacity(sink_cap).lifetime(2).Finalize();
+  sim.AddSink("recyclefuel")
+      .recipe("uox")
+      .capacity(sink_cap)
+      .lifetime(2)
+      .Finalize();
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("pustream", c_pustream());
   sim.AddRecipe("pustreambad", c_pustreambad());
@@ -719,7 +727,8 @@ TEST(FuelFabTests, SwapTopup_ZeroFill) {
   QueryResult qr = sim.db().Query("Transactions", &conds);
   ASSERT_EQ(1, qr.rows.size()) << "failed to meet fuel request";
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
-  EXPECT_NEAR(sink_cap, m->quantity(), cyclus::CY_NEAR_ZERO) << "supplied fuel was constrained too much";
+  EXPECT_NEAR(sink_cap, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "supplied fuel was constrained too much";
 
   conds[0] = Cond("Commodity", "==", std::string("pustream"));
   conds.push_back(Cond("Time", "==", 2));
@@ -740,22 +749,21 @@ TEST(FuelFabTests, SwapTopup_ZeroFill) {
 TEST(FuelFabTests, SwapTopup_TopupConstrained) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>10000</fill_size>"
-     ""
-     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-     "<fiss_recipe>pustreambad</fiss_recipe>"
-     "<fiss_size>10000</fiss_size>"
-     ""
-     "<topup_commod>pustream</topup_commod>"
-     "<topup_recipe>pustream</topup_recipe>"
-     "<topup_size>1</topup_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>10000</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>10000</fill_size>"
+      ""
+      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+      "<fiss_recipe>pustreambad</fiss_recipe>"
+      "<fiss_size>10000</fiss_size>"
+      ""
+      "<topup_commod>pustream</topup_commod>"
+      "<topup_recipe>pustream</topup_recipe>"
+      "<topup_size>1</topup_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>10000</throughput>";
   double topupinv = 1;
   int simdur = 2;
 
@@ -786,7 +794,8 @@ TEST(FuelFabTests, SwapTopup_TopupConstrained) {
   ASSERT_EQ(1, qr.rows.size()) << "failed to meet fuel request";
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
-  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO) << "matched trade uses more fiss than available";
+  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "matched trade uses more fiss than available";
 }
 
 // swap to topup inventory but are limited by fiss inventory quantity.  This
@@ -795,22 +804,21 @@ TEST(FuelFabTests, SwapTopup_TopupConstrained) {
 TEST(FuelFabTests, SwapTopup_FissConstrained) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>0</fill_size>"
-     ""
-     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-     "<fiss_recipe>pustreambad</fiss_recipe>"
-     "<fiss_size>1</fiss_size>"
-     ""
-     "<topup_commod>pustream</topup_commod>"
-     "<topup_recipe>pustream</topup_recipe>"
-     "<topup_size>10000</topup_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>10000</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>0</fill_size>"
+      ""
+      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+      "<fiss_recipe>pustreambad</fiss_recipe>"
+      "<fiss_size>1</fiss_size>"
+      ""
+      "<topup_commod>pustream</topup_commod>"
+      "<topup_recipe>pustream</topup_recipe>"
+      "<topup_size>10000</topup_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>10000</throughput>";
   double fissinv = 1;
   int simdur = 2;
 
@@ -841,31 +849,31 @@ TEST(FuelFabTests, SwapTopup_FissConstrained) {
   ASSERT_EQ(1, qr.rows.size()) << "failed to meet fuel request";
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
-  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO) << "matched trade uses more fiss than available";
+  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "matched trade uses more fiss than available";
 }
 
-// Before this test and a fix, the fuel fab (partially) assumed each entire material
-// buffer had the same composition as the material on top of the buffer when
-// calculating stream mixing ratios for material to supply.  This problem was
-// compounded by the fact that material weights are computed on an atom basis
-// and mixing is done on a mass basis - corresponding conversions resulted in
-// the fab being matched for more than it could actually supply - due to
+// Before this test and a fix, the fuel fab (partially) assumed each entire
+// material buffer had the same composition as the material on top of the buffer
+// when calculating stream mixing ratios for material to supply.  This problem
+// was compounded by the fact that material weights are computed on an atom
+// basis and mixing is done on a mass basis - corresponding conversions resulted
+// in the fab being matched for more than it could actually supply - due to
 // thinking it had an inventory of higher quality material than was actually
 // the case.  This test makes sure that doesn't happen again.
 TEST(FuelFabTests, HomogenousBuffers) {
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>40</fill_size>"
-     ""
-     "<fiss_commods> <val>stream1</val> </fiss_commods>"
-     "<fiss_size>4</fiss_size>"
-     "<fiss_recipe>spentuox</fiss_recipe>"
-     ""
-     "<outcommod>out</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>1e10</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>40</fill_size>"
+      ""
+      "<fiss_commods> <val>stream1</val> </fiss_commods>"
+      "<fiss_size>4</fiss_size>"
+      "<fiss_recipe>spentuox</fiss_recipe>"
+      ""
+      "<outcommod>out</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>1e10</throughput>";
 
   CompMap m;
   m[id("u235")] = 7;
@@ -877,8 +885,18 @@ TEST(FuelFabTests, HomogenousBuffers) {
 
   int simdur = 5;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
-  sim.AddSource("stream1").start(0).lifetime(1).capacity(.01).recipe("special").Finalize();
-  sim.AddSource("stream1").start(1).lifetime(1).capacity(3.98).recipe("natu").Finalize();
+  sim.AddSource("stream1")
+      .start(0)
+      .lifetime(1)
+      .capacity(.01)
+      .recipe("special")
+      .Finalize();
+  sim.AddSource("stream1")
+      .start(1)
+      .lifetime(1)
+      .capacity(3.98)
+      .recipe("natu")
+      .Finalize();
   sim.AddSource("natu").lifetime(1).Finalize();
   sim.AddSink("out").start(2).capacity(4).lifetime(1).recipe("uox").Finalize();
   sim.AddSink("out").start(2).capacity(4).lifetime(1).recipe("uox").Finalize();
@@ -893,21 +911,21 @@ TEST(FuelFabTests, HomogenousBuffers) {
 TEST(FuelFabTests, PositionInitialize) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>0</fill_size>"
-     ""
-     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-     "<fiss_recipe>pustreambad</fiss_recipe>"
-     "<fiss_size>1</fiss_size>"
-     ""
-     "<topup_commod>pustream</topup_commod>"
-     "<topup_recipe>pustream</topup_recipe>"
-     "<topup_size>10000</topup_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>10000</throughput>";
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>0</fill_size>"
+      ""
+      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+      "<fiss_recipe>pustreambad</fiss_recipe>"
+      "<fiss_size>1</fiss_size>"
+      ""
+      "<topup_commod>pustream</topup_commod>"
+      "<topup_recipe>pustream</topup_recipe>"
+      "<topup_size>10000</topup_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>10000</throughput>";
   double fillinv = 1;
   int simdur = 2;
 
@@ -939,24 +957,23 @@ TEST(FuelFabTests, PositionInitialize) {
 TEST(FuelFabTests, PositionInitialize2) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>0</fill_size>"
-     ""
-     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-     "<fiss_recipe>pustreambad</fiss_recipe>"
-     "<fiss_size>1</fiss_size>"
-     ""
-     "<topup_commod>pustream</topup_commod>"
-     "<topup_recipe>pustream</topup_recipe>"
-     "<topup_size>10000</topup_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>10000</throughput>"
-     "<latitude>-90.0</latitude> "
-     "<longitude>-120.0</longitude> "
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>0</fill_size>"
+      ""
+      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+      "<fiss_recipe>pustreambad</fiss_recipe>"
+      "<fiss_size>1</fiss_size>"
+      ""
+      "<topup_commod>pustream</topup_commod>"
+      "<topup_recipe>pustream</topup_recipe>"
+      "<topup_size>10000</topup_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>10000</throughput>"
+      "<latitude>-90.0</latitude> "
+      "<longitude>-120.0</longitude> ";
   double fillinv = 1;
   int simdur = 2;
 
@@ -985,5 +1002,5 @@ TEST(FuelFabTests, PositionInitialize2) {
   EXPECT_EQ(qr.GetVal<double>("Longitude"), -120.0);
 }
 
-} // namespace fuelfabtests
-} // namespace cycamore
+}  // namespace fuelfabtests
+}  // namespace cycamore

--- a/src/fuel_fab_tests.cc
+++ b/src/fuel_fab_tests.cc
@@ -4,12 +4,12 @@
 #include <sstream>
 #include "cyclus.h"
 
-using pyne::nucname::id;
-using cyclus::Composition;
 using cyclus::CompMap;
+using cyclus::Composition;
+using cyclus::Cond;
 using cyclus::Material;
 using cyclus::QueryResult;
-using cyclus::Cond;
+using pyne::nucname::id;
 
 namespace cycamore {
 namespace fuelfabtests {
@@ -31,8 +31,8 @@ Composition::Ptr c_mox() {
 
 Composition::Ptr c_natu() {
   CompMap m;
-  m[id("u235")] =  .007;
-  m[id("u238")] =  .993;
+  m[id("u235")] = .007;
+  m[id("u238")] = .993;
   return Composition::CreateFromMass(m);
 };
 
@@ -65,8 +65,8 @@ Composition::Ptr c_pustreambad() {
 
 Composition::Ptr c_water() {
   CompMap m;
-  m[id("O16")] =  1;
-  m[id("H1")] =  2;
+  m[id("O16")] = 1;
+  m[id("H1")] = 2;
   return Composition::CreateFromAtom(m);
 };
 
@@ -137,7 +137,8 @@ TEST(FuelFabTests, CosiWeight_Mixed) {
   Material::Ptr m2 = Material::CreateUntracked(fill_frac, c_natu());
   m1->Absorb(m2);
   double got = CosiWeight(m1->comp(), "thermal");
-  EXPECT_LT(std::abs((w_target-got)/w_target), 0.00001) << "mixed composition not within 0.001% of target";
+  EXPECT_LT(std::abs((w_target - got) / w_target), 0.00001)
+      << "mixed composition not within 0.001% of target";
 }
 
 TEST(FuelFabTests, HighFrac) {
@@ -151,7 +152,7 @@ TEST(FuelFabTests, HighFrac) {
   EXPECT_THROW(HighFrac(w_target, w_fiss, w_fill), cyclus::ValueError);
 
   double f = HighFrac(w_fill, w_target, w_fiss);
-  EXPECT_DOUBLE_EQ((w_target-w_fill)/(w_fiss-w_fill), f);
+  EXPECT_DOUBLE_EQ((w_target - w_fill) / (w_fiss - w_fill), f);
 }
 
 TEST(FuelFabTests, LowFrac) {
@@ -165,7 +166,7 @@ TEST(FuelFabTests, LowFrac) {
   EXPECT_THROW(LowFrac(w_target, w_fiss, w_fill), cyclus::ValueError);
 
   double f = LowFrac(w_fill, w_target, w_fiss);
-  EXPECT_DOUBLE_EQ((w_fiss-w_target)/(w_fiss-w_fill), f);
+  EXPECT_DOUBLE_EQ((w_fiss - w_target) / (w_fiss - w_fill), f);
 }
 
 TEST(FuelFabTests, ValidWeights) {
@@ -185,18 +186,18 @@ TEST(FuelFabTests, ValidWeights) {
 // request (and receive) a specific recipe for fissile stream correctly.
 TEST(FuelFabTests, FissRecipe) {
   std::string config =
-     "<fill_commods> <val>dummy</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>1</fill_size>"
-     ""
-     "<fiss_commods> <val>stream1</val> <val>stream2</val> <val>stream3</val> </fiss_commods>"
-     "<fiss_size>2.5</fiss_size>"
-     "<fiss_recipe>spentuox</fiss_recipe>"
-     ""
-     "<outcommod>dummyout</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>0</throughput>"
-     ;
+      "<fill_commods> <val>dummy</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>1</fill_size>"
+      ""
+      "<fiss_commods> <val>stream1</val> <val>stream2</val> <val>stream3</val> "
+      "</fiss_commods>"
+      "<fiss_size>2.5</fiss_size>"
+      "<fiss_recipe>spentuox</fiss_recipe>"
+      ""
+      "<outcommod>dummyout</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>0</throughput>";
 
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
@@ -212,7 +213,8 @@ TEST(FuelFabTests, FissRecipe) {
   cyclus::compmath::Normalize(&want);
   CompMap::iterator it;
   for (it = want.begin(); it != want.end(); ++it) {
-    EXPECT_DOUBLE_EQ(it->second, got[it->first]) << "nuclide qty off: " << pyne::nucname::name(it->first);
+    EXPECT_DOUBLE_EQ(it->second, got[it->first])
+        << "nuclide qty off: " << pyne::nucname::name(it->first);
   }
 }
 
@@ -220,17 +222,17 @@ TEST(FuelFabTests, FissRecipe) {
 // fissile material inventory.
 TEST(FuelFabTests, MultipleFissStreams) {
   std::string config =
-     "<fill_commods> <val>dummy</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>1</fill_size>"
-     ""
-     "<fiss_commods> <val>stream1</val> <val>stream2</val> <val>stream3</val> </fiss_commods>"
-     "<fiss_size>2.5</fiss_size>"
-     ""
-     "<outcommod>dummyout</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>0</throughput>"
-     ;
+      "<fill_commods> <val>dummy</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>1</fill_size>"
+      ""
+      "<fiss_commods> <val>stream1</val> <val>stream2</val> <val>stream3</val> "
+      "</fiss_commods>"
+      "<fiss_size>2.5</fiss_size>"
+      ""
+      "<outcommod>dummyout</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>0</throughput>";
 
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
@@ -261,18 +263,19 @@ TEST(FuelFabTests, MultipleFissStreams) {
 // fissile stream preferences can be specified.
 TEST(FuelFabTests, FissStreamPrefs) {
   std::string config =
-     "<fill_commods> <val>dummy</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>1</fill_size>"
-     ""
-     "<fiss_commods>      <val>stream1</val> <val>stream2</val> <val>stream3</val> </fiss_commods>"
-     "<fiss_commod_prefs> <val>1.0</val>     <val>0.1</val>     <val>2.0</val> </fiss_commod_prefs>"
-     "<fiss_size>1.5</fiss_size>"
-     ""
-     "<outcommod>dummyout</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>0</throughput>"
-     ;
+      "<fill_commods> <val>dummy</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>1</fill_size>"
+      ""
+      "<fiss_commods>      <val>stream1</val> <val>stream2</val> "
+      "<val>stream3</val> </fiss_commods>"
+      "<fiss_commod_prefs> <val>1.0</val>     <val>0.1</val>     "
+      "<val>2.0</val> </fiss_commod_prefs>"
+      "<fiss_size>1.5</fiss_size>"
+      ""
+      "<outcommod>dummyout</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>0</throughput>";
 
   int simdur = 1;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
@@ -302,22 +305,21 @@ TEST(FuelFabTests, FissStreamPrefs) {
 // zero throughput must not result in a zero capacity constraint excception.
 TEST(FuelFabTests, ZeroThroughput) {
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>3.9</fill_size>"
-     ""
-     "<fiss_commods> <val>spentuox</val> </fiss_commods>"
-     "<fiss_recipe>spentuox</fiss_recipe>"
-     "<fiss_size>3.5</fiss_size>"
-     ""
-     "<topup_commod>uox</topup_commod>"
-     "<topup_recipe>uox</topup_recipe>"
-     "<topup_size>3.3</topup_size>"
-     ""
-     "<outcommod>dummyout</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>0</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>3.9</fill_size>"
+      ""
+      "<fiss_commods> <val>spentuox</val> </fiss_commods>"
+      "<fiss_recipe>spentuox</fiss_recipe>"
+      "<fiss_size>3.5</fiss_size>"
+      ""
+      "<topup_commod>uox</topup_commod>"
+      "<topup_recipe>uox</topup_recipe>"
+      "<topup_size>3.3</topup_size>"
+      ""
+      "<outcommod>dummyout</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>0</throughput>";
 
   int simdur = 10;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
@@ -335,22 +337,21 @@ TEST(FuelFabTests, ZeroThroughput) {
 // enforced after they are full.
 TEST(FuelFabTests, FillAllInventories) {
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>3.9</fill_size>"
-     ""
-     "<fiss_commods> <val>spentuox</val> </fiss_commods>"
-     "<fiss_recipe>spentuox</fiss_recipe>"
-     "<fiss_size>3.5</fiss_size>"
-     ""
-     "<topup_commod>uox</topup_commod>"
-     "<topup_recipe>uox</topup_recipe>"
-     "<topup_size>3.3</topup_size>"
-     ""
-     "<outcommod>dummyout</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>1</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>3.9</fill_size>"
+      ""
+      "<fiss_commods> <val>spentuox</val> </fiss_commods>"
+      "<fiss_recipe>spentuox</fiss_recipe>"
+      "<fiss_size>3.5</fiss_size>"
+      ""
+      "<topup_commod>uox</topup_commod>"
+      "<topup_recipe>uox</topup_recipe>"
+      "<topup_size>3.3</topup_size>"
+      ""
+      "<outcommod>dummyout</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>1</throughput>";
 
   int simdur = 10;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
@@ -365,8 +366,7 @@ TEST(FuelFabTests, FillAllInventories) {
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
       "SELECT SUM(r.Quantity) FROM Transactions AS t"
       " INNER JOIN Resources AS r ON r.ResourceId = t.ResourceId"
-      " WHERE t.Commodity = ?;"
-      );
+      " WHERE t.Commodity = ?;");
 
   stmt->BindText(1, "natu");
   stmt->Step();
@@ -385,18 +385,17 @@ TEST(FuelFabTests, FillAllInventories) {
 // inventory quantity.
 TEST(FuelFabTests, ProvideStraightFiss_WithZeroFill) {
   std::string config =
-     "<fill_commods> <val>nothing</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>100</fill_size>"
-     ""
-     "<fiss_commods> <val>anything</val> </fiss_commods>"
-     "<fiss_recipe>spentuox</fiss_recipe>"
-     "<fiss_size>100</fiss_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>100</throughput>"
-     ;
+      "<fill_commods> <val>nothing</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>100</fill_size>"
+      ""
+      "<fiss_commods> <val>anything</val> </fiss_commods>"
+      "<fiss_recipe>spentuox</fiss_recipe>"
+      "<fiss_size>100</fiss_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>100</throughput>";
   int simdur = 6;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
   sim.AddSource("anything").Finalize();
@@ -415,18 +414,17 @@ TEST(FuelFabTests, ProvideStraightFiss_WithZeroFill) {
 
 TEST(FuelFabTests, ProvideStraightFill_ZeroFiss) {
   std::string config =
-     "<fill_commods> <val>anything</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>100</fill_size>"
-     ""
-     "<fiss_commods> <val>nothing</val> </fiss_commods>"
-     "<fiss_recipe>spentuox</fiss_recipe>"
-     "<fiss_size>100</fiss_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>100</throughput>"
-     ;
+      "<fill_commods> <val>anything</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>100</fill_size>"
+      ""
+      "<fiss_commods> <val>nothing</val> </fiss_commods>"
+      "<fiss_recipe>spentuox</fiss_recipe>"
+      "<fiss_size>100</fiss_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>100</throughput>";
   int simdur = 6;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
   sim.AddSource("anything").Finalize();
@@ -447,24 +445,23 @@ TEST(FuelFabTests, ProvideStraightFill_ZeroFiss) {
 // requests and with ample material inventory.
 TEST(FuelFabTests, ThroughputLimit) {
   std::string config =
-     "<fill_commods> <val>anything</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>100</fill_size>"
-     ""
-     "<fiss_commods> <val>anything</val> </fiss_commods>"
-     "<fiss_recipe>pustream</fiss_recipe>"
-     "<fiss_size>100</fiss_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>3</throughput>"
-     ;
+      "<fill_commods> <val>anything</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>100</fill_size>"
+      ""
+      "<fiss_commods> <val>anything</val> </fiss_commods>"
+      "<fiss_recipe>pustream</fiss_recipe>"
+      "<fiss_size>100</fiss_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>3</throughput>";
   double throughput = 3;
 
   int simdur = 5;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
   sim.AddSource("anything").lifetime(1).Finalize();
-  sim.AddSink("recyclefuel").recipe("uox").capacity(2*throughput).Finalize();
+  sim.AddSink("recyclefuel").recipe("uox").capacity(2 * throughput).Finalize();
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("pustream", c_pustream());
   sim.AddRecipe("natu", c_natu());
@@ -476,35 +473,32 @@ TEST(FuelFabTests, ThroughputLimit) {
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
       "SELECT SUM(r.Quantity) FROM Transactions AS t"
       " INNER JOIN Resources AS r ON r.ResourceId = t.ResourceId"
-      " WHERE t.Commodity = 'recyclefuel';"
-      );
+      " WHERE t.Commodity = 'recyclefuel';");
 
   stmt->Step();
-  EXPECT_DOUBLE_EQ(throughput * (simdur-1), stmt->GetDouble(0));
+  EXPECT_DOUBLE_EQ(throughput * (simdur - 1), stmt->GetDouble(0));
 
   stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM Transactions WHERE Commodity = 'recyclefuel';"
-      );
+      "SELECT COUNT(*) FROM Transactions WHERE Commodity = 'recyclefuel';");
 
   stmt->Step();
-  EXPECT_DOUBLE_EQ(simdur-1, stmt->GetDouble(0));
+  EXPECT_DOUBLE_EQ(simdur - 1, stmt->GetDouble(0));
 }
 
 // supplied fuel has proper equivalence weights as requested.
 TEST(FuelFabTests, CorrectMixing) {
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>100</fill_size>"
-     ""
-     "<fiss_commods> <val>pustream</val> </fiss_commods>"
-     "<fiss_recipe>pustream</fiss_recipe>"
-     "<fiss_size>100</fiss_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>100</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>100</fill_size>"
+      ""
+      "<fiss_commods> <val>pustream</val> </fiss_commods>"
+      "<fiss_recipe>pustream</fiss_recipe>"
+      "<fiss_size>100</fiss_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>100</throughput>";
   int simdur = 3;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
   sim.AddSource("pustream").Finalize();
@@ -523,20 +517,24 @@ TEST(FuelFabTests, CorrectMixing) {
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
   double got = CosiWeight(m->comp(), "thermal");
   double w_target = CosiWeight(c_uox(), "thermal");
-  EXPECT_LT(std::abs((w_target-got)/w_target), 0.00001) << "mixed composition not within 0.001% of target";
+  EXPECT_LT(std::abs((w_target - got) / w_target), 0.00001)
+      << "mixed composition not within 0.001% of target";
 
   conds.push_back(Cond("Time", "==", 2));
 
-  // TODO: do hand calcs to verify expected vals below - they are just regression values currently.
+  // TODO: do hand calcs to verify expected vals below - they are just
+  // regression values currently.
   conds[0] = Cond("Commodity", "==", std::string("natu"));
   qr = sim.db().Query("Transactions", &conds);
   m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
-  EXPECT_NEAR(9.7463873197, m->quantity(), cyclus::CY_NEAR_ZERO) << "mixed wrong amount of Nat. U stream";
+  EXPECT_NEAR(9.7463873197, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "mixed wrong amount of Nat. U stream";
 
   conds[0] = Cond("Commodity", "==", std::string("pustream"));
   qr = sim.db().Query("Transactions", &conds);
   m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
-  EXPECT_NEAR(0.25361268029, m->quantity(), cyclus::CY_NEAR_ZERO) << "mixed wrong amount of Pu stream";
+  EXPECT_NEAR(0.25361268029, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "mixed wrong amount of Pu stream";
 }
 
 // fuel is requested requiring more filler than is available with plenty of
@@ -544,18 +542,17 @@ TEST(FuelFabTests, CorrectMixing) {
 TEST(FuelFabTests, FillConstrained) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>1</fill_size>"
-     ""
-     "<fiss_commods> <val>pustream</val> </fiss_commods>"
-     "<fiss_recipe>pustream</fiss_recipe>"
-     "<fiss_size>10000</fiss_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>10000</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>1</fill_size>"
+      ""
+      "<fiss_commods> <val>pustream</val> </fiss_commods>"
+      "<fiss_recipe>pustream</fiss_recipe>"
+      "<fiss_size>10000</fiss_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>10000</throughput>";
   double fillinv = 1;
   int simdur = 2;
 
@@ -582,7 +579,8 @@ TEST(FuelFabTests, FillConstrained) {
   QueryResult qr = sim.db().Query("Transactions", &conds);
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
-  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO) << "matched trade uses more fill than available";
+  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "matched trade uses more fill than available";
 }
 
 // fuel is requested requiring more fissile material than is available with
@@ -590,18 +588,17 @@ TEST(FuelFabTests, FillConstrained) {
 TEST(FuelFabTests, FissConstrained) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>10000</fill_size>"
-     ""
-     "<fiss_commods> <val>pustream</val> </fiss_commods>"
-     "<fiss_recipe>pustream</fiss_recipe>"
-     "<fiss_size>1</fiss_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>10000</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>10000</fill_size>"
+      ""
+      "<fiss_commods> <val>pustream</val> </fiss_commods>"
+      "<fiss_recipe>pustream</fiss_recipe>"
+      "<fiss_size>1</fiss_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>10000</throughput>";
   double fissinv = 1;
   int simdur = 2;
 
@@ -628,28 +625,28 @@ TEST(FuelFabTests, FissConstrained) {
   QueryResult qr = sim.db().Query("Transactions", &conds);
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
-  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO) << "matched trade uses more fill than available";
+  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "matched trade uses more fill than available";
 }
 
 // swap to topup inventory because fissile has too low reactivity.
 TEST(FuelFabTests, SwapTopup) {
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>10000</fill_size>"
-     ""
-     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-     "<fiss_recipe>pustreambad</fiss_recipe>"
-     "<fiss_size>10000</fiss_size>"
-     ""
-     "<topup_commod>pustream</topup_commod>"
-     "<topup_recipe>pustream</topup_recipe>"
-     "<topup_size>10000</topup_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>10000</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>10000</fill_size>"
+      ""
+      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+      "<fiss_recipe>pustreambad</fiss_recipe>"
+      "<fiss_size>10000</fiss_size>"
+      ""
+      "<topup_commod>pustream</topup_commod>"
+      "<topup_recipe>pustream</topup_recipe>"
+      "<topup_size>10000</topup_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>10000</throughput>";
   int simdur = 3;
   double sink_cap = 10;
 
@@ -657,7 +654,11 @@ TEST(FuelFabTests, SwapTopup) {
   sim.AddSource("pustream").Finalize();
   sim.AddSource("pustreambad").Finalize();
   sim.AddSource("natu").Finalize();
-  sim.AddSink("recyclefuel").recipe("uox").capacity(sink_cap).lifetime(2).Finalize();
+  sim.AddSink("recyclefuel")
+      .recipe("uox")
+      .capacity(sink_cap)
+      .lifetime(2)
+      .Finalize();
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("pustream", c_pustream());
   sim.AddRecipe("pustreambad", c_pustreambad());
@@ -669,37 +670,39 @@ TEST(FuelFabTests, SwapTopup) {
   QueryResult qr = sim.db().Query("Transactions", &conds);
   ASSERT_EQ(1, qr.rows.size()) << "failed to meet fuel request";
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
-  EXPECT_NEAR(sink_cap, m->quantity(), cyclus::CY_NEAR_ZERO) << "supplied fuel was constrained too much";
+  EXPECT_NEAR(sink_cap, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "supplied fuel was constrained too much";
 
   conds[0] = Cond("Commodity", "==", std::string("natu"));
   conds.push_back(Cond("Time", "==", 2));
   qr = sim.db().Query("Transactions", &conds);
-  ASSERT_EQ(0, qr.rows.size()) << "failed to swith to topup - used fill - uh oh";
+  ASSERT_EQ(0, qr.rows.size())
+      << "failed to swith to topup - used fill - uh oh";
 
   conds[0] = Cond("Commodity", "==", std::string("pustream"));
   conds.push_back(Cond("Time", "==", 2));
   qr = sim.db().Query("Transactions", &conds);
-  ASSERT_EQ(1, qr.rows.size()) << "didn't get more topup after supposedly using it - why?";
+  ASSERT_EQ(1, qr.rows.size())
+      << "didn't get more topup after supposedly using it - why?";
 }
 
 TEST(FuelFabTests, SwapTopup_ZeroFill) {
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>0</fill_size>"
-     ""
-     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-     "<fiss_recipe>pustreambad</fiss_recipe>"
-     "<fiss_size>10000</fiss_size>"
-     ""
-     "<topup_commod>pustream</topup_commod>"
-     "<topup_recipe>pustream</topup_recipe>"
-     "<topup_size>10000</topup_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>10000</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>0</fill_size>"
+      ""
+      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+      "<fiss_recipe>pustreambad</fiss_recipe>"
+      "<fiss_size>10000</fiss_size>"
+      ""
+      "<topup_commod>pustream</topup_commod>"
+      "<topup_recipe>pustream</topup_recipe>"
+      "<topup_size>10000</topup_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>10000</throughput>";
   int simdur = 3;
   double sink_cap = 10;
 
@@ -707,7 +710,11 @@ TEST(FuelFabTests, SwapTopup_ZeroFill) {
   sim.AddSource("pustream").Finalize();
   sim.AddSource("pustreambad").Finalize();
   sim.AddSource("natu").Finalize();
-  sim.AddSink("recyclefuel").recipe("uox").capacity(sink_cap).lifetime(2).Finalize();
+  sim.AddSink("recyclefuel")
+      .recipe("uox")
+      .capacity(sink_cap)
+      .lifetime(2)
+      .Finalize();
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("pustream", c_pustream());
   sim.AddRecipe("pustreambad", c_pustreambad());
@@ -719,7 +726,8 @@ TEST(FuelFabTests, SwapTopup_ZeroFill) {
   QueryResult qr = sim.db().Query("Transactions", &conds);
   ASSERT_EQ(1, qr.rows.size()) << "failed to meet fuel request";
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
-  EXPECT_NEAR(sink_cap, m->quantity(), cyclus::CY_NEAR_ZERO) << "supplied fuel was constrained too much";
+  EXPECT_NEAR(sink_cap, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "supplied fuel was constrained too much";
 
   conds[0] = Cond("Commodity", "==", std::string("pustream"));
   conds.push_back(Cond("Time", "==", 2));
@@ -740,22 +748,21 @@ TEST(FuelFabTests, SwapTopup_ZeroFill) {
 TEST(FuelFabTests, SwapTopup_TopupConstrained) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>10000</fill_size>"
-     ""
-     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-     "<fiss_recipe>pustreambad</fiss_recipe>"
-     "<fiss_size>10000</fiss_size>"
-     ""
-     "<topup_commod>pustream</topup_commod>"
-     "<topup_recipe>pustream</topup_recipe>"
-     "<topup_size>1</topup_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>10000</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>10000</fill_size>"
+      ""
+      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+      "<fiss_recipe>pustreambad</fiss_recipe>"
+      "<fiss_size>10000</fiss_size>"
+      ""
+      "<topup_commod>pustream</topup_commod>"
+      "<topup_recipe>pustream</topup_recipe>"
+      "<topup_size>1</topup_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>10000</throughput>";
   double topupinv = 1;
   int simdur = 2;
 
@@ -786,7 +793,8 @@ TEST(FuelFabTests, SwapTopup_TopupConstrained) {
   ASSERT_EQ(1, qr.rows.size()) << "failed to meet fuel request";
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
-  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO) << "matched trade uses more fiss than available";
+  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "matched trade uses more fiss than available";
 }
 
 // swap to topup inventory but are limited by fiss inventory quantity.  This
@@ -795,22 +803,21 @@ TEST(FuelFabTests, SwapTopup_TopupConstrained) {
 TEST(FuelFabTests, SwapTopup_FissConstrained) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>0</fill_size>"
-     ""
-     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-     "<fiss_recipe>pustreambad</fiss_recipe>"
-     "<fiss_size>1</fiss_size>"
-     ""
-     "<topup_commod>pustream</topup_commod>"
-     "<topup_recipe>pustream</topup_recipe>"
-     "<topup_size>10000</topup_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>10000</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>0</fill_size>"
+      ""
+      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+      "<fiss_recipe>pustreambad</fiss_recipe>"
+      "<fiss_size>1</fiss_size>"
+      ""
+      "<topup_commod>pustream</topup_commod>"
+      "<topup_recipe>pustream</topup_recipe>"
+      "<topup_size>10000</topup_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>10000</throughput>";
   double fissinv = 1;
   int simdur = 2;
 
@@ -841,31 +848,31 @@ TEST(FuelFabTests, SwapTopup_FissConstrained) {
   ASSERT_EQ(1, qr.rows.size()) << "failed to meet fuel request";
   Material::Ptr m = sim.GetMaterial(qr.GetVal<int>("ResourceId"));
 
-  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO) << "matched trade uses more fiss than available";
+  EXPECT_NEAR(max_provide, m->quantity(), cyclus::CY_NEAR_ZERO)
+      << "matched trade uses more fiss than available";
 }
 
-// Before this test and a fix, the fuel fab (partially) assumed each entire material
-// buffer had the same composition as the material on top of the buffer when
-// calculating stream mixing ratios for material to supply.  This problem was
-// compounded by the fact that material weights are computed on an atom basis
-// and mixing is done on a mass basis - corresponding conversions resulted in
-// the fab being matched for more than it could actually supply - due to
+// Before this test and a fix, the fuel fab (partially) assumed each entire
+// material buffer had the same composition as the material on top of the buffer
+// when calculating stream mixing ratios for material to supply.  This problem
+// was compounded by the fact that material weights are computed on an atom
+// basis and mixing is done on a mass basis - corresponding conversions resulted
+// in the fab being matched for more than it could actually supply - due to
 // thinking it had an inventory of higher quality material than was actually
 // the case.  This test makes sure that doesn't happen again.
 TEST(FuelFabTests, HomogenousBuffers) {
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>40</fill_size>"
-     ""
-     "<fiss_commods> <val>stream1</val> </fiss_commods>"
-     "<fiss_size>4</fiss_size>"
-     "<fiss_recipe>spentuox</fiss_recipe>"
-     ""
-     "<outcommod>out</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>1e10</throughput>"
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>40</fill_size>"
+      ""
+      "<fiss_commods> <val>stream1</val> </fiss_commods>"
+      "<fiss_size>4</fiss_size>"
+      "<fiss_recipe>spentuox</fiss_recipe>"
+      ""
+      "<outcommod>out</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>1e10</throughput>";
 
   CompMap m;
   m[id("u235")] = 7;
@@ -877,8 +884,18 @@ TEST(FuelFabTests, HomogenousBuffers) {
 
   int simdur = 5;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:FuelFab"), config, simdur);
-  sim.AddSource("stream1").start(0).lifetime(1).capacity(.01).recipe("special").Finalize();
-  sim.AddSource("stream1").start(1).lifetime(1).capacity(3.98).recipe("natu").Finalize();
+  sim.AddSource("stream1")
+      .start(0)
+      .lifetime(1)
+      .capacity(.01)
+      .recipe("special")
+      .Finalize();
+  sim.AddSource("stream1")
+      .start(1)
+      .lifetime(1)
+      .capacity(3.98)
+      .recipe("natu")
+      .Finalize();
   sim.AddSource("natu").lifetime(1).Finalize();
   sim.AddSink("out").start(2).capacity(4).lifetime(1).recipe("uox").Finalize();
   sim.AddSink("out").start(2).capacity(4).lifetime(1).recipe("uox").Finalize();
@@ -893,21 +910,21 @@ TEST(FuelFabTests, HomogenousBuffers) {
 TEST(FuelFabTests, PositionInitialize) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>0</fill_size>"
-     ""
-     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-     "<fiss_recipe>pustreambad</fiss_recipe>"
-     "<fiss_size>1</fiss_size>"
-     ""
-     "<topup_commod>pustream</topup_commod>"
-     "<topup_recipe>pustream</topup_recipe>"
-     "<topup_size>10000</topup_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>10000</throughput>";
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>0</fill_size>"
+      ""
+      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+      "<fiss_recipe>pustreambad</fiss_recipe>"
+      "<fiss_size>1</fiss_size>"
+      ""
+      "<topup_commod>pustream</topup_commod>"
+      "<topup_recipe>pustream</topup_recipe>"
+      "<topup_size>10000</topup_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>10000</throughput>";
   double fillinv = 1;
   int simdur = 2;
 
@@ -939,24 +956,23 @@ TEST(FuelFabTests, PositionInitialize) {
 TEST(FuelFabTests, PositionInitialize2) {
   cyclus::Env::SetNucDataPath();
   std::string config =
-     "<fill_commods> <val>natu</val> </fill_commods>"
-     "<fill_recipe>natu</fill_recipe>"
-     "<fill_size>0</fill_size>"
-     ""
-     "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
-     "<fiss_recipe>pustreambad</fiss_recipe>"
-     "<fiss_size>1</fiss_size>"
-     ""
-     "<topup_commod>pustream</topup_commod>"
-     "<topup_recipe>pustream</topup_recipe>"
-     "<topup_size>10000</topup_size>"
-     ""
-     "<outcommod>recyclefuel</outcommod>"
-     "<spectrum>thermal</spectrum>"
-     "<throughput>10000</throughput>"
-     "<latitude>-90.0</latitude> "
-     "<longitude>-120.0</longitude> "
-     ;
+      "<fill_commods> <val>natu</val> </fill_commods>"
+      "<fill_recipe>natu</fill_recipe>"
+      "<fill_size>0</fill_size>"
+      ""
+      "<fiss_commods> <val>pustreambad</val> </fiss_commods>"
+      "<fiss_recipe>pustreambad</fiss_recipe>"
+      "<fiss_size>1</fiss_size>"
+      ""
+      "<topup_commod>pustream</topup_commod>"
+      "<topup_recipe>pustream</topup_recipe>"
+      "<topup_size>10000</topup_size>"
+      ""
+      "<outcommod>recyclefuel</outcommod>"
+      "<spectrum>thermal</spectrum>"
+      "<throughput>10000</throughput>"
+      "<latitude>-90.0</latitude> "
+      "<longitude>-120.0</longitude> ";
   double fillinv = 1;
   int simdur = 2;
 
@@ -985,5 +1001,5 @@ TEST(FuelFabTests, PositionInitialize2) {
   EXPECT_EQ(qr.GetVal<double>("Longitude"), -120.0);
 }
 
-} // namespace fuelfabtests
-} // namespace cycamore
+}  // namespace fuelfabtests
+}  // namespace cycamore

--- a/src/growth_region.cc
+++ b/src/growth_region.cc
@@ -8,18 +8,16 @@ GrowthRegion::GrowthRegion(cyclus::Context* ctx)
       latitude(0.0),
       longitude(0.0),
       coordinates(latitude, longitude) {
-  #if !CYCLUS_HAS_COIN
-    throw cyclus::Error("Growth Region requires that Cyclus & Cycamore be compiled "
-                        "with COIN support.");
-  #endif
+#if !CYCLUS_HAS_COIN
+  throw cyclus::Error(
+      "Growth Region requires that Cyclus & Cycamore be compiled "
+      "with COIN support.");
+#endif
 }
 
 GrowthRegion::~GrowthRegion() {}
 
-void GrowthRegion::AddCommodityDemand_(std::string commod,
-                                       Demand& demand) {
-
-
+void GrowthRegion::AddCommodityDemand_(std::string commod, Demand& demand) {
   cyclus::toolkit::PiecewiseFunctionFactory pff;
   cyclus::toolkit::BasicFunctionFactory bff;
   bool continuous = false;
@@ -31,7 +29,7 @@ void GrowthRegion::AddCommodityDemand_(std::string commod,
     type = it->second.first;
     params = it->second.second;
     pff.AddFunction(bff.GetFunctionPtr(type, params), time, continuous);
-    continuous = true; // only the first entry is not continuous
+    continuous = true;  // only the first entry is not continuous
   }
 
   // register the commodity and demand
@@ -51,8 +49,8 @@ void GrowthRegion::EnterNotify() {
 
   std::map<std::string, Demand>::iterator it;
   for (it = commodity_demand.begin(); it != commodity_demand.end(); ++it) {
-    LOG(cyclus::LEV_INFO3, "greg") << "Adding demand for commodity "
-                                   << it->first;
+    LOG(cyclus::LEV_INFO3, "greg")
+        << "Adding demand for commodity " << it->first;
     AddCommodityDemand_(it->first, it->second);
   }
   RecordPosition();
@@ -63,46 +61,45 @@ void GrowthRegion::DecomNotify(Agent* a) {
 }
 
 void GrowthRegion::Register_(cyclus::Agent* agent) {
-  using cyclus::toolkit::CommodityProducerManager;
   using cyclus::toolkit::Builder;
+  using cyclus::toolkit::CommodityProducerManager;
 #if CYCLUS_HAS_COIN
   CommodityProducerManager* cpm_cast =
       dynamic_cast<CommodityProducerManager*>(agent);
   if (cpm_cast != NULL) {
-    LOG(cyclus::LEV_INFO3, "greg") << "Registering agent "
-                                   << agent->prototype() << agent->id()
-                                   << " as a commodity producer manager.";
+    LOG(cyclus::LEV_INFO3, "greg")
+        << "Registering agent " << agent->prototype() << agent->id()
+        << " as a commodity producer manager.";
     sdmanager_.RegisterProducerManager(cpm_cast);
   }
 
   Builder* b_cast = dynamic_cast<Builder*>(agent);
   if (b_cast != NULL) {
-    LOG(cyclus::LEV_INFO3, "greg") << "Registering agent "
-                                   << agent->prototype() << agent->id()
-                                   << " as a builder.";
+    LOG(cyclus::LEV_INFO3, "greg") << "Registering agent " << agent->prototype()
+                                   << agent->id() << " as a builder.";
     buildmanager_.Register(b_cast);
   }
 #else
-  throw cyclus::Error("Growth Region requires that Cyclus & Cycamore be compiled "
-                      "with COIN support.");
+  throw cyclus::Error(
+      "Growth Region requires that Cyclus & Cycamore be compiled "
+      "with COIN support.");
 #endif
 }
 
 void GrowthRegion::Unregister_(cyclus::Agent* agent) {
-  using cyclus::toolkit::CommodityProducerManager;
   using cyclus::toolkit::Builder;
+  using cyclus::toolkit::CommodityProducerManager;
 #if CYCLUS_HAS_COIN
   CommodityProducerManager* cpm_cast =
-    dynamic_cast<CommodityProducerManager*>(agent);
-  if (cpm_cast != NULL)
-    sdmanager_.UnregisterProducerManager(cpm_cast);
+      dynamic_cast<CommodityProducerManager*>(agent);
+  if (cpm_cast != NULL) sdmanager_.UnregisterProducerManager(cpm_cast);
 
   Builder* b_cast = dynamic_cast<Builder*>(agent);
-  if (b_cast != NULL)
-    buildmanager_.Unregister(b_cast);
+  if (b_cast != NULL) buildmanager_.Unregister(b_cast);
 #else
-  throw cyclus::Error("Growth Region requires that Cyclus & Cycamore be compiled "
-                      "with COIN support.");
+  throw cyclus::Error(
+      "Growth Region requires that Cyclus & Cycamore be compiled "
+      "with COIN support.");
 #endif
 }
 
@@ -117,10 +114,10 @@ void GrowthRegion::Tick() {
     supply = sdmanager_.Supply(commod);
     unmetdemand = demand - supply;
 
-    LOG(cyclus::LEV_INFO3, "greg") << "GrowthRegion: " << prototype()
-                                   << " at time: " << time
-                                   << " has the following values regarding "
-                                   << " commodity: " << commod.name();
+    LOG(cyclus::LEV_INFO3, "greg")
+        << "GrowthRegion: " << prototype() << " at time: " << time
+        << " has the following values regarding "
+        << " commodity: " << commod.name();
     LOG(cyclus::LEV_INFO3, "greg") << "  * demand = " << demand;
     LOG(cyclus::LEV_INFO3, "greg") << "  * supply = " << supply;
     LOG(cyclus::LEV_INFO3, "greg") << "  * unmet demand = " << unmetdemand;
@@ -137,11 +134,10 @@ void GrowthRegion::OrderBuilds(cyclus::toolkit::Commodity& commodity,
 #if CYCLUS_HAS_COIN
   using std::vector;
   vector<cyclus::toolkit::BuildOrder> orders =
-    buildmanager_.MakeBuildDecision(commodity, unmetdemand);
+      buildmanager_.MakeBuildDecision(commodity, unmetdemand);
 
   LOG(cyclus::LEV_INFO3, "greg")
-      << "The build orders have been determined. "
-      << orders.size()
+      << "The build orders have been determined. " << orders.size()
       << " different type(s) of prototypes will be built.";
 
   cyclus::toolkit::BuildOrder* order;
@@ -152,16 +148,15 @@ void GrowthRegion::OrderBuilds(cyclus::toolkit::Commodity& commodity,
     instcast = dynamic_cast<cyclus::Institution*>(order->builder);
     agentcast = dynamic_cast<cyclus::Agent*>(order->producer);
     if (!instcast || !agentcast) {
-      throw cyclus::CastError("growth_region has tried to incorrectly "
-                              "cast an already known entity.");
+      throw cyclus::CastError(
+          "growth_region has tried to incorrectly "
+          "cast an already known entity.");
     }
 
     LOG(cyclus::LEV_INFO3, "greg")
-        << "A build order for " << order->number
-        << " prototype(s) of type "
+        << "A build order for " << order->number << " prototype(s) of type "
         << dynamic_cast<cyclus::Agent*>(agentcast)->prototype()
-        << " from builder " << instcast->prototype()
-        << " is being placed.";
+        << " from builder " << instcast->prototype() << " is being placed.";
 
     for (int j = 0; j < order->number; j++) {
       LOG(cyclus::LEV_DEBUG2, "greg") << "Ordering build number: " << j + 1;
@@ -169,8 +164,9 @@ void GrowthRegion::OrderBuilds(cyclus::toolkit::Commodity& commodity,
     }
   }
 #else
-  throw cyclus::Error("Growth Region requires that Cyclus & Cycamore be compiled "
-                      "with COIN support.");
+  throw cyclus::Error(
+      "Growth Region requires that Cyclus & Cycamore be compiled "
+      "with COIN support.");
 #endif
 }
 

--- a/src/growth_region.cc
+++ b/src/growth_region.cc
@@ -8,16 +8,18 @@ GrowthRegion::GrowthRegion(cyclus::Context* ctx)
       latitude(0.0),
       longitude(0.0),
       coordinates(latitude, longitude) {
-#if !CYCLUS_HAS_COIN
-  throw cyclus::Error(
-      "Growth Region requires that Cyclus & Cycamore be compiled "
-      "with COIN support.");
-#endif
+  #if !CYCLUS_HAS_COIN
+    throw cyclus::Error("Growth Region requires that Cyclus & Cycamore be compiled "
+                        "with COIN support.");
+  #endif
 }
 
 GrowthRegion::~GrowthRegion() {}
 
-void GrowthRegion::AddCommodityDemand_(std::string commod, Demand& demand) {
+void GrowthRegion::AddCommodityDemand_(std::string commod,
+                                       Demand& demand) {
+
+
   cyclus::toolkit::PiecewiseFunctionFactory pff;
   cyclus::toolkit::BasicFunctionFactory bff;
   bool continuous = false;
@@ -29,7 +31,7 @@ void GrowthRegion::AddCommodityDemand_(std::string commod, Demand& demand) {
     type = it->second.first;
     params = it->second.second;
     pff.AddFunction(bff.GetFunctionPtr(type, params), time, continuous);
-    continuous = true;  // only the first entry is not continuous
+    continuous = true; // only the first entry is not continuous
   }
 
   // register the commodity and demand
@@ -49,8 +51,8 @@ void GrowthRegion::EnterNotify() {
 
   std::map<std::string, Demand>::iterator it;
   for (it = commodity_demand.begin(); it != commodity_demand.end(); ++it) {
-    LOG(cyclus::LEV_INFO3, "greg")
-        << "Adding demand for commodity " << it->first;
+    LOG(cyclus::LEV_INFO3, "greg") << "Adding demand for commodity "
+                                   << it->first;
     AddCommodityDemand_(it->first, it->second);
   }
   RecordPosition();
@@ -61,45 +63,46 @@ void GrowthRegion::DecomNotify(Agent* a) {
 }
 
 void GrowthRegion::Register_(cyclus::Agent* agent) {
-  using cyclus::toolkit::Builder;
   using cyclus::toolkit::CommodityProducerManager;
+  using cyclus::toolkit::Builder;
 #if CYCLUS_HAS_COIN
   CommodityProducerManager* cpm_cast =
       dynamic_cast<CommodityProducerManager*>(agent);
   if (cpm_cast != NULL) {
-    LOG(cyclus::LEV_INFO3, "greg")
-        << "Registering agent " << agent->prototype() << agent->id()
-        << " as a commodity producer manager.";
+    LOG(cyclus::LEV_INFO3, "greg") << "Registering agent "
+                                   << agent->prototype() << agent->id()
+                                   << " as a commodity producer manager.";
     sdmanager_.RegisterProducerManager(cpm_cast);
   }
 
   Builder* b_cast = dynamic_cast<Builder*>(agent);
   if (b_cast != NULL) {
-    LOG(cyclus::LEV_INFO3, "greg") << "Registering agent " << agent->prototype()
-                                   << agent->id() << " as a builder.";
+    LOG(cyclus::LEV_INFO3, "greg") << "Registering agent "
+                                   << agent->prototype() << agent->id()
+                                   << " as a builder.";
     buildmanager_.Register(b_cast);
   }
 #else
-  throw cyclus::Error(
-      "Growth Region requires that Cyclus & Cycamore be compiled "
-      "with COIN support.");
+  throw cyclus::Error("Growth Region requires that Cyclus & Cycamore be compiled "
+                      "with COIN support.");
 #endif
 }
 
 void GrowthRegion::Unregister_(cyclus::Agent* agent) {
-  using cyclus::toolkit::Builder;
   using cyclus::toolkit::CommodityProducerManager;
+  using cyclus::toolkit::Builder;
 #if CYCLUS_HAS_COIN
   CommodityProducerManager* cpm_cast =
-      dynamic_cast<CommodityProducerManager*>(agent);
-  if (cpm_cast != NULL) sdmanager_.UnregisterProducerManager(cpm_cast);
+    dynamic_cast<CommodityProducerManager*>(agent);
+  if (cpm_cast != NULL)
+    sdmanager_.UnregisterProducerManager(cpm_cast);
 
   Builder* b_cast = dynamic_cast<Builder*>(agent);
-  if (b_cast != NULL) buildmanager_.Unregister(b_cast);
+  if (b_cast != NULL)
+    buildmanager_.Unregister(b_cast);
 #else
-  throw cyclus::Error(
-      "Growth Region requires that Cyclus & Cycamore be compiled "
-      "with COIN support.");
+  throw cyclus::Error("Growth Region requires that Cyclus & Cycamore be compiled "
+                      "with COIN support.");
 #endif
 }
 
@@ -114,10 +117,10 @@ void GrowthRegion::Tick() {
     supply = sdmanager_.Supply(commod);
     unmetdemand = demand - supply;
 
-    LOG(cyclus::LEV_INFO3, "greg")
-        << "GrowthRegion: " << prototype() << " at time: " << time
-        << " has the following values regarding "
-        << " commodity: " << commod.name();
+    LOG(cyclus::LEV_INFO3, "greg") << "GrowthRegion: " << prototype()
+                                   << " at time: " << time
+                                   << " has the following values regarding "
+                                   << " commodity: " << commod.name();
     LOG(cyclus::LEV_INFO3, "greg") << "  * demand = " << demand;
     LOG(cyclus::LEV_INFO3, "greg") << "  * supply = " << supply;
     LOG(cyclus::LEV_INFO3, "greg") << "  * unmet demand = " << unmetdemand;
@@ -134,10 +137,11 @@ void GrowthRegion::OrderBuilds(cyclus::toolkit::Commodity& commodity,
 #if CYCLUS_HAS_COIN
   using std::vector;
   vector<cyclus::toolkit::BuildOrder> orders =
-      buildmanager_.MakeBuildDecision(commodity, unmetdemand);
+    buildmanager_.MakeBuildDecision(commodity, unmetdemand);
 
   LOG(cyclus::LEV_INFO3, "greg")
-      << "The build orders have been determined. " << orders.size()
+      << "The build orders have been determined. "
+      << orders.size()
       << " different type(s) of prototypes will be built.";
 
   cyclus::toolkit::BuildOrder* order;
@@ -148,15 +152,16 @@ void GrowthRegion::OrderBuilds(cyclus::toolkit::Commodity& commodity,
     instcast = dynamic_cast<cyclus::Institution*>(order->builder);
     agentcast = dynamic_cast<cyclus::Agent*>(order->producer);
     if (!instcast || !agentcast) {
-      throw cyclus::CastError(
-          "growth_region has tried to incorrectly "
-          "cast an already known entity.");
+      throw cyclus::CastError("growth_region has tried to incorrectly "
+                              "cast an already known entity.");
     }
 
     LOG(cyclus::LEV_INFO3, "greg")
-        << "A build order for " << order->number << " prototype(s) of type "
+        << "A build order for " << order->number
+        << " prototype(s) of type "
         << dynamic_cast<cyclus::Agent*>(agentcast)->prototype()
-        << " from builder " << instcast->prototype() << " is being placed.";
+        << " from builder " << instcast->prototype()
+        << " is being placed.";
 
     for (int j = 0; j < order->number; j++) {
       LOG(cyclus::LEV_DEBUG2, "greg") << "Ordering build number: " << j + 1;
@@ -164,9 +169,8 @@ void GrowthRegion::OrderBuilds(cyclus::toolkit::Commodity& commodity,
     }
   }
 #else
-  throw cyclus::Error(
-      "Growth Region requires that Cyclus & Cycamore be compiled "
-      "with COIN support.");
+  throw cyclus::Error("Growth Region requires that Cyclus & Cycamore be compiled "
+                      "with COIN support.");
 #endif
 }
 

--- a/src/growth_region.cc
+++ b/src/growth_region.cc
@@ -3,20 +3,17 @@
 
 namespace cycamore {
 
-GrowthRegion::GrowthRegion(cyclus::Context* ctx)
-    : cyclus::Region(ctx) {
-  #if !CYCLUS_HAS_COIN
-    throw cyclus::Error("Growth Region requires that Cyclus & Cycamore be compiled "
-                        "with COIN support.");
-  #endif
+GrowthRegion::GrowthRegion(cyclus::Context* ctx) : cyclus::Region(ctx) {
+#if !CYCLUS_HAS_COIN
+  throw cyclus::Error(
+      "Growth Region requires that Cyclus & Cycamore be compiled "
+      "with COIN support.");
+#endif
 }
 
 GrowthRegion::~GrowthRegion() {}
 
-void GrowthRegion::AddCommodityDemand_(std::string commod,
-                                       Demand& demand) {
-
-
+void GrowthRegion::AddCommodityDemand_(std::string commod, Demand& demand) {
   cyclus::toolkit::PiecewiseFunctionFactory pff;
   cyclus::toolkit::BasicFunctionFactory bff;
   bool continuous = false;
@@ -28,7 +25,7 @@ void GrowthRegion::AddCommodityDemand_(std::string commod,
     type = it->second.first;
     params = it->second.second;
     pff.AddFunction(bff.GetFunctionPtr(type, params), time, continuous);
-    continuous = true; // only the first entry is not continuous
+    continuous = true;  // only the first entry is not continuous
   }
 
   // register the commodity and demand
@@ -48,11 +45,11 @@ void GrowthRegion::EnterNotify() {
 
   std::map<std::string, Demand>::iterator it;
   for (it = commodity_demand.begin(); it != commodity_demand.end(); ++it) {
-    LOG(cyclus::LEV_INFO3, "greg") << "Adding demand for commodity "
-                                   << it->first;
+    LOG(cyclus::LEV_INFO3, "greg")
+        << "Adding demand for commodity " << it->first;
     AddCommodityDemand_(it->first, it->second);
   }
-  
+
   InitializePosition();
 }
 
@@ -61,46 +58,45 @@ void GrowthRegion::DecomNotify(Agent* a) {
 }
 
 void GrowthRegion::Register_(cyclus::Agent* agent) {
-  using cyclus::toolkit::CommodityProducerManager;
   using cyclus::toolkit::Builder;
+  using cyclus::toolkit::CommodityProducerManager;
 #if CYCLUS_HAS_COIN
   CommodityProducerManager* cpm_cast =
       dynamic_cast<CommodityProducerManager*>(agent);
   if (cpm_cast != NULL) {
-    LOG(cyclus::LEV_INFO3, "greg") << "Registering agent "
-                                   << agent->prototype() << agent->id()
-                                   << " as a commodity producer manager.";
+    LOG(cyclus::LEV_INFO3, "greg")
+        << "Registering agent " << agent->prototype() << agent->id()
+        << " as a commodity producer manager.";
     sdmanager_.RegisterProducerManager(cpm_cast);
   }
 
   Builder* b_cast = dynamic_cast<Builder*>(agent);
   if (b_cast != NULL) {
-    LOG(cyclus::LEV_INFO3, "greg") << "Registering agent "
-                                   << agent->prototype() << agent->id()
-                                   << " as a builder.";
+    LOG(cyclus::LEV_INFO3, "greg") << "Registering agent " << agent->prototype()
+                                   << agent->id() << " as a builder.";
     buildmanager_.Register(b_cast);
   }
 #else
-  throw cyclus::Error("Growth Region requires that Cyclus & Cycamore be compiled "
-                      "with COIN support.");
+  throw cyclus::Error(
+      "Growth Region requires that Cyclus & Cycamore be compiled "
+      "with COIN support.");
 #endif
 }
 
 void GrowthRegion::Unregister_(cyclus::Agent* agent) {
-  using cyclus::toolkit::CommodityProducerManager;
   using cyclus::toolkit::Builder;
+  using cyclus::toolkit::CommodityProducerManager;
 #if CYCLUS_HAS_COIN
   CommodityProducerManager* cpm_cast =
-    dynamic_cast<CommodityProducerManager*>(agent);
-  if (cpm_cast != NULL)
-    sdmanager_.UnregisterProducerManager(cpm_cast);
+      dynamic_cast<CommodityProducerManager*>(agent);
+  if (cpm_cast != NULL) sdmanager_.UnregisterProducerManager(cpm_cast);
 
   Builder* b_cast = dynamic_cast<Builder*>(agent);
-  if (b_cast != NULL)
-    buildmanager_.Unregister(b_cast);
+  if (b_cast != NULL) buildmanager_.Unregister(b_cast);
 #else
-  throw cyclus::Error("Growth Region requires that Cyclus & Cycamore be compiled "
-                      "with COIN support.");
+  throw cyclus::Error(
+      "Growth Region requires that Cyclus & Cycamore be compiled "
+      "with COIN support.");
 #endif
 }
 
@@ -115,10 +111,10 @@ void GrowthRegion::Tick() {
     supply = sdmanager_.Supply(commod);
     unmetdemand = demand - supply;
 
-    LOG(cyclus::LEV_INFO3, "greg") << "GrowthRegion: " << prototype()
-                                   << " at time: " << time
-                                   << " has the following values regarding "
-                                   << " commodity: " << commod.name();
+    LOG(cyclus::LEV_INFO3, "greg")
+        << "GrowthRegion: " << prototype() << " at time: " << time
+        << " has the following values regarding "
+        << " commodity: " << commod.name();
     LOG(cyclus::LEV_INFO3, "greg") << "  * demand = " << demand;
     LOG(cyclus::LEV_INFO3, "greg") << "  * supply = " << supply;
     LOG(cyclus::LEV_INFO3, "greg") << "  * unmet demand = " << unmetdemand;
@@ -135,11 +131,10 @@ void GrowthRegion::OrderBuilds(cyclus::toolkit::Commodity& commodity,
 #if CYCLUS_HAS_COIN
   using std::vector;
   vector<cyclus::toolkit::BuildOrder> orders =
-    buildmanager_.MakeBuildDecision(commodity, unmetdemand);
+      buildmanager_.MakeBuildDecision(commodity, unmetdemand);
 
   LOG(cyclus::LEV_INFO3, "greg")
-      << "The build orders have been determined. "
-      << orders.size()
+      << "The build orders have been determined. " << orders.size()
       << " different type(s) of prototypes will be built.";
 
   cyclus::toolkit::BuildOrder* order;
@@ -150,16 +145,15 @@ void GrowthRegion::OrderBuilds(cyclus::toolkit::Commodity& commodity,
     instcast = dynamic_cast<cyclus::Institution*>(order->builder);
     agentcast = dynamic_cast<cyclus::Agent*>(order->producer);
     if (!instcast || !agentcast) {
-      throw cyclus::CastError("growth_region has tried to incorrectly "
-                              "cast an already known entity.");
+      throw cyclus::CastError(
+          "growth_region has tried to incorrectly "
+          "cast an already known entity.");
     }
 
     LOG(cyclus::LEV_INFO3, "greg")
-        << "A build order for " << order->number
-        << " prototype(s) of type "
+        << "A build order for " << order->number << " prototype(s) of type "
         << dynamic_cast<cyclus::Agent*>(agentcast)->prototype()
-        << " from builder " << instcast->prototype()
-        << " is being placed.";
+        << " from builder " << instcast->prototype() << " is being placed.";
 
     for (int j = 0; j < order->number; j++) {
       LOG(cyclus::LEV_DEBUG2, "greg") << "Ordering build number: " << j + 1;
@@ -167,8 +161,9 @@ void GrowthRegion::OrderBuilds(cyclus::toolkit::Commodity& commodity,
     }
   }
 #else
-  throw cyclus::Error("Growth Region requires that Cyclus & Cycamore be compiled "
-                      "with COIN support.");
+  throw cyclus::Error(
+      "Growth Region requires that Cyclus & Cycamore be compiled "
+      "with COIN support.");
 #endif
 }
 

--- a/src/growth_region.h
+++ b/src/growth_region.h
@@ -31,7 +31,7 @@ typedef std::vector<
 /// @TODO In order to make GrowthRegion copacetic with init/restart, its input
 /// parameter space was simplified. For now it can only provide growth support
 /// for a single demanded commodity. A relatively simple next step will be to
-/// determin an input API and corresponding implementation that again supports
+/// determine an input API and corresponding implementation that again supports
 /// multiple commodities being demanded.
 ///
 /// @warning The growth region is experimental
@@ -49,8 +49,13 @@ class GrowthRegion : public cyclus::Region,
 
   #pragma cyclus
 
-  #pragma cyclus note {"doc": "A region that governs a scenario in which " \
-                              "there is growth in demand for a commodity. "}
+  // clang-format off
+  #pragma cyclus note { \
+    "doc": \
+      "A region that governs a scenario in which there is growth in demand " \
+      "for a commodity.", \
+  }
+  // clang-format on
 
   /// On each tick, the GrowthRegion queries its supply demand manager
   /// to determine if there exists some demand. If demand for a
@@ -70,39 +75,33 @@ class GrowthRegion : public cyclus::Region,
   }
 
  protected:
+  // clang-format off
   #pragma cyclus var { \
     "alias": ["growth", "commod", \
-              ["piecewise_function",                                    \
-               ["piece", "start", ["function", "type", "params"]]]],    \
+              ["piecewise_function", \
+               ["piece", "start", ["function", "type", "params"]]]], \
     "uitype": ["oneormore", "string", \
                ["oneormore", \
-                ["pair", "int", ["pair", "string", "string"]]]],      \
+                ["pair", "int", ["pair", "string", "string"]]]], \
     "uilabel": "Growth Demand Curves", \
-    "doc": "Nameplate capacity demand functions." \
-    "\n\n"                                       \
-    "Each demand type must be for a commodity for which capacity can be built "\
-    "(e.g., 'power' from cycamore::Reactors). Any archetype that implements the "\
-    "cyclus::toolkit::CommodityProducer interface can interact with the "\
-    "GrowthRegion in the manner."                                       \
-    "\n\n"                                       \
-    "Demand functions are defined as piecewise functions. Each piece must "\
-    "be provided a starting time and function description. Each function "\
-    "description is comprised of a function type and associated parameters. "\
-    "\n\n"                                       \
-    "  * Start times are inclusive. For a start time :math:`t_0`, the demand "\
-    "function is evaluated on :math:`[t_0, \infty)`."                     \
-    "\n\n"                                       \
-    "  * Supported function types are based on the "\
-    "`cyclus::toolkit::BasicFunctionFactory "\
-    "types <http://fuelcycle.org/cyclus/api/classcyclus_1_1toolkit_1_1BasicFunctionFactory.html#a2f3806305d99a745ab57c300e54a603d>`_. " \
-    "\n\n"                                       \
-    "  * The type name is the lower-case name of the function (e.g., " \
-    "'linear', 'exponential', etc.)." \
-    "\n\n"                                       \
-    "  * The parameters associated with each function type can be found on their " \
-    "respective documentation pages.",                                  \
+    "doc": \
+      "Nameplate capacity demand functions.\n\n" \
+      "Each demand type must be for a commodity for which capacity can be " \
+      "built (e.g., 'power' from cycamore::Reactors). Any archetype that " \
+      "implements the cyclus::toolkit::CommodityProducer interface can " \
+      "interact with GrowthRegion accordingly.\n\n" \
+      "Demand functions are defined as piecewise functions. Each piece must " \
+      "include a starting time and a function description consisting of a " \
+      "function type and associated parameters.\n\n" \
+      "  * Start times are inclusive: for start time t0, the function is " \
+      "evaluated on [t0, ∞).\n\n" \
+      "  * Supported function types are defined by the " \
+      "cyclus::toolkit::BasicFunctionFactory.\n\n" \
+      "  * Function type names are lower-case (e.g., 'linear', 'exponential').\n\n" \
+      "  * Parameters for each function type are in their respective docs." \
   }
-  std::map<std::string, std::vector<std::pair<int, std::pair<std::string, std::string> > > > commodity_demand; // must match Demand typedef
+std::map<std::string, std::vector<std::pair<int, std::pair<std::string, std::string> > > > commodity_demand;
+  // clang-format on
 
 #if CYCLUS_HAS_COIN
   /// manager for building things
@@ -118,7 +117,7 @@ class GrowthRegion : public cyclus::Region,
   /// unregister a child
   void Unregister_(cyclus::Agent* agent);
 
-  /// add a demand for a commodity on which this region request that
+  /// add a demand for a commodity on which this region requests that
   /// facilities be built
   void AddCommodityDemand_(std::string commod, Demand& demand);
 
@@ -126,30 +125,36 @@ class GrowthRegion : public cyclus::Region,
   /// capacity of that commodity
   /// @param commodity the commodity being demanded
   /// @param unmetdemand the unmet demand
-  void OrderBuilds(cyclus::toolkit::Commodity& commodity, double unmetdemand);
+  void OrderBuilds(cyclus::toolkit::Commodity& commodity,
+                   double unmetdemand);
 
-  private:
+ private:
+  // clang-format off
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
+    "doc": \
+      "Latitude of the agent's geographical position. The value should be " \
+      "expressed in degrees as a double." \
   }
   double latitude;
 
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
+    "doc": \
+      "Longitude of the agent's geographical position. The value should be " \
+      "expressed in degrees as a double." \
   }
   double longitude;
+  // clang-format on
 
   cyclus::toolkit::Position coordinates;
 
   /// Records an agent's latitude and longitude to the output db
   void RecordPosition();
 };
+
 }  // namespace cycamore
 
 #endif  // CYCAMORE_SRC_GROWTH_REGION_H_

--- a/src/growth_region.h
+++ b/src/growth_region.h
@@ -5,8 +5,8 @@
 #include <utility>
 #include <vector>
 
-#include "cycamore_version.h"
 #include "cyclus.h"
+#include "cycamore_version.h"
 
 // forward declarations
 namespace cycamore {
@@ -19,7 +19,8 @@ class GrowthRegion;
 namespace cycamore {
 
 /// A container of (time, (demand type, demand parameters))
-typedef std::vector<std::pair<int, std::pair<std::string, std::string>>> Demand;
+typedef std::vector<
+  std::pair<int, std::pair<std::string, std::string> > > Demand;
 
 /// This region determines if there is a need to meet a certain
 /// capacity (as defined via input) at each time step. If there is
@@ -34,9 +35,9 @@ typedef std::vector<std::pair<int, std::pair<std::string, std::string>>> Demand;
 /// multiple commodities being demanded.
 ///
 /// @warning The growth region is experimental
-class GrowthRegion : public cyclus::Region, public cyclus::toolkit::Position {
+class GrowthRegion : public cyclus::Region,
+  public cyclus::toolkit::Position {
   friend class GrowthRegionTests;
-
  public:
   /// The default constructor for the GrowthRegion
   GrowthRegion(cyclus::Context* ctx);
@@ -46,7 +47,7 @@ class GrowthRegion : public cyclus::Region, public cyclus::toolkit::Position {
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-#pragma cyclus
+  #pragma cyclus
 
   // clang-format off
   #pragma cyclus note { \
@@ -124,7 +125,8 @@ std::map<std::string, std::vector<std::pair<int, std::pair<std::string, std::str
   /// capacity of that commodity
   /// @param commodity the commodity being demanded
   /// @param unmetdemand the unmet demand
-  void OrderBuilds(cyclus::toolkit::Commodity& commodity, double unmetdemand);
+  void OrderBuilds(cyclus::toolkit::Commodity& commodity,
+                   double unmetdemand);
 
  private:
   // clang-format off

--- a/src/growth_region.h
+++ b/src/growth_region.h
@@ -5,8 +5,8 @@
 #include <utility>
 #include <vector>
 
-#include "cyclus.h"
 #include "cycamore_version.h"
+#include "cyclus.h"
 
 // forward declarations
 namespace cycamore {
@@ -19,8 +19,7 @@ class GrowthRegion;
 namespace cycamore {
 
 /// A container of (time, (demand type, demand parameters))
-typedef std::vector<
-  std::pair<int, std::pair<std::string, std::string> > > Demand;
+typedef std::vector<std::pair<int, std::pair<std::string, std::string>>> Demand;
 
 /// This region determines if there is a need to meet a certain
 /// capacity (as defined via input) at each time step. If there is
@@ -35,9 +34,9 @@ typedef std::vector<
 /// multiple commodities being demanded.
 ///
 /// @warning The growth region is experimental
-class GrowthRegion : public cyclus::Region,
-  public cyclus::toolkit::Position {
+class GrowthRegion : public cyclus::Region, public cyclus::toolkit::Position {
   friend class GrowthRegionTests;
+
  public:
   /// The default constructor for the GrowthRegion
   GrowthRegion(cyclus::Context* ctx);
@@ -47,7 +46,7 @@ class GrowthRegion : public cyclus::Region,
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-  #pragma cyclus
+#pragma cyclus
 
   // clang-format off
   #pragma cyclus note { \
@@ -125,8 +124,7 @@ std::map<std::string, std::vector<std::pair<int, std::pair<std::string, std::str
   /// capacity of that commodity
   /// @param commodity the commodity being demanded
   /// @param unmetdemand the unmet demand
-  void OrderBuilds(cyclus::toolkit::Commodity& commodity,
-                   double unmetdemand);
+  void OrderBuilds(cyclus::toolkit::Commodity& commodity, double unmetdemand);
 
  private:
   // clang-format off

--- a/src/growth_region.h
+++ b/src/growth_region.h
@@ -108,7 +108,7 @@ class GrowthRegion : public cyclus::Region,
     "  * The parameters associated with each function type can be found on their " \
     "respective documentation pages.",                                  \
   }
-std::map<std::string, std::vector<std::pair<int, std::pair<std::string, std::string> > > > commodity_demand;
+  std::map<std::string, std::vector<std::pair<int, std::pair<std::string, std::string> > > > commodity_demand;  // must match Demand typedef
   // clang-format on
 
 #if CYCLUS_HAS_COIN

--- a/src/growth_region.h
+++ b/src/growth_region.h
@@ -60,7 +60,6 @@ class GrowthRegion : public cyclus::Region, public cyclus::toolkit::Position {
   /// to determine if there exists some demand. If demand for a
   /// commodity exists, then the correct build order for that demand
   /// is constructed and executed.
-  /// @param time is the time to perform the tick
   virtual void Tick();
 
   /// enter the simulation and register any children present

--- a/src/growth_region.h
+++ b/src/growth_region.h
@@ -19,8 +19,7 @@ class GrowthRegion;
 namespace cycamore {
 
 /// A container of (time, (demand type, demand parameters))
-typedef std::vector<
-  std::pair<int, std::pair<std::string, std::string> > > Demand;
+typedef std::vector<std::pair<int, std::pair<std::string, std::string>>> Demand;
 
 /// This region determines if there is a need to meet a certain
 /// capacity (as defined via input) at each time step. If there is
@@ -35,9 +34,9 @@ typedef std::vector<
 /// multiple commodities being demanded.
 ///
 /// @warning The growth region is experimental
-class GrowthRegion : public cyclus::Region,
-  public cyclus::toolkit::Position {
+class GrowthRegion : public cyclus::Region, public cyclus::toolkit::Position {
   friend class GrowthRegionTests;
+
  public:
   /// The default constructor for the GrowthRegion
   GrowthRegion(cyclus::Context* ctx);
@@ -47,7 +46,7 @@ class GrowthRegion : public cyclus::Region,
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-  #pragma cyclus
+#pragma cyclus
 
   // clang-format off
   #pragma cyclus note { \
@@ -133,13 +132,11 @@ class GrowthRegion : public cyclus::Region,
   /// capacity of that commodity
   /// @param commodity the commodity being demanded
   /// @param unmetdemand the unmet demand
-  void OrderBuilds(cyclus::toolkit::Commodity& commodity,
-                   double unmetdemand);
+  void OrderBuilds(cyclus::toolkit::Commodity& commodity, double unmetdemand);
 
-  private:
-  // Code Injection:
-  #include "toolkit/position.cycpp.h"
-
+ private:
+// Code Injection:
+#include "toolkit/position.cycpp.h"
 };
 
 }  // namespace cycamore

--- a/src/growth_region_tests.cc
+++ b/src/growth_region_tests.cc
@@ -1,6 +1,6 @@
-#include "growth_region_tests.h"
-
 #include <sstream>
+
+#include "growth_region_tests.h"
 #if CYCLUS_HAS_COIN
 
 namespace cycamore {
@@ -22,8 +22,7 @@ void GrowthRegionTests::TearDown() {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-bool GrowthRegionTests::ManagesCommodity(
-    cyclus::toolkit::Commodity& commodity) {
+bool GrowthRegionTests::ManagesCommodity(cyclus::toolkit::Commodity& commodity) {
   return region->sdmanager()->ManagesCommodity(commodity);
 }
 
@@ -31,8 +30,7 @@ bool GrowthRegionTests::ManagesCommodity(
 TEST_F(GrowthRegionTests, init) {
   cyclus::toolkit::Commodity commodity(commodity_name);
   cyclus::toolkit::ExpFunctionFactory eff;
-  region->sdmanager()->RegisterCommodity(commodity,
-                                         eff.GetFunctionPtr("2.0 4.0"));
+  region->sdmanager()->RegisterCommodity(commodity, eff.GetFunctionPtr("2.0 4.0"));
   EXPECT_TRUE(ManagesCommodity(commodity));
 }
 
@@ -52,7 +50,7 @@ static int cyclus_agent_tests_connected = ConnectAgentTests();
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_SUITE_P(GrowthRegion, RegionTests,
-                         Values(&GrowthRegionConstructor));
+                        Values(&GrowthRegionConstructor));
 INSTANTIATE_TEST_SUITE_P(GrowthRegion, AgentTests,
-                         Values(&GrowthRegionConstructor));
+                        Values(&GrowthRegionConstructor));
 #endif  // CYCLUS_HAS_COIN

--- a/src/growth_region_tests.cc
+++ b/src/growth_region_tests.cc
@@ -1,6 +1,6 @@
-#include <sstream>
-
 #include "growth_region_tests.h"
+
+#include <sstream>
 #if CYCLUS_HAS_COIN
 
 namespace cycamore {
@@ -22,7 +22,8 @@ void GrowthRegionTests::TearDown() {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-bool GrowthRegionTests::ManagesCommodity(cyclus::toolkit::Commodity& commodity) {
+bool GrowthRegionTests::ManagesCommodity(
+    cyclus::toolkit::Commodity& commodity) {
   return region->sdmanager()->ManagesCommodity(commodity);
 }
 
@@ -30,7 +31,8 @@ bool GrowthRegionTests::ManagesCommodity(cyclus::toolkit::Commodity& commodity) 
 TEST_F(GrowthRegionTests, init) {
   cyclus::toolkit::Commodity commodity(commodity_name);
   cyclus::toolkit::ExpFunctionFactory eff;
-  region->sdmanager()->RegisterCommodity(commodity, eff.GetFunctionPtr("2.0 4.0"));
+  region->sdmanager()->RegisterCommodity(commodity,
+                                         eff.GetFunctionPtr("2.0 4.0"));
   EXPECT_TRUE(ManagesCommodity(commodity));
 }
 
@@ -50,7 +52,7 @@ static int cyclus_agent_tests_connected = ConnectAgentTests();
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_SUITE_P(GrowthRegion, RegionTests,
-                        Values(&GrowthRegionConstructor));
+                         Values(&GrowthRegionConstructor));
 INSTANTIATE_TEST_SUITE_P(GrowthRegion, AgentTests,
-                        Values(&GrowthRegionConstructor));
+                         Values(&GrowthRegionConstructor));
 #endif  // CYCLUS_HAS_COIN

--- a/src/growth_region_tests.cc
+++ b/src/growth_region_tests.cc
@@ -22,7 +22,8 @@ void GrowthRegionTests::TearDown() {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-bool GrowthRegionTests::ManagesCommodity(cyclus::toolkit::Commodity& commodity) {
+bool GrowthRegionTests::ManagesCommodity(
+    cyclus::toolkit::Commodity& commodity) {
   return region->sdmanager()->ManagesCommodity(commodity);
 }
 
@@ -30,7 +31,8 @@ bool GrowthRegionTests::ManagesCommodity(cyclus::toolkit::Commodity& commodity) 
 TEST_F(GrowthRegionTests, init) {
   cyclus::toolkit::Commodity commodity(commodity_name);
   cyclus::toolkit::ExpFunctionFactory eff;
-  region->sdmanager()->RegisterCommodity(commodity, eff.GetFunctionPtr("2.0 4.0"));
+  region->sdmanager()->RegisterCommodity(commodity,
+                                         eff.GetFunctionPtr("2.0 4.0"));
   EXPECT_TRUE(ManagesCommodity(commodity));
 }
 
@@ -50,7 +52,7 @@ static int cyclus_agent_tests_connected = ConnectAgentTests();
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_SUITE_P(GrowthRegion, RegionTests,
-                        Values(&GrowthRegionConstructor));
+                         Values(&GrowthRegionConstructor));
 INSTANTIATE_TEST_SUITE_P(GrowthRegion, AgentTests,
-                        Values(&GrowthRegionConstructor));
+                         Values(&GrowthRegionConstructor));
 #endif  // CYCLUS_HAS_COIN

--- a/src/growth_region_tests.h
+++ b/src/growth_region_tests.h
@@ -5,15 +5,13 @@
 
 #include <gtest/gtest.h>
 
+#include "agent_tests.h"
 #include "context.h"
 #include "growth_region.h"
 #include "recorder.h"
-#include "timer.h"
-
-#include "test_context.h"
 #include "region_tests.h"
-#include "agent_tests.h"
-
+#include "test_context.h"
+#include "timer.h"
 
 namespace cycamore {
 

--- a/src/growth_region_tests.h
+++ b/src/growth_region_tests.h
@@ -5,13 +5,15 @@
 
 #include <gtest/gtest.h>
 
-#include "agent_tests.h"
 #include "context.h"
 #include "growth_region.h"
 #include "recorder.h"
-#include "region_tests.h"
-#include "test_context.h"
 #include "timer.h"
+
+#include "test_context.h"
+#include "region_tests.h"
+#include "agent_tests.h"
+
 
 namespace cycamore {
 

--- a/src/growth_region_tests.h
+++ b/src/growth_region_tests.h
@@ -14,7 +14,6 @@
 #include "region_tests.h"
 #include "agent_tests.h"
 
-
 namespace cycamore {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/manager_inst.cc
+++ b/src/manager_inst.cc
@@ -5,10 +5,10 @@ namespace cycamore {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ManagerInst::ManagerInst(cyclus::Context* ctx)
-      : cyclus::Institution(ctx),
-        latitude(0.0),
-        longitude(0.0),
-        coordinates(latitude, longitude) {}
+    : cyclus::Institution(ctx),
+      latitude(0.0),
+      longitude(0.0),
+      coordinates(latitude, longitude) {}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ManagerInst::~ManagerInst() {}
@@ -37,9 +37,9 @@ void ManagerInst::EnterNotify() {
     Agent* a = context()->CreateAgent<Agent>(*vit);
     CommodityProducer* cp_cast = dynamic_cast<CommodityProducer*>(a);
     if (cp_cast != NULL) {
-      LOG(cyclus::LEV_INFO3, "mani") << "Registering prototype "
-                                     << a->prototype() << a->id()
-                                     << " with the Builder interface.";
+      LOG(cyclus::LEV_INFO3, "mani")
+          << "Registering prototype " << a->prototype() << a->id()
+          << " with the Builder interface.";
       Builder::Register(cp_cast);
     }
   }
@@ -52,9 +52,8 @@ void ManagerInst::Register_(Agent* a) {
 
   CommodityProducer* cp_cast = dynamic_cast<CommodityProducer*>(a);
   if (cp_cast != NULL) {
-    LOG(cyclus::LEV_INFO3, "mani") << "Registering agent "
-                                   << a->prototype() << a->id()
-                                   << " as a commodity producer.";
+    LOG(cyclus::LEV_INFO3, "mani") << "Registering agent " << a->prototype()
+                                   << a->id() << " as a commodity producer.";
     CommodityProducerManager::Register(cp_cast);
   }
 }
@@ -64,28 +63,26 @@ void ManagerInst::Unregister_(Agent* a) {
   using cyclus::toolkit::CommodityProducerManager;
 
   CommodityProducer* cp_cast = dynamic_cast<CommodityProducer*>(a);
-  if (cp_cast != NULL)
-    CommodityProducerManager::Unregister(cp_cast);
+  if (cp_cast != NULL) CommodityProducerManager::Unregister(cp_cast);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void ManagerInst::WriteProducerInformation(
-  cyclus::toolkit::CommodityProducer* producer) {
+    cyclus::toolkit::CommodityProducer* producer) {
   using std::set;
-  set<cyclus::toolkit::Commodity,
-      cyclus::toolkit::CommodityCompare> commodities =
-          producer->ProducedCommodities();
-  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>::
-      iterator it;
+  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>
+      commodities = producer->ProducedCommodities();
+  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>::iterator
+      it;
 
-  LOG(cyclus::LEV_DEBUG3, "maninst") << " Clone produces " << commodities.size()
-                                     << " commodities.";
+  LOG(cyclus::LEV_DEBUG3, "maninst")
+      << " Clone produces " << commodities.size() << " commodities.";
   for (it = commodities.begin(); it != commodities.end(); it++) {
     LOG(cyclus::LEV_DEBUG3, "maninst") << " Commodity produced: " << it->name();
-    LOG(cyclus::LEV_DEBUG3, "maninst") << "           capacity: " <<
-                                       producer->Capacity(*it);
-    LOG(cyclus::LEV_DEBUG3, "maninst") << "               cost: " <<
-                                       producer->Cost(*it);
+    LOG(cyclus::LEV_DEBUG3, "maninst")
+        << "           capacity: " << producer->Capacity(*it);
+    LOG(cyclus::LEV_DEBUG3, "maninst")
+        << "               cost: " << producer->Cost(*it);
   }
 }
 

--- a/src/manager_inst.cc
+++ b/src/manager_inst.cc
@@ -5,10 +5,10 @@ namespace cycamore {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ManagerInst::ManagerInst(cyclus::Context* ctx)
-    : cyclus::Institution(ctx),
-      latitude(0.0),
-      longitude(0.0),
-      coordinates(latitude, longitude) {}
+      : cyclus::Institution(ctx),
+        latitude(0.0),
+        longitude(0.0),
+        coordinates(latitude, longitude) {}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ManagerInst::~ManagerInst() {}
@@ -37,9 +37,9 @@ void ManagerInst::EnterNotify() {
     Agent* a = context()->CreateAgent<Agent>(*vit);
     CommodityProducer* cp_cast = dynamic_cast<CommodityProducer*>(a);
     if (cp_cast != NULL) {
-      LOG(cyclus::LEV_INFO3, "mani")
-          << "Registering prototype " << a->prototype() << a->id()
-          << " with the Builder interface.";
+      LOG(cyclus::LEV_INFO3, "mani") << "Registering prototype "
+                                     << a->prototype() << a->id()
+                                     << " with the Builder interface.";
       Builder::Register(cp_cast);
     }
   }
@@ -52,8 +52,9 @@ void ManagerInst::Register_(Agent* a) {
 
   CommodityProducer* cp_cast = dynamic_cast<CommodityProducer*>(a);
   if (cp_cast != NULL) {
-    LOG(cyclus::LEV_INFO3, "mani") << "Registering agent " << a->prototype()
-                                   << a->id() << " as a commodity producer.";
+    LOG(cyclus::LEV_INFO3, "mani") << "Registering agent "
+                                   << a->prototype() << a->id()
+                                   << " as a commodity producer.";
     CommodityProducerManager::Register(cp_cast);
   }
 }
@@ -63,26 +64,28 @@ void ManagerInst::Unregister_(Agent* a) {
   using cyclus::toolkit::CommodityProducerManager;
 
   CommodityProducer* cp_cast = dynamic_cast<CommodityProducer*>(a);
-  if (cp_cast != NULL) CommodityProducerManager::Unregister(cp_cast);
+  if (cp_cast != NULL)
+    CommodityProducerManager::Unregister(cp_cast);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void ManagerInst::WriteProducerInformation(
-    cyclus::toolkit::CommodityProducer* producer) {
+  cyclus::toolkit::CommodityProducer* producer) {
   using std::set;
-  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>
-      commodities = producer->ProducedCommodities();
-  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>::iterator
-      it;
+  set<cyclus::toolkit::Commodity,
+      cyclus::toolkit::CommodityCompare> commodities =
+          producer->ProducedCommodities();
+  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>::
+      iterator it;
 
-  LOG(cyclus::LEV_DEBUG3, "maninst")
-      << " Clone produces " << commodities.size() << " commodities.";
+  LOG(cyclus::LEV_DEBUG3, "maninst") << " Clone produces " << commodities.size()
+                                     << " commodities.";
   for (it = commodities.begin(); it != commodities.end(); it++) {
     LOG(cyclus::LEV_DEBUG3, "maninst") << " Commodity produced: " << it->name();
-    LOG(cyclus::LEV_DEBUG3, "maninst")
-        << "           capacity: " << producer->Capacity(*it);
-    LOG(cyclus::LEV_DEBUG3, "maninst")
-        << "               cost: " << producer->Cost(*it);
+    LOG(cyclus::LEV_DEBUG3, "maninst") << "           capacity: " <<
+                                       producer->Capacity(*it);
+    LOG(cyclus::LEV_DEBUG3, "maninst") << "               cost: " <<
+                                       producer->Cost(*it);
   }
 }
 

--- a/src/manager_inst.cc
+++ b/src/manager_inst.cc
@@ -4,8 +4,7 @@
 namespace cycamore {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-ManagerInst::ManagerInst(cyclus::Context* ctx)
-      : cyclus::Institution(ctx) {}
+ManagerInst::ManagerInst(cyclus::Context* ctx) : cyclus::Institution(ctx) {}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ManagerInst::~ManagerInst() {}
@@ -34,9 +33,9 @@ void ManagerInst::EnterNotify() {
     Agent* a = context()->CreateAgent<Agent>(*vit);
     CommodityProducer* cp_cast = dynamic_cast<CommodityProducer*>(a);
     if (cp_cast != NULL) {
-      LOG(cyclus::LEV_INFO3, "mani") << "Registering prototype "
-                                     << a->prototype() << a->id()
-                                     << " with the Builder interface.";
+      LOG(cyclus::LEV_INFO3, "mani")
+          << "Registering prototype " << a->prototype() << a->id()
+          << " with the Builder interface.";
       Builder::Register(cp_cast);
     }
   }
@@ -50,9 +49,8 @@ void ManagerInst::Register_(Agent* a) {
 
   CommodityProducer* cp_cast = dynamic_cast<CommodityProducer*>(a);
   if (cp_cast != NULL) {
-    LOG(cyclus::LEV_INFO3, "mani") << "Registering agent "
-                                   << a->prototype() << a->id()
-                                   << " as a commodity producer.";
+    LOG(cyclus::LEV_INFO3, "mani") << "Registering agent " << a->prototype()
+                                   << a->id() << " as a commodity producer.";
     CommodityProducerManager::Register(cp_cast);
   }
 }
@@ -62,28 +60,26 @@ void ManagerInst::Unregister_(Agent* a) {
   using cyclus::toolkit::CommodityProducerManager;
 
   CommodityProducer* cp_cast = dynamic_cast<CommodityProducer*>(a);
-  if (cp_cast != NULL)
-    CommodityProducerManager::Unregister(cp_cast);
+  if (cp_cast != NULL) CommodityProducerManager::Unregister(cp_cast);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void ManagerInst::WriteProducerInformation(
-  cyclus::toolkit::CommodityProducer* producer) {
+    cyclus::toolkit::CommodityProducer* producer) {
   using std::set;
-  set<cyclus::toolkit::Commodity,
-      cyclus::toolkit::CommodityCompare> commodities =
-          producer->ProducedCommodities();
-  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>::
-      iterator it;
+  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>
+      commodities = producer->ProducedCommodities();
+  set<cyclus::toolkit::Commodity, cyclus::toolkit::CommodityCompare>::iterator
+      it;
 
-  LOG(cyclus::LEV_DEBUG3, "maninst") << " Clone produces " << commodities.size()
-                                     << " commodities.";
+  LOG(cyclus::LEV_DEBUG3, "maninst")
+      << " Clone produces " << commodities.size() << " commodities.";
   for (it = commodities.begin(); it != commodities.end(); it++) {
     LOG(cyclus::LEV_DEBUG3, "maninst") << " Commodity produced: " << it->name();
-    LOG(cyclus::LEV_DEBUG3, "maninst") << "           capacity: " <<
-                                       producer->Capacity(*it);
-    LOG(cyclus::LEV_DEBUG3, "maninst") << "               cost: " <<
-                                       producer->Cost(*it);
+    LOG(cyclus::LEV_DEBUG3, "maninst")
+        << "           capacity: " << producer->Capacity(*it);
+    LOG(cyclus::LEV_DEBUG3, "maninst")
+        << "               cost: " << producer->Cost(*it);
   }
 }
 

--- a/src/manager_inst.h
+++ b/src/manager_inst.h
@@ -26,9 +26,12 @@ class ManagerInst
 
   #pragma cyclus
 
-  #pragma cyclus note {"doc": "An institution that owns and operates a " \
-                              "manually entered list of facilities in " \
-                              "the input file"}
+  // clang-format off
+  #pragma cyclus note { \
+    "doc": "An institution that owns and operates a manually entered list " \
+           "of facilities in the input file", \
+  }
+  // clang-format on
 
   /// enter the simulation and register any children present
   virtual void EnterNotify();
@@ -44,38 +47,40 @@ class ManagerInst
   void WriteProducerInformation(cyclus::toolkit::CommodityProducer*
                                 producer);
 
-  private:
+ private:
   /// register a child
   void Register_(cyclus::Agent* agent);
 
   /// unregister a child
   void Unregister_(cyclus::Agent* agent);
- 
+
+  // clang-format off
   #pragma cyclus var { \
-    "tooltip": "producer facility prototypes",                          \
-    "uilabel": "Producer Prototype List",                               \
-    "uitype": ["oneormore", "prototype"],                                    \
+    "tooltip": "producer facility prototypes", \
+    "uilabel": "Producer Prototype List", \
+    "uitype": ["oneormore", "prototype"], \
     "doc": "A set of facility prototypes that this institution can build. " \
-    "All prototypes in this list must be based on an archetype that "   \
-    "implements the cyclus::toolkit::CommodityProducer interface",      \
-    }
+           "All prototypes in this list must be based on an archetype that " \
+           "implements the cyclus::toolkit::CommodityProducer interface" \
+  }
   std::vector<std::string> prototypes;
 
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
+    "doc": "Latitude of the agent's geographical position. The value " \
+           "should be expressed in degrees as a double." \
   }
   double latitude;
 
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
+    "doc": "Longitude of the agent's geographical position. The value " \
+           "should be expressed in degrees as a double." \
   }
   double longitude;
+  // clang-format on
 
   cyclus::toolkit::Position coordinates;
 

--- a/src/manager_inst.h
+++ b/src/manager_inst.h
@@ -1,8 +1,8 @@
 #ifndef CYCAMORE_SRC_MANAGER_INST_H_
 #define CYCAMORE_SRC_MANAGER_INST_H_
 
-#include "cyclus.h"
 #include "cycamore_version.h"
+#include "cyclus.h"
 
 namespace cycamore {
 
@@ -10,11 +10,10 @@ namespace cycamore {
 /// @section introduction Introduction
 /// @section detailedBehavior Detailed Behavior
 /// @warning The ManagerInst is experimental
-class ManagerInst
-    : public cyclus::Institution,
-      public cyclus::toolkit::CommodityProducerManager,
-      public cyclus::toolkit::Builder,
-      public cyclus::toolkit::Position {
+class ManagerInst : public cyclus::Institution,
+                    public cyclus::toolkit::CommodityProducerManager,
+                    public cyclus::toolkit::Builder,
+                    public cyclus::toolkit::Position {
  public:
   /// Default constructor
   ManagerInst(cyclus::Context* ctx);
@@ -24,7 +23,7 @@ class ManagerInst
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-  #pragma cyclus
+#pragma cyclus
 
   // clang-format off
   #pragma cyclus note { \
@@ -44,8 +43,7 @@ class ManagerInst
 
   /// write information about a commodity producer to a stream
   /// @param producer the producer
-  void WriteProducerInformation(cyclus::toolkit::CommodityProducer*
-                                producer);
+  void WriteProducerInformation(cyclus::toolkit::CommodityProducer* producer);
 
  private:
   /// register a child

--- a/src/manager_inst.h
+++ b/src/manager_inst.h
@@ -1,8 +1,8 @@
 #ifndef CYCAMORE_SRC_MANAGER_INST_H_
 #define CYCAMORE_SRC_MANAGER_INST_H_
 
-#include "cycamore_version.h"
 #include "cyclus.h"
+#include "cycamore_version.h"
 
 namespace cycamore {
 
@@ -10,10 +10,11 @@ namespace cycamore {
 /// @section introduction Introduction
 /// @section detailedBehavior Detailed Behavior
 /// @warning The ManagerInst is experimental
-class ManagerInst : public cyclus::Institution,
-                    public cyclus::toolkit::CommodityProducerManager,
-                    public cyclus::toolkit::Builder,
-                    public cyclus::toolkit::Position {
+class ManagerInst
+    : public cyclus::Institution,
+      public cyclus::toolkit::CommodityProducerManager,
+      public cyclus::toolkit::Builder,
+      public cyclus::toolkit::Position {
  public:
   /// Default constructor
   ManagerInst(cyclus::Context* ctx);
@@ -23,7 +24,7 @@ class ManagerInst : public cyclus::Institution,
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-#pragma cyclus
+  #pragma cyclus
 
   // clang-format off
   #pragma cyclus note { \
@@ -43,7 +44,8 @@ class ManagerInst : public cyclus::Institution,
 
   /// write information about a commodity producer to a stream
   /// @param producer the producer
-  void WriteProducerInformation(cyclus::toolkit::CommodityProducer* producer);
+  void WriteProducerInformation(cyclus::toolkit::CommodityProducer*
+                                producer);
 
  private:
   /// register a child

--- a/src/manager_inst.h
+++ b/src/manager_inst.h
@@ -10,11 +10,10 @@ namespace cycamore {
 /// @section introduction Introduction
 /// @section detailedBehavior Detailed Behavior
 /// @warning The ManagerInst is experimental
-class ManagerInst
-    : public cyclus::Institution,
-      public cyclus::toolkit::CommodityProducerManager,
-      public cyclus::toolkit::Builder,
-      public cyclus::toolkit::Position {
+class ManagerInst : public cyclus::Institution,
+                    public cyclus::toolkit::CommodityProducerManager,
+                    public cyclus::toolkit::Builder,
+                    public cyclus::toolkit::Position {
  public:
   /// Default constructor
   ManagerInst(cyclus::Context* ctx);
@@ -24,7 +23,7 @@ class ManagerInst
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-  #pragma cyclus
+#pragma cyclus
 
   // clang-format off
   #pragma cyclus note { \
@@ -44,12 +43,11 @@ class ManagerInst
 
   /// write information about a commodity producer to a stream
   /// @param producer the producer
-  void WriteProducerInformation(cyclus::toolkit::CommodityProducer*
-                                producer);
+  void WriteProducerInformation(cyclus::toolkit::CommodityProducer* producer);
 
-  private:
-  // Code Injection:
-  #include "toolkit/position.cycpp.h"
+ private:
+// Code Injection:
+#include "toolkit/position.cycpp.h"
 
   /// register a child
   void Register_(cyclus::Agent* agent);

--- a/src/manager_inst_tests.cc
+++ b/src/manager_inst_tests.cc
@@ -33,10 +33,10 @@ TEST_F(ManagerInstTests, producerexists) {
   using std::set;
   ctx_->AddPrototype("foop", producer);
   set<cyclus::toolkit::CommodityProducer*>::iterator it;
-  for (it = src_inst->cyclus::toolkit::CommodityProducerManager::
-          producers().begin();
-       it != src_inst->cyclus::toolkit::CommodityProducerManager::
-          producers().end();
+  for (it = src_inst->cyclus::toolkit::CommodityProducerManager::producers()
+                .begin();
+       it !=
+       src_inst->cyclus::toolkit::CommodityProducerManager::producers().end();
        it++) {
     EXPECT_EQ(dynamic_cast<TestProducer*>(*it)->prototype(),
               producer->prototype());
@@ -61,6 +61,6 @@ static int cyclus_agent_tests_connected = ConnectAgentTests();
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_SUITE_P(ManagerInst, InstitutionTests,
-                        Values(&ManagerInstitutionConstructor));
+                         Values(&ManagerInstitutionConstructor));
 INSTANTIATE_TEST_SUITE_P(ManagerInst, AgentTests,
-                        Values(&ManagerInstitutionConstructor));
+                         Values(&ManagerInstitutionConstructor));

--- a/src/manager_inst_tests.cc
+++ b/src/manager_inst_tests.cc
@@ -33,10 +33,10 @@ TEST_F(ManagerInstTests, producerexists) {
   using std::set;
   ctx_->AddPrototype("foop", producer);
   set<cyclus::toolkit::CommodityProducer*>::iterator it;
-  for (it = src_inst->cyclus::toolkit::CommodityProducerManager::producers()
-                .begin();
-       it !=
-       src_inst->cyclus::toolkit::CommodityProducerManager::producers().end();
+  for (it = src_inst->cyclus::toolkit::CommodityProducerManager::
+          producers().begin();
+       it != src_inst->cyclus::toolkit::CommodityProducerManager::
+          producers().end();
        it++) {
     EXPECT_EQ(dynamic_cast<TestProducer*>(*it)->prototype(),
               producer->prototype());
@@ -61,6 +61,6 @@ static int cyclus_agent_tests_connected = ConnectAgentTests();
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_SUITE_P(ManagerInst, InstitutionTests,
-                         Values(&ManagerInstitutionConstructor));
+                        Values(&ManagerInstitutionConstructor));
 INSTANTIATE_TEST_SUITE_P(ManagerInst, AgentTests,
-                         Values(&ManagerInstitutionConstructor));
+                        Values(&ManagerInstitutionConstructor));

--- a/src/manager_inst_tests.h
+++ b/src/manager_inst_tests.h
@@ -3,19 +3,16 @@
 
 #include <gtest/gtest.h>
 
-#include "cyclus.h"
-#include "timer.h"
-#include "test_context.h"
-#include "institution_tests.h"
 #include "agent_tests.h"
-
+#include "cyclus.h"
+#include "institution_tests.h"
 #include "manager_inst.h"
-
+#include "test_context.h"
+#include "timer.h"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-class TestProducer
-    : public cyclus::Facility,
-      public cyclus::toolkit::CommodityProducer {
+class TestProducer : public cyclus::Facility,
+                     public cyclus::toolkit::CommodityProducer {
  public:
   TestProducer(cyclus::Context* ctx);
   ~TestProducer();
@@ -26,9 +23,7 @@ class TestProducer
     return m;
   }
 
-  void InitFrom(TestProducer* m) {
-    cyclus::Facility::InitFrom(m);
-  }
+  void InitFrom(TestProducer* m) { cyclus::Facility::InitFrom(m); }
 
   void InitInv(cyclus::Inventories& inv) {}
 

--- a/src/manager_inst_tests.h
+++ b/src/manager_inst_tests.h
@@ -3,16 +3,19 @@
 
 #include <gtest/gtest.h>
 
-#include "agent_tests.h"
 #include "cyclus.h"
-#include "institution_tests.h"
-#include "manager_inst.h"
-#include "test_context.h"
 #include "timer.h"
+#include "test_context.h"
+#include "institution_tests.h"
+#include "agent_tests.h"
+
+#include "manager_inst.h"
+
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-class TestProducer : public cyclus::Facility,
-                     public cyclus::toolkit::CommodityProducer {
+class TestProducer
+    : public cyclus::Facility,
+      public cyclus::toolkit::CommodityProducer {
  public:
   TestProducer(cyclus::Context* ctx);
   ~TestProducer();
@@ -23,7 +26,9 @@ class TestProducer : public cyclus::Facility,
     return m;
   }
 
-  void InitFrom(TestProducer* m) { cyclus::Facility::InitFrom(m); }
+  void InitFrom(TestProducer* m) {
+    cyclus::Facility::InitFrom(m);
+  }
 
   void InitInv(cyclus::Inventories& inv) {}
 

--- a/src/manager_inst_tests.h
+++ b/src/manager_inst_tests.h
@@ -11,11 +11,9 @@
 
 #include "manager_inst.h"
 
-
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-class TestProducer
-    : public cyclus::Facility,
-      public cyclus::toolkit::CommodityProducer {
+class TestProducer : public cyclus::Facility,
+                     public cyclus::toolkit::CommodityProducer {
  public:
   TestProducer(cyclus::Context* ctx);
   ~TestProducer();
@@ -26,9 +24,7 @@ class TestProducer
     return m;
   }
 
-  void InitFrom(TestProducer* m) {
-    cyclus::Facility::InitFrom(m);
-  }
+  void InitFrom(TestProducer* m) { cyclus::Facility::InitFrom(m); }
 
   void InitInv(cyclus::Inventories& inv) {}
 

--- a/src/mixer.cc
+++ b/src/mixer.cc
@@ -1,6 +1,6 @@
-#include "mixer.h"
-
 #include <sstream>
+
+#include "mixer.h"
 
 namespace cycamore {
 
@@ -24,7 +24,8 @@ cyclus::Inventories Mixer::SnapshotInv() {
   invs["output-inv-name"] = output.PopNRes(output.count());
   output.Push(invs["output-inv-name"]);
 
-  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material>>::iterator it;
+  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material> >::iterator
+      it;
   for (it = streambufs.begin(); it != streambufs.end(); ++it) {
     invs[it->first] = it->second.PopNRes(it->second.count());
     it->second.Push(invs[it->first]);
@@ -75,10 +76,9 @@ void Mixer::EnterNotify() {
 
     if (frac_sum != 1.0) {
       std::stringstream ss;
-      ss << "prototype '" << prototype()
-         << "': the sum of mixing fractions is "
-            "not 1, renormalization will be "
-            "done.";
+      ss << "prototype '" << prototype() << "': the sum of mixing fractions is "
+                                            "not 1, renormalization will be "
+                                            "done.";
       cyclus::Warn<cyclus::VALUE_WARNING>(ss.str());
     }
     if (frac_sum != 0) {
@@ -123,20 +123,21 @@ void Mixer::Tick() {
       output.Push(m);
     }
   }
-  cyclus::toolkit::RecordTimeSeries<double>("supply" + out_commod, this,
-                                            output.quantity());
+  cyclus::toolkit::RecordTimeSeries<double>("supply"+out_commod, this, output.quantity());
 }
 
 std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
 Mixer::GetMatlRequests() {
   using cyclus::RequestPortfolio;
 
-  for (int i = 0; i < mixing_ratios.size(); i++) {
+  for (int i = 0; i < mixing_ratios.size(); i++)
+  {
     std::string name = "in_stream_" + std::to_string(i);
     std::map<std::string, double>::iterator it;
     std::map<std::string, double>::iterator max_it = in_commods[i].begin();
     double prev_pref = 0;
-    for (it = in_commods[i].begin(); it != in_commods[i].end(); it++) {
+    for (it = in_commods[i].begin(); it != in_commods[i].end(); it++)
+    {
       cyclus::toolkit::RecordTimeSeries<double>("demand" + it->first, this,
                                                 streambufs[name].space());
     }
@@ -157,10 +158,10 @@ Mixer::GetMatlRequests() {
       std::vector<cyclus::Request<cyclus::Material>*> reqs;
 
       std::map<std::string, double>::iterator it;
-      for (it = in_commods[i].begin(); it != in_commods[i].end(); it++) {
+      for (it = in_commods[i].begin() ; it != in_commods[i].end(); it++) {
         std::string commod = it->first;
         double pref = it->second;
-        reqs.push_back(port->AddRequest(m, this, commod, pref, false));
+        reqs.push_back(port->AddRequest(m, this, commod , pref, false));
         req_inventories_[reqs.back()] = name;
       }
       port->AddMutualReqs(reqs);
@@ -172,9 +173,9 @@ Mixer::GetMatlRequests() {
 
 void Mixer::AcceptMatlTrades(
     const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                                cyclus::Material::Ptr>>& responses) {
+                                cyclus::Material::Ptr> >& responses) {
   std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                        cyclus::Material::Ptr>>::const_iterator trade;
+                        cyclus::Material::Ptr> >::const_iterator trade;
 
   for (trade = responses.begin(); trade != responses.end(); ++trade) {
     cyclus::Request<cyclus::Material>* req = trade->first.request;
@@ -182,7 +183,7 @@ void Mixer::AcceptMatlTrades(
 
     std::string name = req_inventories_[req];
     bool assigned = false;
-    std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material>>::iterator
+    std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material> >::iterator
         it;
 
     for (it = streambufs.begin(); it != streambufs.end(); it++) {
@@ -215,4 +216,4 @@ void Mixer::RecordPosition() {
 extern "C" cyclus::Agent* ConstructMixer(cyclus::Context* ctx) {
   return new Mixer(ctx);
 }
-}  // namespace cycamore
+}

--- a/src/mixer.cc
+++ b/src/mixer.cc
@@ -1,6 +1,6 @@
-#include <sstream>
-
 #include "mixer.h"
+
+#include <sstream>
 
 namespace cycamore {
 
@@ -24,8 +24,7 @@ cyclus::Inventories Mixer::SnapshotInv() {
   invs["output-inv-name"] = output.PopNRes(output.count());
   output.Push(invs["output-inv-name"]);
 
-  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material> >::iterator
-      it;
+  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material>>::iterator it;
   for (it = streambufs.begin(); it != streambufs.end(); ++it) {
     invs[it->first] = it->second.PopNRes(it->second.count());
     it->second.Push(invs[it->first]);
@@ -76,9 +75,10 @@ void Mixer::EnterNotify() {
 
     if (frac_sum != 1.0) {
       std::stringstream ss;
-      ss << "prototype '" << prototype() << "': the sum of mixing fractions is "
-                                            "not 1, renormalization will be "
-                                            "done.";
+      ss << "prototype '" << prototype()
+         << "': the sum of mixing fractions is "
+            "not 1, renormalization will be "
+            "done.";
       cyclus::Warn<cyclus::VALUE_WARNING>(ss.str());
     }
     if (frac_sum != 0) {
@@ -123,21 +123,20 @@ void Mixer::Tick() {
       output.Push(m);
     }
   }
-  cyclus::toolkit::RecordTimeSeries<double>("supply"+out_commod, this, output.quantity());
+  cyclus::toolkit::RecordTimeSeries<double>("supply" + out_commod, this,
+                                            output.quantity());
 }
 
 std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
 Mixer::GetMatlRequests() {
   using cyclus::RequestPortfolio;
 
-  for (int i = 0; i < mixing_ratios.size(); i++)
-  {
+  for (int i = 0; i < mixing_ratios.size(); i++) {
     std::string name = "in_stream_" + std::to_string(i);
     std::map<std::string, double>::iterator it;
     std::map<std::string, double>::iterator max_it = in_commods[i].begin();
     double prev_pref = 0;
-    for (it = in_commods[i].begin(); it != in_commods[i].end(); it++)
-    {
+    for (it = in_commods[i].begin(); it != in_commods[i].end(); it++) {
       cyclus::toolkit::RecordTimeSeries<double>("demand" + it->first, this,
                                                 streambufs[name].space());
     }
@@ -158,10 +157,10 @@ Mixer::GetMatlRequests() {
       std::vector<cyclus::Request<cyclus::Material>*> reqs;
 
       std::map<std::string, double>::iterator it;
-      for (it = in_commods[i].begin() ; it != in_commods[i].end(); it++) {
+      for (it = in_commods[i].begin(); it != in_commods[i].end(); it++) {
         std::string commod = it->first;
         double pref = it->second;
-        reqs.push_back(port->AddRequest(m, this, commod , pref, false));
+        reqs.push_back(port->AddRequest(m, this, commod, pref, false));
         req_inventories_[reqs.back()] = name;
       }
       port->AddMutualReqs(reqs);
@@ -173,9 +172,9 @@ Mixer::GetMatlRequests() {
 
 void Mixer::AcceptMatlTrades(
     const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                                cyclus::Material::Ptr> >& responses) {
+                                cyclus::Material::Ptr>>& responses) {
   std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                        cyclus::Material::Ptr> >::const_iterator trade;
+                        cyclus::Material::Ptr>>::const_iterator trade;
 
   for (trade = responses.begin(); trade != responses.end(); ++trade) {
     cyclus::Request<cyclus::Material>* req = trade->first.request;
@@ -183,7 +182,7 @@ void Mixer::AcceptMatlTrades(
 
     std::string name = req_inventories_[req];
     bool assigned = false;
-    std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material> >::iterator
+    std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material>>::iterator
         it;
 
     for (it = streambufs.begin(); it != streambufs.end(); it++) {
@@ -216,4 +215,4 @@ void Mixer::RecordPosition() {
 extern "C" cyclus::Agent* ConstructMixer(cyclus::Context* ctx) {
   return new Mixer(ctx);
 }
-}
+}  // namespace cycamore

--- a/src/mixer.cc
+++ b/src/mixer.cc
@@ -4,9 +4,7 @@
 
 namespace cycamore {
 
-Mixer::Mixer(cyclus::Context* ctx)
-    : cyclus::Facility(ctx),
-      throughput(0) {
+Mixer::Mixer(cyclus::Context* ctx) : cyclus::Facility(ctx), throughput(0) {
   cyclus::Warn<cyclus::EXPERIMENTAL_WARNING>(
       "the Mixer archetype is experimental");
 }
@@ -20,8 +18,7 @@ cyclus::Inventories Mixer::SnapshotInv() {
   invs["output-inv-name"] = output.PopNRes(output.count());
   output.Push(invs["output-inv-name"]);
 
-  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material> >::iterator
-      it;
+  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material>>::iterator it;
   for (it = streambufs.begin(); it != streambufs.end(); ++it) {
     invs[it->first] = it->second.PopNRes(it->second.count());
     it->second.Push(invs[it->first]);
@@ -74,9 +71,10 @@ void Mixer::EnterNotify() {
 
     if (frac_sum != 1.0) {
       std::stringstream ss;
-      ss << "prototype '" << prototype() << "': the sum of mixing fractions is "
-                                            "not 1, renormalization will be "
-                                            "done.";
+      ss << "prototype '" << prototype()
+         << "': the sum of mixing fractions is "
+            "not 1, renormalization will be "
+            "done.";
       cyclus::Warn<cyclus::VALUE_WARNING>(ss.str());
     }
     if (frac_sum != 0) {
@@ -121,21 +119,20 @@ void Mixer::Tick() {
       output.Push(m);
     }
   }
-  cyclus::toolkit::RecordTimeSeries<double>("supply"+out_commod, this, output.quantity());
+  cyclus::toolkit::RecordTimeSeries<double>("supply" + out_commod, this,
+                                            output.quantity());
 }
 
 std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
 Mixer::GetMatlRequests() {
   using cyclus::RequestPortfolio;
 
-  for (int i = 0; i < mixing_ratios.size(); i++)
-  {
+  for (int i = 0; i < mixing_ratios.size(); i++) {
     std::string name = "in_stream_" + std::to_string(i);
     std::map<std::string, double>::iterator it;
     std::map<std::string, double>::iterator max_it = in_commods[i].begin();
     double prev_pref = 0;
-    for (it = in_commods[i].begin(); it != in_commods[i].end(); it++)
-    {
+    for (it = in_commods[i].begin(); it != in_commods[i].end(); it++) {
       cyclus::toolkit::RecordTimeSeries<double>("demand" + it->first, this,
                                                 streambufs[name].space());
     }
@@ -156,10 +153,10 @@ Mixer::GetMatlRequests() {
       std::vector<cyclus::Request<cyclus::Material>*> reqs;
 
       std::map<std::string, double>::iterator it;
-      for (it = in_commods[i].begin() ; it != in_commods[i].end(); it++) {
+      for (it = in_commods[i].begin(); it != in_commods[i].end(); it++) {
         std::string commod = it->first;
         double pref = it->second;
-        reqs.push_back(port->AddRequest(m, this, commod , pref, false));
+        reqs.push_back(port->AddRequest(m, this, commod, pref, false));
         req_inventories_[reqs.back()] = name;
       }
       port->AddMutualReqs(reqs);
@@ -171,9 +168,9 @@ Mixer::GetMatlRequests() {
 
 void Mixer::AcceptMatlTrades(
     const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                                cyclus::Material::Ptr> >& responses) {
+                                cyclus::Material::Ptr>>& responses) {
   std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                        cyclus::Material::Ptr> >::const_iterator trade;
+                        cyclus::Material::Ptr>>::const_iterator trade;
 
   for (trade = responses.begin(); trade != responses.end(); ++trade) {
     cyclus::Request<cyclus::Material>* req = trade->first.request;
@@ -181,7 +178,7 @@ void Mixer::AcceptMatlTrades(
 
     std::string name = req_inventories_[req];
     bool assigned = false;
-    std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material> >::iterator
+    std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material>>::iterator
         it;
 
     for (it = streambufs.begin(); it != streambufs.end(); it++) {
@@ -202,4 +199,4 @@ void Mixer::AcceptMatlTrades(
 extern "C" cyclus::Agent* ConstructMixer(cyclus::Context* ctx) {
   return new Mixer(ctx);
 }
-}
+}  // namespace cycamore

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -2,6 +2,7 @@
 #define CYCAMORE_SRC_MIXER_H_
 
 #include <string>
+
 #include "cycamore_version.h"
 #include "cyclus.h"
 
@@ -17,10 +18,7 @@ namespace cycamore {
 /// inventories: one for each stream to be mixed, and one output
 /// stream. The supplying of mixed material is constrained by
 /// available inventory of mixed material quantities.
-class Mixer
-  : public cyclus::Facility,
-    public cyclus::toolkit::Position {
-
+class Mixer : public cyclus::Facility, public cyclus::toolkit::Position {
   // clang-format off
   #pragma cyclus note { \
     "niche": "mixing facility", \
@@ -39,7 +37,7 @@ class Mixer
   virtual ~Mixer(){};
 
   virtual void Tick();
-  virtual void Tock(){};
+  virtual void Tock() {};
   virtual void EnterNotify();
 
   virtual void AcceptMatlTrades(
@@ -47,7 +45,7 @@ class Mixer
                                   cyclus::Material::Ptr>>& responses);
 
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-      GetMatlRequests();
+  GetMatlRequests();
 
 #pragma cyclus clone
 #pragma cyclus initfromcopy
@@ -84,8 +82,7 @@ class Mixer
 
   // custom SnapshotInv and InitInv and EnterNotify are used to persist this
   // state var.
-  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material>>
-      streambufs;
+  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material>> streambufs;
 
   // clang-format off
   #pragma cyclus var { \

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -5,26 +5,32 @@
 #include "cycamore_version.h"
 #include "cyclus.h"
 
-#pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
+// clang-format off
+#pragma cyclus exec \
+  from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
+// clang-format on
 
 namespace cycamore {
 
 /// Mixer mixes N streams with fixed, static, user-specified
-/// ratios into a single output stream. The Mixer has N input inventories:
-/// one for each streams to be mixed, and one output stream. The supplying of
-/// mixed material is constrained by available inventory of mixed material
-/// quantities.
+/// ratios into a single output stream. The Mixer has N input
+/// inventories: one for each stream to be mixed, and one output
+/// stream. The supplying of mixed material is constrained by
+/// available inventory of mixed material quantities.
 class Mixer
   : public cyclus::Facility,
     public cyclus::toolkit::Position {
-#pragma cyclus note {   	  \
-    "niche": "mixing facility",				  \
-    "doc": "Mixer mixes N streams with fixed, static, user-specified" \
-           " ratios into a single output stream. The Mixer has N input"\
-           " inventories: one for each streams to be mixed, and one output"\
-           " stream. The supplying of mixed material is constrained by "\
-           " available inventory of mixed material quantities.", \
-    }
+
+  // clang-format off
+  #pragma cyclus note { \
+    "niche": "mixing facility", \
+    "doc": "Mixer mixes N streams with fixed, static, user-specified " \
+           "ratios into a single output stream. The Mixer has N input " \
+           "inventories: one for each stream to be mixed, and one output " \
+           "stream. The supplying of mixed material is constrained by " \
+           "available inventory of mixed material quantities.", \
+  }
+  // clang-format on
 
   friend class MixerTest;
 
@@ -38,10 +44,10 @@ class Mixer
 
   virtual void AcceptMatlTrades(
       const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                                  cyclus::Material::Ptr> >& responses);
+                                  cyclus::Material::Ptr>>& responses);
 
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-  GetMatlRequests();
+      GetMatlRequests();
 
 #pragma cyclus clone
 #pragma cyclus initfromcopy
@@ -50,7 +56,7 @@ class Mixer
 #pragma cyclus schema
 #pragma cyclus annotations
 #pragma cyclus snapshot
-  // the following pragmas are ommitted and the functions are written
+  // the following pragmas are omitted and the functions are written
   // manually in order to handle the vector of resource buffers:
   //
   //     #pragma cyclus snapshotinv
@@ -60,52 +66,60 @@ class Mixer
   virtual void InitInv(cyclus::Inventories& inv);
 
  protected:
-#pragma cyclus var { \
-    "alias": ["in_streams", [ "stream", [ "info", "mixing_ratio", "buf_size"], [ "commodities", "commodity", "pref"]]], \
-    "uitype": ["oneormore", [ "pair", ["pair", "double", "double"], ["oneormore", "incommodity", "double"]]], \
+  // clang-format off
+  #pragma cyclus var { \
+    "alias": ["in_streams", [ "stream", [ "info", "mixing_ratio", "buf_size"], \
+                             [ "commodities", "commodity", "pref"]]], \
+    "uitype": ["oneormore", [ "pair", ["pair", "double", "double"], \
+                             ["oneormore", "incommodity", "double"]]], \
     "uilabel": "", \
-    "doc": "", \
+    "doc": "" \
   }
-  std::vector<std::pair<std::pair<double, double>, std::map<std::string, double> > > streams_;
+ std::vector<std::pair<std::pair<double, double>, std::map<std::string, double> > > streams_;
+  // clang-format on
 
-  std::vector<std::map<std::string, double> > in_commods;
+  std::vector<std::map<std::string, double>> in_commods;
   std::vector<double> in_buf_sizes;
   std::vector<double> mixing_ratios;
 
   // custom SnapshotInv and InitInv and EnterNotify are used to persist this
   // state var.
-  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material> > streambufs;
+  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material>>
+      streambufs;
 
-
-#pragma cyclus var {                                                 \
-  "doc" : "Commodity on which to offer/supply mixed fuel material.", \
-  "uilabel" : "Output Commodity", "uitype" : "outcommodity", }
+  // clang-format off
+  #pragma cyclus var { \
+    "doc": "Commodity on which to offer/supply mixed fuel material.", \
+    "uilabel": "Output Commodity", \
+    "uitype": "outcommodity" \
+  }
   std::string out_commod;
 
-#pragma cyclus var { \
-    "doc" : "Maximum amount of mixed material that can be stored." \
-            " If full, the facility halts operation until space becomes" \
-            " available.", \
+  #pragma cyclus var { \
+    "doc": "Maximum amount of mixed material that can be stored. If full, " \
+           "the facility halts operation until space becomes available.", \
     "uilabel": "Maximum Leftover Inventory", \
     "default": CY_LARGE_DOUBLE, \
     "uitype": "range", \
     "range": [0.0, CY_LARGE_DOUBLE], \
-    "units": "kg", \
+    "units": "kg" \
   }
   double out_buf_size;
 
-#pragma cyclus var { "capacity" : "out_buf_size", }
+  #pragma cyclus var { "capacity": "out_buf_size" }
   cyclus::toolkit::ResBuf<cyclus::Material> output;
 
-#pragma cyclus var { \
+  #pragma cyclus var { \
     "default": CY_LARGE_DOUBLE, \
-    "doc": "Maximum number of kg of fuel material that can be mixed per time step.", \
+    "doc": "Maximum number of kg of fuel material that can be mixed per " \
+           "time step.", \
     "uilabel": "Maximum Throughput", \
     "uitype": "range", \
     "range": [0.0, CY_LARGE_DOUBLE], \
-    "units": "kg", \
+    "units": "kg" \
   }
   double throughput;
+  // clang-format on
 
   // intra-time-step state - no need to be a state var
   // map<request, inventory name>
@@ -114,7 +128,8 @@ class Mixer
   //// A policy for sending material
   cyclus::toolkit::MatlSellPolicy sell_policy;
 
-  private:
+ private:
+  // clang-format off
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical latitude in degrees as a double", \
@@ -130,6 +145,7 @@ class Mixer
            "be expressed in degrees as a double." \
   }
   double longitude;
+  // clang-format on
 
   cyclus::toolkit::Position coordinates;
 

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -2,7 +2,6 @@
 #define CYCAMORE_SRC_MIXER_H_
 
 #include <string>
-
 #include "cycamore_version.h"
 #include "cyclus.h"
 
@@ -18,7 +17,10 @@ namespace cycamore {
 /// inventories: one for each stream to be mixed, and one output
 /// stream. The supplying of mixed material is constrained by
 /// available inventory of mixed material quantities.
-class Mixer : public cyclus::Facility, public cyclus::toolkit::Position {
+class Mixer
+  : public cyclus::Facility,
+    public cyclus::toolkit::Position {
+
   // clang-format off
   #pragma cyclus note { \
     "niche": "mixing facility", \
@@ -37,7 +39,7 @@ class Mixer : public cyclus::Facility, public cyclus::toolkit::Position {
   virtual ~Mixer(){};
 
   virtual void Tick();
-  virtual void Tock() {};
+  virtual void Tock(){};
   virtual void EnterNotify();
 
   virtual void AcceptMatlTrades(
@@ -45,7 +47,7 @@ class Mixer : public cyclus::Facility, public cyclus::toolkit::Position {
                                   cyclus::Material::Ptr>>& responses);
 
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-  GetMatlRequests();
+      GetMatlRequests();
 
 #pragma cyclus clone
 #pragma cyclus initfromcopy
@@ -82,7 +84,8 @@ class Mixer : public cyclus::Facility, public cyclus::toolkit::Position {
 
   // custom SnapshotInv and InitInv and EnterNotify are used to persist this
   // state var.
-  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material>> streambufs;
+  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material>>
+      streambufs;
 
   // clang-format off
   #pragma cyclus var { \

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -17,10 +17,7 @@ namespace cycamore {
 /// inventories: one for each stream to be mixed, and one output
 /// stream. The supplying of mixed material is constrained by
 /// available inventory of mixed material quantities.
-class Mixer
-  : public cyclus::Facility,
-    public cyclus::toolkit::Position {
-
+class Mixer : public cyclus::Facility, public cyclus::toolkit::Position {
   // clang-format off
   #pragma cyclus note { \
     "niche": "mixing facility", \
@@ -39,7 +36,7 @@ class Mixer
   virtual ~Mixer(){};
 
   virtual void Tick();
-  virtual void Tock(){};
+  virtual void Tock() {};
   virtual void EnterNotify();
 
   virtual void AcceptMatlTrades(
@@ -47,7 +44,7 @@ class Mixer
                                   cyclus::Material::Ptr>>& responses);
 
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-      GetMatlRequests();
+  GetMatlRequests();
 
 #pragma cyclus clone
 #pragma cyclus initfromcopy
@@ -84,8 +81,7 @@ class Mixer
 
   // custom SnapshotInv and InitInv and EnterNotify are used to persist this
   // state var.
-  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material>>
-      streambufs;
+  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material>> streambufs;
 
   // clang-format off
   #pragma cyclus var { \
@@ -128,10 +124,9 @@ class Mixer
   //// A policy for sending material
   cyclus::toolkit::MatlSellPolicy sell_policy;
 
-  private:
-  // Code Injection:
-  #include "toolkit/position.cycpp.h"
-  
+ private:
+// Code Injection:
+#include "toolkit/position.cycpp.h"
 };
 
 }  // namespace cycamore

--- a/src/mixer_tests.cc
+++ b/src/mixer_tests.cc
@@ -1,11 +1,12 @@
-#include <gtest/gtest.h>
+#include "mixer.h"
 
 #include "agent_tests.h"
 #include "context.h"
 #include "cyclus.h"
 #include "equality_helpers.h"
 #include "facility_tests.h"
-#include "mixer.h"
+
+#include <gtest/gtest.h>
 
 using cyclus::QueryResult;
 
@@ -14,7 +15,7 @@ namespace cycamore {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 typedef std::vector<
-    std::pair<std::pair<double, double>, std::map<std::string, double>>>
+    std::pair<std::pair<double, double>, std::map<std::string, double> > >
     t_instream;
 
 cyclus::Composition::Ptr c_pustream() {
@@ -56,7 +57,7 @@ class MixerTest : public ::testing::Test {
   virtual void SetUp() {
     mf_facility_ = new Mixer(tc_.get());
 
-    std::vector<std::map<std::string, double>> in_commods;
+    std::vector<std::map<std::string, double> > in_commods;
     {
       std::map<std::string, double> in_com;
       in_com.insert(std::pair<std::string, double>("in_c1", 1));
@@ -75,13 +76,13 @@ class MixerTest : public ::testing::Test {
 
     std::vector<double> in_ratios = {1, 1, 1};
     std::vector<double> in_caps = {30, 20, 10};
-    SetIn_stream(in_commods, in_ratios, in_caps);
+    SetIn_stream(in_commods, in_ratios,  in_caps);
 
     SetOutStream_comds("out_com");
   }
   virtual void TearDown() { delete mf_facility_; }
 
-  std::vector<std::map<std::string, double>> in_coms;
+  std::vector<std::map<std::string, double> > in_coms;
   std::vector<double> in_frac;
   std::vector<double> in_cap;
 
@@ -106,14 +107,14 @@ class MixerTest : public ::testing::Test {
     }
   }
 
-  void SetIn_stream(std::vector<std::map<std::string, double>> in_stream,
+  void SetIn_stream(std::vector<std::map<std::string, double> > in_stream,
                     std::vector<double> ratios, std::vector<double> caps) {
     t_instream instream_tmp;
     for (int i = 0; i < in_stream.size(); i++) {
       std::pair<double, double> info_mtp =
           std::pair<double, double>(ratios[i], caps[i]);
       instream_tmp.push_back(
-          std::pair<std::pair<double, double>, std::map<std::string, double>>(
+          std::pair<std::pair<double, double>, std::map<std::string, double> >(
               info_mtp, in_stream[i]));
     }
     SetIn_stream(instream_tmp);
@@ -260,6 +261,7 @@ TEST_F(MixerTest, MixingComposition) {
   Material::Ptr final_mat = cyclus::ResCast<Material>(buffer->PopBack());
   cyclus::CompMap final_comp = final_mat->comp()->mass();
 
+
   cyclus::compmath::Normalize(&v, 1);
   cyclus::compmath::Normalize(&final_comp, 1);
 
@@ -323,42 +325,42 @@ TEST_F(MixerTest, Throughput) {
 TEST(MixerTests, MultipleFissStreams) {
   std::string config =
       "<in_streams>"
-      "<stream>"
-      "<info>"
-      "<mixing_ratio>0.8</mixing_ratio>"
-      "<buf_size>2.5</buf_size>"
-      "</info>"
-      "<commodities>"
-      "<item>"
-      "<commodity>stream1</commodity>"
-      "<pref>1</pref>"
-      "</item>"
-      "</commodities>"
-      "</stream>"
-      "<stream>"
-      "<info>"
-      "<mixing_ratio>0.15</mixing_ratio>"
-      "<buf_size>3</buf_size>"
-      "</info>"
-      "<commodities>"
-      "<item>"
-      "<commodity>stream2</commodity>"
-      "<pref>1</pref>"
-      "</item>"
-      "</commodities>"
-      "</stream>"
-      "<stream>"
-      "<info>"
-      "<mixing_ratio>0.05</mixing_ratio>"
-      "<buf_size>5</buf_size>"
-      "</info>"
-      "<commodities>"
-      "<item>"
-      "<commodity>stream3</commodity>"
-      "<pref>1</pref>"
-      "</item>"
-      "</commodities>"
-      "</stream>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.8</mixing_ratio>"
+            "<buf_size>2.5</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<item>"
+              "<commodity>stream1</commodity>"
+              "<pref>1</pref>"
+            "</item>"
+          "</commodities>"
+        "</stream>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.15</mixing_ratio>"
+            "<buf_size>3</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<item>"
+              "<commodity>stream2</commodity>"
+              "<pref>1</pref>"
+            "</item>"
+          "</commodities>"
+        "</stream>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.05</mixing_ratio>"
+            "<buf_size>5</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<item>"
+              "<commodity>stream3</commodity>"
+              "<pref>1</pref>"
+            "</item>"
+          "</commodities>"
+        "</stream>"
       "</in_streams>"
       "<out_commod>mixedstream</out_commod>"
       "<outputbuf_size>0</outputbuf_size>"
@@ -397,42 +399,42 @@ TEST(MixerTests, MultipleFissStreams) {
 TEST(MixerTests, CompleteMixingProcess) {
   std::string config =
       "<in_streams>"
-      "<stream>"
-      "<info>"
-      "<mixing_ratio>0.8</mixing_ratio>"
-      "<buf_size>2.5</buf_size>"
-      "</info>"
-      "<commodities>"
-      "<item>"
-      "<commodity>stream1</commodity>"
-      "<pref>1</pref>"
-      "</item>"
-      "</commodities>"
-      "</stream>"
-      "<stream>"
-      "<info>"
-      "<mixing_ratio>0.15</mixing_ratio>"
-      "<buf_size>3</buf_size>"
-      "</info>"
-      "<commodities>"
-      "<item>"
-      "<commodity>stream2</commodity>"
-      "<pref>1</pref>"
-      "</item>"
-      "</commodities>"
-      "</stream>"
-      "<stream>"
-      "<info>"
-      "<mixing_ratio>0.05</mixing_ratio>"
-      "<buf_size>5</buf_size>"
-      "</info>"
-      "<commodities>"
-      "<item>"
-      "<commodity>stream3</commodity>"
-      "<pref>1</pref>"
-      "</item>"
-      "</commodities>"
-      "</stream>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.8</mixing_ratio>"
+            "<buf_size>2.5</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<item>"
+              "<commodity>stream1</commodity>"
+              "<pref>1</pref>"
+            "</item>"
+          "</commodities>"
+        "</stream>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.15</mixing_ratio>"
+            "<buf_size>3</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<item>"
+              "<commodity>stream2</commodity>"
+              "<pref>1</pref>"
+            "</item>"
+          "</commodities>"
+        "</stream>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.05</mixing_ratio>"
+            "<buf_size>5</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<item>"
+              "<commodity>stream3</commodity>"
+              "<pref>1</pref>"
+            "</item>"
+          "</commodities>"
+        "</stream>"
       "</in_streams>"
       "<out_commod>mixedstream</out_commod>"
       "<outputbuf_size>10</outputbuf_size>"
@@ -462,42 +464,42 @@ TEST(MixerTests, CompleteMixingProcess) {
 TEST(MixerTests, PositionInitialize) {
   std::string config =
       "<in_streams>"
-      "<stream>"
-      "<info>"
-      "<mixing_ratio>0.8</mixing_ratio>"
-      "<buf_size>2.5</buf_size>"
-      "</info>"
-      "<commodities>"
-      "<item>"
-      "<commodity>stream1</commodity>"
-      "<pref>1</pref>"
-      "</item>"
-      "</commodities>"
-      "</stream>"
-      "<stream>"
-      "<info>"
-      "<mixing_ratio>0.15</mixing_ratio>"
-      "<buf_size>3</buf_size>"
-      "</info>"
-      "<commodities>"
-      "<item>"
-      "<commodity>stream2</commodity>"
-      "<pref>1</pref>"
-      "</item>"
-      "</commodities>"
-      "</stream>"
-      "<stream>"
-      "<info>"
-      "<mixing_ratio>0.05</mixing_ratio>"
-      "<buf_size>5</buf_size>"
-      "</info>"
-      "<commodities>"
-      "<item>"
-      "<commodity>stream3</commodity>"
-      "<pref>1</pref>"
-      "</item>"
-      "</commodities>"
-      "</stream>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.8</mixing_ratio>"
+            "<buf_size>2.5</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<item>"
+              "<commodity>stream1</commodity>"
+              "<pref>1</pref>"
+            "</item>"
+          "</commodities>"
+        "</stream>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.15</mixing_ratio>"
+            "<buf_size>3</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<item>"
+              "<commodity>stream2</commodity>"
+              "<pref>1</pref>"
+            "</item>"
+          "</commodities>"
+        "</stream>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.05</mixing_ratio>"
+            "<buf_size>5</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<item>"
+              "<commodity>stream3</commodity>"
+              "<pref>1</pref>"
+            "</item>"
+          "</commodities>"
+        "</stream>"
       "</in_streams>"
       "<out_commod>mixedstream</out_commod>"
       "<outputbuf_size>0</outputbuf_size>"

--- a/src/mixer_tests.cc
+++ b/src/mixer_tests.cc
@@ -1,12 +1,11 @@
-#include "mixer.h"
+#include <gtest/gtest.h>
 
 #include "agent_tests.h"
 #include "context.h"
 #include "cyclus.h"
 #include "equality_helpers.h"
 #include "facility_tests.h"
-
-#include <gtest/gtest.h>
+#include "mixer.h"
 
 using cyclus::QueryResult;
 
@@ -15,7 +14,7 @@ namespace cycamore {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 typedef std::vector<
-    std::pair<std::pair<double, double>, std::map<std::string, double> > >
+    std::pair<std::pair<double, double>, std::map<std::string, double>>>
     t_instream;
 
 cyclus::Composition::Ptr c_pustream() {
@@ -57,7 +56,7 @@ class MixerTest : public ::testing::Test {
   virtual void SetUp() {
     mf_facility_ = new Mixer(tc_.get());
 
-    std::vector<std::map<std::string, double> > in_commods;
+    std::vector<std::map<std::string, double>> in_commods;
     {
       std::map<std::string, double> in_com;
       in_com.insert(std::pair<std::string, double>("in_c1", 1));
@@ -76,13 +75,13 @@ class MixerTest : public ::testing::Test {
 
     std::vector<double> in_ratios = {1, 1, 1};
     std::vector<double> in_caps = {30, 20, 10};
-    SetIn_stream(in_commods, in_ratios,  in_caps);
+    SetIn_stream(in_commods, in_ratios, in_caps);
 
     SetOutStream_comds("out_com");
   }
   virtual void TearDown() { delete mf_facility_; }
 
-  std::vector<std::map<std::string, double> > in_coms;
+  std::vector<std::map<std::string, double>> in_coms;
   std::vector<double> in_frac;
   std::vector<double> in_cap;
 
@@ -107,14 +106,14 @@ class MixerTest : public ::testing::Test {
     }
   }
 
-  void SetIn_stream(std::vector<std::map<std::string, double> > in_stream,
+  void SetIn_stream(std::vector<std::map<std::string, double>> in_stream,
                     std::vector<double> ratios, std::vector<double> caps) {
     t_instream instream_tmp;
     for (int i = 0; i < in_stream.size(); i++) {
       std::pair<double, double> info_mtp =
           std::pair<double, double>(ratios[i], caps[i]);
       instream_tmp.push_back(
-          std::pair<std::pair<double, double>, std::map<std::string, double> >(
+          std::pair<std::pair<double, double>, std::map<std::string, double>>(
               info_mtp, in_stream[i]));
     }
     SetIn_stream(instream_tmp);
@@ -261,7 +260,6 @@ TEST_F(MixerTest, MixingComposition) {
   Material::Ptr final_mat = cyclus::ResCast<Material>(buffer->PopBack());
   cyclus::CompMap final_comp = final_mat->comp()->mass();
 
-
   cyclus::compmath::Normalize(&v, 1);
   cyclus::compmath::Normalize(&final_comp, 1);
 
@@ -325,42 +323,42 @@ TEST_F(MixerTest, Throughput) {
 TEST(MixerTests, MultipleFissStreams) {
   std::string config =
       "<in_streams>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.8</mixing_ratio>"
-            "<buf_size>2.5</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream1</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.15</mixing_ratio>"
-            "<buf_size>3</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream2</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.05</mixing_ratio>"
-            "<buf_size>5</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream3</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.8</mixing_ratio>"
+      "<buf_size>2.5</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream1</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.15</mixing_ratio>"
+      "<buf_size>3</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream2</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.05</mixing_ratio>"
+      "<buf_size>5</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream3</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
       "</in_streams>"
       "<out_commod>mixedstream</out_commod>"
       "<outputbuf_size>0</outputbuf_size>"
@@ -399,42 +397,42 @@ TEST(MixerTests, MultipleFissStreams) {
 TEST(MixerTests, CompleteMixingProcess) {
   std::string config =
       "<in_streams>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.8</mixing_ratio>"
-            "<buf_size>2.5</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream1</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.15</mixing_ratio>"
-            "<buf_size>3</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream2</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.05</mixing_ratio>"
-            "<buf_size>5</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream3</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.8</mixing_ratio>"
+      "<buf_size>2.5</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream1</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.15</mixing_ratio>"
+      "<buf_size>3</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream2</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.05</mixing_ratio>"
+      "<buf_size>5</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream3</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
       "</in_streams>"
       "<out_commod>mixedstream</out_commod>"
       "<outputbuf_size>10</outputbuf_size>"
@@ -464,42 +462,42 @@ TEST(MixerTests, CompleteMixingProcess) {
 TEST(MixerTests, PositionInitialize) {
   std::string config =
       "<in_streams>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.8</mixing_ratio>"
-            "<buf_size>2.5</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream1</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.15</mixing_ratio>"
-            "<buf_size>3</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream2</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.05</mixing_ratio>"
-            "<buf_size>5</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream3</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.8</mixing_ratio>"
+      "<buf_size>2.5</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream1</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.15</mixing_ratio>"
+      "<buf_size>3</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream2</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.05</mixing_ratio>"
+      "<buf_size>5</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream3</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
       "</in_streams>"
       "<out_commod>mixedstream</out_commod>"
       "<outputbuf_size>0</outputbuf_size>"

--- a/src/mixer_tests.cc
+++ b/src/mixer_tests.cc
@@ -15,7 +15,7 @@ namespace cycamore {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 typedef std::vector<
-    std::pair<std::pair<double, double>, std::map<std::string, double> > >
+    std::pair<std::pair<double, double>, std::map<std::string, double>>>
     t_instream;
 
 cyclus::Composition::Ptr c_pustream() {
@@ -57,7 +57,7 @@ class MixerTest : public ::testing::Test {
   virtual void SetUp() {
     mf_facility_ = new Mixer(tc_.get());
 
-    std::vector<std::map<std::string, double> > in_commods;
+    std::vector<std::map<std::string, double>> in_commods;
     {
       std::map<std::string, double> in_com;
       in_com.insert(std::pair<std::string, double>("in_c1", 1));
@@ -76,13 +76,13 @@ class MixerTest : public ::testing::Test {
 
     std::vector<double> in_ratios = {1, 1, 1};
     std::vector<double> in_caps = {30, 20, 10};
-    SetIn_stream(in_commods, in_ratios,  in_caps);
+    SetIn_stream(in_commods, in_ratios, in_caps);
 
     SetOutStream_comds("out_com");
   }
   virtual void TearDown() { delete mf_facility_; }
 
-  std::vector<std::map<std::string, double> > in_coms;
+  std::vector<std::map<std::string, double>> in_coms;
   std::vector<double> in_frac;
   std::vector<double> in_cap;
 
@@ -107,14 +107,14 @@ class MixerTest : public ::testing::Test {
     }
   }
 
-  void SetIn_stream(std::vector<std::map<std::string, double> > in_stream,
+  void SetIn_stream(std::vector<std::map<std::string, double>> in_stream,
                     std::vector<double> ratios, std::vector<double> caps) {
     t_instream instream_tmp;
     for (int i = 0; i < in_stream.size(); i++) {
       std::pair<double, double> info_mtp =
           std::pair<double, double>(ratios[i], caps[i]);
       instream_tmp.push_back(
-          std::pair<std::pair<double, double>, std::map<std::string, double> >(
+          std::pair<std::pair<double, double>, std::map<std::string, double>>(
               info_mtp, in_stream[i]));
     }
     SetIn_stream(instream_tmp);
@@ -261,7 +261,6 @@ TEST_F(MixerTest, MixingComposition) {
   Material::Ptr final_mat = cyclus::ResCast<Material>(buffer->PopBack());
   cyclus::CompMap final_comp = final_mat->comp()->mass();
 
-
   cyclus::compmath::Normalize(&v, 1);
   cyclus::compmath::Normalize(&final_comp, 1);
 
@@ -325,42 +324,42 @@ TEST_F(MixerTest, Throughput) {
 TEST(MixerTests, MultipleFissStreams) {
   std::string config =
       "<in_streams>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.8</mixing_ratio>"
-            "<buf_size>2.5</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream1</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.15</mixing_ratio>"
-            "<buf_size>3</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream2</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.05</mixing_ratio>"
-            "<buf_size>5</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream3</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.8</mixing_ratio>"
+      "<buf_size>2.5</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream1</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.15</mixing_ratio>"
+      "<buf_size>3</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream2</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.05</mixing_ratio>"
+      "<buf_size>5</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream3</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
       "</in_streams>"
       "<out_commod>mixedstream</out_commod>"
       "<outputbuf_size>0</outputbuf_size>"
@@ -399,42 +398,42 @@ TEST(MixerTests, MultipleFissStreams) {
 TEST(MixerTests, CompleteMixingProcess) {
   std::string config =
       "<in_streams>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.8</mixing_ratio>"
-            "<buf_size>2.5</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream1</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.15</mixing_ratio>"
-            "<buf_size>3</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream2</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.05</mixing_ratio>"
-            "<buf_size>5</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream3</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.8</mixing_ratio>"
+      "<buf_size>2.5</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream1</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.15</mixing_ratio>"
+      "<buf_size>3</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream2</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.05</mixing_ratio>"
+      "<buf_size>5</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream3</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
       "</in_streams>"
       "<out_commod>mixedstream</out_commod>"
       "<outputbuf_size>10</outputbuf_size>"
@@ -464,42 +463,42 @@ TEST(MixerTests, CompleteMixingProcess) {
 TEST(MixerTests, PositionInitialize) {
   std::string config =
       "<in_streams>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.8</mixing_ratio>"
-            "<buf_size>2.5</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream1</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.15</mixing_ratio>"
-            "<buf_size>3</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream2</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
-        "<stream>"
-          "<info>"
-            "<mixing_ratio>0.05</mixing_ratio>"
-            "<buf_size>5</buf_size>"
-          "</info>"
-          "<commodities>"
-            "<item>"
-              "<commodity>stream3</commodity>"
-              "<pref>1</pref>"
-            "</item>"
-          "</commodities>"
-        "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.8</mixing_ratio>"
+      "<buf_size>2.5</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream1</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.15</mixing_ratio>"
+      "<buf_size>3</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream2</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
+      "<stream>"
+      "<info>"
+      "<mixing_ratio>0.05</mixing_ratio>"
+      "<buf_size>5</buf_size>"
+      "</info>"
+      "<commodities>"
+      "<item>"
+      "<commodity>stream3</commodity>"
+      "<pref>1</pref>"
+      "</item>"
+      "</commodities>"
+      "</stream>"
       "</in_streams>"
       "<out_commod>mixedstream</out_commod>"
       "<outputbuf_size>0</outputbuf_size>"

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -1,10 +1,10 @@
 #include "reactor.h"
 
-using cyclus::Material;
-using cyclus::toolkit::MatVec;
 using cyclus::KeyError;
-using cyclus::ValueError;
+using cyclus::Material;
 using cyclus::Request;
+using cyclus::ValueError;
+using cyclus::toolkit::MatVec;
 
 namespace cycamore {
 
@@ -26,7 +26,6 @@ Reactor::Reactor(cyclus::Context* ctx)
       keep_packaging(true),
       coordinates(latitude, longitude) {}
 
-
 #pragma cyclus def clone cycamore::Reactor
 
 #pragma cyclus def schema cycamore::Reactor
@@ -42,21 +41,21 @@ Reactor::Reactor(cyclus::Context* ctx)
 #pragma cyclus def initinv cycamore::Reactor
 
 void Reactor::InitFrom(Reactor* m) {
-  #pragma cyclus impl initfromcopy cycamore::Reactor
+#pragma cyclus impl initfromcopy cycamore::Reactor
   cyclus::toolkit::CommodityProducer::Copy(m);
 }
 
 void Reactor::InitFrom(cyclus::QueryableBackend* b) {
-  #pragma cyclus impl initfromdb cycamore::Reactor
+#pragma cyclus impl initfromdb cycamore::Reactor
 
   namespace tk = cyclus::toolkit;
   tk::CommodityProducer::Add(tk::Commodity(power_name),
                              tk::CommodInfo(power_cap, power_cap));
 
   for (int i = 0; i < side_products.size(); i++) {
-    tk::CommodityProducer::Add(tk::Commodity(side_products[i]),
-                               tk::CommodInfo(side_product_quantity[i],
-                                              side_product_quantity[i]));
+    tk::CommodityProducer::Add(
+        tk::Commodity(side_products[i]),
+        tk::CommodInfo(side_product_quantity[i], side_product_quantity[i]));
   }
 }
 
@@ -77,7 +76,7 @@ void Reactor::EnterNotify() {
   }
 
   // Test if any side products have been defined.
-  if (side_products.size() == 0){
+  if (side_products.size() == 0) {
     hybrid_ = false;
   }
 
@@ -129,11 +128,10 @@ void Reactor::Tick() {
   if (retired()) {
     Record("RETIRED", "");
 
-    if (context()->time() == exit_time() + 1) { // only need to transmute once
+    if (context()->time() == exit_time() + 1) {  // only need to transmute once
       if (decom_transmute_all == true) {
         Transmute(ceil(static_cast<double>(n_assem_core)));
-      }
-      else {
+      } else {
         Transmute(ceil(static_cast<double>(n_assem_core) / 2.0));
       }
     }
@@ -148,8 +146,8 @@ void Reactor::Tick() {
     while (fresh.count() > 0 && spent.space() >= assem_size) {
       spent.Push(fresh.Pop());
     }
-    if(CheckDecommissionCondition()) {
-      context()->SchedDecom(this);    
+    if (CheckDecommissionCondition()) {
+      context()->SchedDecom(this);
     }
     return;
   }
@@ -210,7 +208,8 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> Reactor::GetMatlRequests() {
 
   // second min expression reduces assembles to amount needed until
   // retirement if it is near.
-  int n_assem_order = n_assem_core - core.count() + n_assem_fresh - fresh.count();
+  int n_assem_order =
+      n_assem_core - core.count() + n_assem_fresh - fresh.count();
 
   if (exit_time() != -1) {
     // the +1 accounts for the fact that the reactor is alive and gets to
@@ -218,9 +217,10 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> Reactor::GetMatlRequests() {
     int t_left = exit_time() - context()->time() + 1;
     int t_left_cycle = cycle_time + refuel_time - cycle_step;
     double n_cycles_left = static_cast<double>(t_left - t_left_cycle) /
-                         static_cast<double>(cycle_time + refuel_time);
+                           static_cast<double>(cycle_time + refuel_time);
     n_cycles_left = ceil(n_cycles_left);
-    int n_need = std::max(0.0, n_cycles_left * n_assem_batch - n_assem_fresh + n_assem_core - core.count());
+    int n_need = std::max(0.0, n_cycles_left * n_assem_batch - n_assem_fresh +
+                                   n_assem_core - core.count());
     n_assem_order = std::min(n_assem_order, n_need);
   }
 
@@ -247,8 +247,8 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> Reactor::GetMatlRequests() {
     result = std::max_element(fuel_prefs.begin(), fuel_prefs.end());
     int max_index = std::distance(fuel_prefs.begin(), result);
 
-    cyclus::toolkit::RecordTimeSeries<double>("demand"+fuel_incommods[max_index], this,
-                                          assem_size) ;
+    cyclus::toolkit::RecordTimeSeries<double>(
+        "demand" + fuel_incommods[max_index], this, assem_size);
 
     port->AddMutualReqs(mreqs);
     ports.insert(port);
@@ -258,9 +258,8 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> Reactor::GetMatlRequests() {
 }
 
 void Reactor::GetMatlTrades(
-    const std::vector<cyclus::Trade<Material> >& trades,
-    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
-        responses) {
+    const std::vector<cyclus::Trade<Material>>& trades,
+    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>& responses) {
   using cyclus::Trade;
 
   std::map<std::string, MatVec> mats = PopSpent();
@@ -274,10 +273,11 @@ void Reactor::GetMatlTrades(
   PushSpent(mats);  // return leftovers back to spent buffer
 }
 
-void Reactor::AcceptMatlTrades(const std::vector<
-    std::pair<cyclus::Trade<Material>, Material::Ptr> >& responses) {
-  std::vector<std::pair<cyclus::Trade<Material>,
-                        Material::Ptr> >::const_iterator trade;
+void Reactor::AcceptMatlTrades(
+    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>&
+        responses) {
+  std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>::const_iterator
+      trade;
 
   std::stringstream ss;
   int nload = std::min((int)responses.size(), n_assem_core - core.count());
@@ -360,11 +360,12 @@ void Reactor::Tock() {
   if (retired()) {
     return;
   }
-  
-  // Check that irradiation and refueling periods are over, that 
-  // the core is full and that fuel was successfully discharged in this refueling time.
-  // If this is the case, then a new cycle will be initiated.
-  if (cycle_step >= cycle_time + refuel_time && core.count() == n_assem_core && discharged == true) {
+
+  // Check that irradiation and refueling periods are over, that
+  // the core is full and that fuel was successfully discharged in this
+  // refueling time. If this is the case, then a new cycle will be initiated.
+  if (cycle_step >= cycle_time + refuel_time && core.count() == n_assem_core &&
+      discharged == true) {
     discharged = false;
     cycle_step = 0;
   }
@@ -391,7 +392,9 @@ void Reactor::Tock() {
   }
 }
 
-void Reactor::Transmute() { Transmute(n_assem_batch); }
+void Reactor::Transmute() {
+  Transmute(n_assem_batch);
+}
 
 void Reactor::Transmute(int n_assem) {
   MatVec old = core.PopN(std::min(n_assem, core.count()));
@@ -438,11 +441,12 @@ bool Reactor::Discharge() {
     spent_mats = PeekSpent();
     MatVec mats = spent_mats[fuel_outcommods[i]];
     double tot_spent = 0;
-    for (int j = 0; j<mats.size(); j++){
+    for (int j = 0; j < mats.size(); j++) {
       Material::Ptr m = mats[j];
       tot_spent += m->quantity();
     }
-    cyclus::toolkit::RecordTimeSeries<double>("supply"+fuel_outcommods[i], this, tot_spent);
+    cyclus::toolkit::RecordTimeSeries<double>("supply" + fuel_outcommods[i],
+                                              this, tot_spent);
   }
 
   return true;
@@ -537,15 +541,14 @@ void Reactor::PushSpent(std::map<std::string, MatVec> leftover) {
   }
 }
 
-void Reactor::RecordSideProduct(bool produce){
-  if (hybrid_){
+void Reactor::RecordSideProduct(bool produce) {
+  if (hybrid_) {
     double value;
     for (int i = 0; i < side_products.size(); i++) {
-      if (produce){
-          value = side_product_quantity[i];
-      }
-      else {
-          value = 0;
+      if (produce) {
+        value = side_product_quantity[i];
+      } else {
+        value = 0;
       }
 
       context()

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -1,10 +1,10 @@
 #include "reactor.h"
 
-using cyclus::Material;
-using cyclus::toolkit::MatVec;
 using cyclus::KeyError;
-using cyclus::ValueError;
+using cyclus::Material;
 using cyclus::Request;
+using cyclus::ValueError;
+using cyclus::toolkit::MatVec;
 
 namespace cycamore {
 
@@ -23,7 +23,6 @@ Reactor::Reactor(cyclus::Context* ctx)
       discharged(false),
       keep_packaging(true) {}
 
-
 #pragma cyclus def clone cycamore::Reactor
 
 #pragma cyclus def schema cycamore::Reactor
@@ -39,21 +38,21 @@ Reactor::Reactor(cyclus::Context* ctx)
 #pragma cyclus def initinv cycamore::Reactor
 
 void Reactor::InitFrom(Reactor* m) {
-  #pragma cyclus impl initfromcopy cycamore::Reactor
+#pragma cyclus impl initfromcopy cycamore::Reactor
   cyclus::toolkit::CommodityProducer::Copy(m);
 }
 
 void Reactor::InitFrom(cyclus::QueryableBackend* b) {
-  #pragma cyclus impl initfromdb cycamore::Reactor
+#pragma cyclus impl initfromdb cycamore::Reactor
 
   namespace tk = cyclus::toolkit;
   tk::CommodityProducer::Add(tk::Commodity(power_name),
                              tk::CommodInfo(power_cap, power_cap));
 
   for (int i = 0; i < side_products.size(); i++) {
-    tk::CommodityProducer::Add(tk::Commodity(side_products[i]),
-                               tk::CommodInfo(side_product_quantity[i],
-                                              side_product_quantity[i]));
+    tk::CommodityProducer::Add(
+        tk::Commodity(side_products[i]),
+        tk::CommodInfo(side_product_quantity[i], side_product_quantity[i]));
   }
 }
 
@@ -74,7 +73,7 @@ void Reactor::EnterNotify() {
   }
 
   // Test if any side products have been defined.
-  if (side_products.size() == 0){
+  if (side_products.size() == 0) {
     hybrid_ = false;
   }
 
@@ -108,7 +107,7 @@ void Reactor::EnterNotify() {
   if (ss.str().size() > 0) {
     throw ValueError(ss.str());
   }
-  
+
   InitializePosition();
 }
 
@@ -127,11 +126,10 @@ void Reactor::Tick() {
   if (retired()) {
     Record("RETIRED", "");
 
-    if (context()->time() == exit_time() + 1) { // only need to transmute once
+    if (context()->time() == exit_time() + 1) {  // only need to transmute once
       if (decom_transmute_all == true) {
         Transmute(ceil(static_cast<double>(n_assem_core)));
-      }
-      else {
+      } else {
         Transmute(ceil(static_cast<double>(n_assem_core) / 2.0));
       }
     }
@@ -146,8 +144,8 @@ void Reactor::Tick() {
     while (fresh.count() > 0 && spent.space() >= assem_size) {
       spent.Push(fresh.Pop());
     }
-    if(CheckDecommissionCondition()) {
-      context()->SchedDecom(this);    
+    if (CheckDecommissionCondition()) {
+      context()->SchedDecom(this);
     }
     return;
   }
@@ -208,7 +206,8 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> Reactor::GetMatlRequests() {
 
   // second min expression reduces assembles to amount needed until
   // retirement if it is near.
-  int n_assem_order = n_assem_core - core.count() + n_assem_fresh - fresh.count();
+  int n_assem_order =
+      n_assem_core - core.count() + n_assem_fresh - fresh.count();
 
   if (exit_time() != -1) {
     // the +1 accounts for the fact that the reactor is alive and gets to
@@ -216,9 +215,10 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> Reactor::GetMatlRequests() {
     int t_left = exit_time() - context()->time() + 1;
     int t_left_cycle = cycle_time + refuel_time - cycle_step;
     double n_cycles_left = static_cast<double>(t_left - t_left_cycle) /
-                         static_cast<double>(cycle_time + refuel_time);
+                           static_cast<double>(cycle_time + refuel_time);
     n_cycles_left = ceil(n_cycles_left);
-    int n_need = std::max(0.0, n_cycles_left * n_assem_batch - n_assem_fresh + n_assem_core - core.count());
+    int n_need = std::max(0.0, n_cycles_left * n_assem_batch - n_assem_fresh +
+                                   n_assem_core - core.count());
     n_assem_order = std::min(n_assem_order, n_need);
   }
 
@@ -245,8 +245,8 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> Reactor::GetMatlRequests() {
     result = std::max_element(fuel_prefs.begin(), fuel_prefs.end());
     int max_index = std::distance(fuel_prefs.begin(), result);
 
-    cyclus::toolkit::RecordTimeSeries<double>("demand"+fuel_incommods[max_index], this,
-                                          assem_size) ;
+    cyclus::toolkit::RecordTimeSeries<double>(
+        "demand" + fuel_incommods[max_index], this, assem_size);
 
     port->AddMutualReqs(mreqs);
     ports.insert(port);
@@ -256,9 +256,8 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> Reactor::GetMatlRequests() {
 }
 
 void Reactor::GetMatlTrades(
-    const std::vector<cyclus::Trade<Material> >& trades,
-    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
-        responses) {
+    const std::vector<cyclus::Trade<Material>>& trades,
+    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>& responses) {
   using cyclus::Trade;
 
   std::map<std::string, MatVec> mats = PopSpent();
@@ -272,10 +271,11 @@ void Reactor::GetMatlTrades(
   PushSpent(mats);  // return leftovers back to spent buffer
 }
 
-void Reactor::AcceptMatlTrades(const std::vector<
-    std::pair<cyclus::Trade<Material>, Material::Ptr> >& responses) {
-  std::vector<std::pair<cyclus::Trade<Material>,
-                        Material::Ptr> >::const_iterator trade;
+void Reactor::AcceptMatlTrades(
+    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>&
+        responses) {
+  std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>::const_iterator
+      trade;
 
   std::stringstream ss;
   int nload = std::min((int)responses.size(), n_assem_core - core.count());
@@ -358,11 +358,12 @@ void Reactor::Tock() {
   if (retired()) {
     return;
   }
-  
-  // Check that irradiation and refueling periods are over, that 
-  // the core is full and that fuel was successfully discharged in this refueling time.
-  // If this is the case, then a new cycle will be initiated.
-  if (cycle_step >= cycle_time + refuel_time && core.count() == n_assem_core && discharged == true) {
+
+  // Check that irradiation and refueling periods are over, that
+  // the core is full and that fuel was successfully discharged in this
+  // refueling time. If this is the case, then a new cycle will be initiated.
+  if (cycle_step >= cycle_time + refuel_time && core.count() == n_assem_core &&
+      discharged == true) {
     discharged = false;
     cycle_step = 0;
   }
@@ -389,7 +390,9 @@ void Reactor::Tock() {
   }
 }
 
-void Reactor::Transmute() { Transmute(n_assem_batch); }
+void Reactor::Transmute() {
+  Transmute(n_assem_batch);
+}
 
 void Reactor::Transmute(int n_assem) {
   MatVec old = core.PopN(std::min(n_assem, core.count()));
@@ -436,11 +439,12 @@ bool Reactor::Discharge() {
     spent_mats = PeekSpent();
     MatVec mats = spent_mats[fuel_outcommods[i]];
     double tot_spent = 0;
-    for (int j = 0; j<mats.size(); j++){
+    for (int j = 0; j < mats.size(); j++) {
       Material::Ptr m = mats[j];
       tot_spent += m->quantity();
     }
-    cyclus::toolkit::RecordTimeSeries<double>("supply"+fuel_outcommods[i], this, tot_spent);
+    cyclus::toolkit::RecordTimeSeries<double>("supply" + fuel_outcommods[i],
+                                              this, tot_spent);
   }
 
   return true;
@@ -535,15 +539,14 @@ void Reactor::PushSpent(std::map<std::string, MatVec> leftover) {
   }
 }
 
-void Reactor::RecordSideProduct(bool produce){
-  if (hybrid_){
+void Reactor::RecordSideProduct(bool produce) {
+  if (hybrid_) {
     double value;
     for (int i = 0; i < side_products.size(); i++) {
-      if (produce){
-          value = side_product_quantity[i];
-      }
-      else {
-          value = 0;
+      if (produce) {
+        value = side_product_quantity[i];
+      } else {
+        value = 0;
       }
 
       context()

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -1,8 +1,8 @@
 #ifndef CYCAMORE_SRC_REACTOR_H_
 #define CYCAMORE_SRC_REACTOR_H_
 
-#include "cyclus.h"
 #include "cycamore_version.h"
+#include "cyclus.h"
 
 namespace cycamore {
 
@@ -53,10 +53,9 @@ namespace cycamore {
 /// compositions.
 
 class Reactor : public cyclus::Facility,
-  public cyclus::toolkit::CommodityProducer,
-  public cyclus::toolkit::Position {
-
-// clang-format off
+                public cyclus::toolkit::CommodityProducer,
+                public cyclus::toolkit::Position {
+  // clang-format off
 #pragma cyclus note { \
 "niche": "reactor", \
 "doc": \
@@ -107,7 +106,7 @@ class Reactor : public cyclus::Facility,
   " compositions." \
   "", \
 }
-// clang-format on
+  // clang-format on
 
  public:
   Reactor(cyclus::Context* ctx);
@@ -120,8 +119,9 @@ class Reactor : public cyclus::Facility,
   virtual void EnterNotify();
   virtual bool CheckDecommissionCondition();
 
-  virtual void AcceptMatlTrades(const std::vector<std::pair<
-      cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr> >& responses);
+  virtual void AcceptMatlTrades(
+      const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                                  cyclus::Material::Ptr>>& responses);
 
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
   GetMatlRequests();
@@ -130,11 +130,11 @@ class Reactor : public cyclus::Facility,
       cyclus::CommodMap<cyclus::Material>::type& commod_requests);
 
   virtual void GetMatlTrades(
-      const std::vector<cyclus::Trade<cyclus::Material> >& trades,
+      const std::vector<cyclus::Trade<cyclus::Material>>& trades,
       std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                            cyclus::Material::Ptr> >& responses);
+                            cyclus::Material::Ptr>>& responses);
 
-  #pragma cyclus decl
+#pragma cyclus decl
 
  private:
   std::string fuel_incommod(cyclus::Material::Ptr m);
@@ -182,7 +182,7 @@ class Reactor : public cyclus::Facility,
   /// Returns all spent assemblies indexed by outcommod without removing them
   /// from the spent fuel buffer.
   std::map<std::string, cyclus::toolkit::MatVec> PeekSpent();
-  
+
   // clang-format off
   /////// fuel specifications /////////
   #pragma cyclus var { \
@@ -487,6 +487,6 @@ class Reactor : public cyclus::Facility,
   void RecordPosition();
 };
 
-} // namespace cycamore
+}  // namespace cycamore
 
 #endif  // CYCAMORE_SRC_REACTOR_H_

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -1,8 +1,8 @@
 #ifndef CYCAMORE_SRC_REACTOR_H_
 #define CYCAMORE_SRC_REACTOR_H_
 
-#include "cycamore_version.h"
 #include "cyclus.h"
+#include "cycamore_version.h"
 
 namespace cycamore {
 
@@ -53,9 +53,10 @@ namespace cycamore {
 /// compositions.
 
 class Reactor : public cyclus::Facility,
-                public cyclus::toolkit::CommodityProducer,
-                public cyclus::toolkit::Position {
-  // clang-format off
+  public cyclus::toolkit::CommodityProducer,
+  public cyclus::toolkit::Position {
+
+// clang-format off
 #pragma cyclus note { \
 "niche": "reactor", \
 "doc": \
@@ -106,7 +107,7 @@ class Reactor : public cyclus::Facility,
   " compositions." \
   "", \
 }
-  // clang-format on
+// clang-format on
 
  public:
   Reactor(cyclus::Context* ctx);
@@ -119,9 +120,8 @@ class Reactor : public cyclus::Facility,
   virtual void EnterNotify();
   virtual bool CheckDecommissionCondition();
 
-  virtual void AcceptMatlTrades(
-      const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                                  cyclus::Material::Ptr>>& responses);
+  virtual void AcceptMatlTrades(const std::vector<std::pair<
+      cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr> >& responses);
 
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
   GetMatlRequests();
@@ -130,11 +130,11 @@ class Reactor : public cyclus::Facility,
       cyclus::CommodMap<cyclus::Material>::type& commod_requests);
 
   virtual void GetMatlTrades(
-      const std::vector<cyclus::Trade<cyclus::Material>>& trades,
+      const std::vector<cyclus::Trade<cyclus::Material> >& trades,
       std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                            cyclus::Material::Ptr>>& responses);
+                            cyclus::Material::Ptr> >& responses);
 
-#pragma cyclus decl
+  #pragma cyclus decl
 
  private:
   std::string fuel_incommod(cyclus::Material::Ptr m);
@@ -182,7 +182,7 @@ class Reactor : public cyclus::Facility,
   /// Returns all spent assemblies indexed by outcommod without removing them
   /// from the spent fuel buffer.
   std::map<std::string, cyclus::toolkit::MatVec> PeekSpent();
-
+  
   // clang-format off
   /////// fuel specifications /////////
   #pragma cyclus var { \
@@ -487,6 +487,6 @@ class Reactor : public cyclus::Facility,
   void RecordPosition();
 };
 
-}  // namespace cycamore
+} // namespace cycamore
 
 #endif  // CYCAMORE_SRC_REACTOR_H_

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -55,6 +55,8 @@ namespace cycamore {
 class Reactor : public cyclus::Facility,
   public cyclus::toolkit::CommodityProducer,
   public cyclus::toolkit::Position {
+
+// clang-format off
 #pragma cyclus note { \
 "niche": "reactor", \
 "doc": \
@@ -105,6 +107,7 @@ class Reactor : public cyclus::Facility,
   " compositions." \
   "", \
 }
+// clang-format on
 
  public:
   Reactor(cyclus::Context* ctx);
@@ -179,7 +182,8 @@ class Reactor : public cyclus::Facility,
   /// Returns all spent assemblies indexed by outcommod without removing them
   /// from the spent fuel buffer.
   std::map<std::string, cyclus::toolkit::MatVec> PeekSpent();
-
+  
+  // clang-format off
   /////// fuel specifications /////////
   #pragma cyclus var { \
     "uitype": ["oneormore", "incommodity"], \
@@ -187,6 +191,7 @@ class Reactor : public cyclus::Facility,
     "doc": "Ordered list of input commodities on which to requesting fuel.", \
   }
   std::vector<std::string> fuel_incommods;
+
   #pragma cyclus var { \
     "uitype": ["oneormore", "inrecipe"], \
     "uilabel": "Fresh Fuel Recipe List", \
@@ -204,6 +209,7 @@ class Reactor : public cyclus::Facility,
            "requests (default).", \
   }
   std::vector<double> fuel_prefs;
+
   #pragma cyclus var { \
     "uitype": ["oneormore", "outcommodity"], \
     "uilabel": "Spent Fuel Commodity List", \
@@ -211,6 +217,7 @@ class Reactor : public cyclus::Facility,
            "received as each particular input commodity (same order)." \
   }
   std::vector<std::string> fuel_outcommods;
+
   #pragma cyclus var {           \
     "uitype": ["oneormore", "outrecipe"], \
     "uilabel": "Spent Fuel Recipe List", \
@@ -229,6 +236,7 @@ class Reactor : public cyclus::Facility,
            "a requested fresh fuel.", \
   }
   std::vector<int> recipe_change_times;
+
   #pragma cyclus var { \
     "default": [], \
     "uilabel": "Commodity for Changed Fresh/Spent Fuel Recipe", \
@@ -238,6 +246,7 @@ class Reactor : public cyclus::Facility,
     "uitype": ["oneormore", "incommodity"], \
   }
   std::vector<std::string> recipe_change_commods;
+
   #pragma cyclus var { \
     "default": [], \
     "uilabel": "New Recipe for Fresh Fuel", \
@@ -247,6 +256,7 @@ class Reactor : public cyclus::Facility,
     "uitype": ["oneormore", "inrecipe"], \
   }
   std::vector<std::string> recipe_change_in;
+
   #pragma cyclus var { \
     "default": [], \
     "uilabel": "New Recipe for Spent Fuel", \
@@ -283,6 +293,7 @@ class Reactor : public cyclus::Facility,
     "doc": "Number of assemblies that constitute a full core.", \
   }
   int n_assem_core;
+
   #pragma cyclus var { \
     "default": 0, \
     "uilabel": "Minimum Fresh Fuel Inventory", \
@@ -292,6 +303,7 @@ class Reactor : public cyclus::Facility,
     "doc": "Number of fresh fuel assemblies to keep on-hand if possible.", \
   }
   int n_assem_fresh;
+
   #pragma cyclus var { \
     "default": 1000000000, \
     "uilabel": "Maximum Spent Fuel Inventory", \
@@ -312,6 +324,7 @@ class Reactor : public cyclus::Facility,
     "units": "time steps", \
   }
   int cycle_time;
+
   #pragma cyclus var { \
     "default": 1, \
     "doc": "The duration of a full refueling period - the minimum time between"\
@@ -320,6 +333,7 @@ class Reactor : public cyclus::Facility,
     "units": "time steps", \
   }
   int refuel_time;
+
   #pragma cyclus var { \
     "default": 0, \
     "doc": "Number of time steps since the start of the last cycle." \
@@ -350,7 +364,6 @@ class Reactor : public cyclus::Facility,
   std::string power_name;
 
   /////////// hybrid params ///////////
-
   #pragma cyclus var { \
     "uilabel": "Side Product from Reactor Plant", \
     "default": [], \
@@ -365,21 +378,21 @@ class Reactor : public cyclus::Facility,
   }
   std::vector<double> side_product_quantity;
 
-  #pragma cyclus var {"default": 1,\
-                      "internal": True,\
-                      "doc": "True if reactor is a hybrid system (produces side products)", \
+  #pragma cyclus var { \
+    "default": 1,\
+    "internal": True,\
+    "doc": "True if reactor is a hybrid system (produces side products)", \
   }
   bool hybrid_;
 
-
   /////////// Decommission transmutation behavior ///////////
-  #pragma cyclus var {"default": 0, \
-                      "uilabel": "Boolean for transmutation behavior upon decommissioning.", \
-                      "doc": "If true, the archetype transmutes all assemblies upon decommissioning " \
-                             "If false, the archetype only transmutes half.", \
+  #pragma cyclus var { \
+    "default": 0, \
+    "uilabel": "Boolean for transmutation behavior upon decommissioning.", \
+    "doc": "If true, the archetype transmutes all assemblies upon decommissioning " \
+           "If false, the archetype only transmutes half.", \
   }
   bool decom_transmute_all;
-
 
   /////////// preference changes ///////////
   #pragma cyclus var { \
@@ -389,6 +402,7 @@ class Reactor : public cyclus::Facility,
            "particular fresh fuel type.", \
   }
   std::vector<int> pref_change_times;
+
   #pragma cyclus var { \
     "default": [], \
     "doc": "The input commodity for a particular fuel preference change.  " \
@@ -398,6 +412,7 @@ class Reactor : public cyclus::Facility,
     "uitype": ["oneormore", "incommodity"], \
   }
   std::vector<std::string> pref_change_commods;
+
   #pragma cyclus var { \
     "default": [], \
     "uilabel": "Changed Fresh Fuel Preference",                        \
@@ -428,18 +443,21 @@ class Reactor : public cyclus::Facility,
   #pragma cyclus var {"capacity": "n_assem_spent * assem_size"}
   cyclus::toolkit::ResBuf<cyclus::Material> spent;
 
-
   // should be hidden in ui (internal only). True if fuel has already been
   // discharged this cycle.
-  #pragma cyclus var {"default": 0, "doc": "This should NEVER be set manually",\
-                      "internal": True \
+  #pragma cyclus var { \
+    "default": 0, \
+    "doc": "This should NEVER be set manually", \
+    "internal": True \
   }
   bool discharged;
 
   // This variable should be hidden/unavailable in ui.  Maps resource object
   // id's to the index for the incommod through which they were received.
-  #pragma cyclus var {"default": {}, "doc": "This should NEVER be set manually", \
-                      "internal": True \
+  #pragma cyclus var { \
+    "default": {}, \
+    "doc": "This should NEVER be set manually", \
+    "internal": True \
   }
   std::map<int, int> res_indexes;
 
@@ -461,6 +479,7 @@ class Reactor : public cyclus::Facility,
            "be expressed in degrees as a double." \
   }
   double longitude;
+  // clang-format on
 
   cyclus::toolkit::Position coordinates;
 

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -53,10 +53,9 @@ namespace cycamore {
 /// compositions.
 
 class Reactor : public cyclus::Facility,
-  public cyclus::toolkit::CommodityProducer,
-  public cyclus::toolkit::Position {
-
-// clang-format off
+                public cyclus::toolkit::CommodityProducer,
+                public cyclus::toolkit::Position {
+  // clang-format off
 #pragma cyclus note { \
 "niche": "reactor", \
 "doc": \
@@ -107,7 +106,7 @@ class Reactor : public cyclus::Facility,
   " compositions." \
   "", \
 }
-// clang-format on
+  // clang-format on
 
  public:
   Reactor(cyclus::Context* ctx);
@@ -120,8 +119,9 @@ class Reactor : public cyclus::Facility,
   virtual void EnterNotify();
   virtual bool CheckDecommissionCondition();
 
-  virtual void AcceptMatlTrades(const std::vector<std::pair<
-      cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr> >& responses);
+  virtual void AcceptMatlTrades(
+      const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                                  cyclus::Material::Ptr>>& responses);
 
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
   GetMatlRequests();
@@ -130,15 +130,15 @@ class Reactor : public cyclus::Facility,
       cyclus::CommodMap<cyclus::Material>::type& commod_requests);
 
   virtual void GetMatlTrades(
-      const std::vector<cyclus::Trade<cyclus::Material> >& trades,
+      const std::vector<cyclus::Trade<cyclus::Material>>& trades,
       std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                            cyclus::Material::Ptr> >& responses);
+                            cyclus::Material::Ptr>>& responses);
 
-  #pragma cyclus decl
+#pragma cyclus decl
 
  private:
-  // Code Injection:
-  #include "toolkit/position.cycpp.h"
+// Code Injection:
+#include "toolkit/position.cycpp.h"
 
   std::string fuel_incommod(cyclus::Material::Ptr m);
   std::string fuel_outcommod(cyclus::Material::Ptr m);
@@ -185,7 +185,7 @@ class Reactor : public cyclus::Facility,
   /// Returns all spent assemblies indexed by outcommod without removing them
   /// from the spent fuel buffer.
   std::map<std::string, cyclus::toolkit::MatVec> PeekSpent();
-  
+
   // clang-format off
   /////// fuel specifications /////////
   #pragma cyclus var { \
@@ -470,6 +470,6 @@ class Reactor : public cyclus::Facility,
   // clang-format on
 };
 
-} // namespace cycamore
+}  // namespace cycamore
 
 #endif  // CYCAMORE_SRC_REACTOR_H_

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -467,6 +467,7 @@ class Reactor : public cyclus::Facility,
 
   // populated lazily and no need to persist.
   std::set<std::string> uniq_outcommods_;
+  // clang-format on
 };
 
 } // namespace cycamore

--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -4,12 +4,12 @@
 
 #include "cyclus.h"
 
+using pyne::nucname::id;
 using cyclus::Composition;
-using cyclus::Cond;
 using cyclus::Material;
 using cyclus::QueryResult;
+using cyclus::Cond;
 using cyclus::toolkit::MatQuery;
-using pyne::nucname::id;
 
 namespace cycamore {
 namespace reactortests {
@@ -31,24 +31,24 @@ Composition::Ptr c_mox() {
 
 Composition::Ptr c_spentuox() {
   cyclus::CompMap m;
-  m[id("u235")] = .8;
-  m[id("u238")] = 100;
+  m[id("u235")] =  .8;
+  m[id("u238")] =  100;
   m[id("pu239")] = 1;
   return Composition::CreateFromMass(m);
 };
 
 Composition::Ptr c_spentmox() {
   cyclus::CompMap m;
-  m[id("u235")] = .2;
-  m[id("u238")] = 100;
+  m[id("u235")] =  .2;
+  m[id("u238")] =  100;
   m[id("pu239")] = .9;
   return Composition::CreateFromMass(m);
 };
 
 Composition::Ptr c_water() {
   cyclus::CompMap m;
-  m[id("O16")] = 1;
-  m[id("H1")] = 2;
+  m[id("O16")] =  1;
+  m[id("H1")] =  2;
   return Composition::CreateFromAtom(m);
 };
 
@@ -57,17 +57,17 @@ Composition::Ptr c_water() {
 // delay.
 TEST(ReactorTests, JustInTimeOrdering) {
   std::string config =
-      "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
-      "  <fuel_prefs>      <val>1.0</val>        </fuel_prefs>  "
-      ""
-      "  <cycle_time>1</cycle_time>  "
-      "  <refuel_time>0</refuel_time>  "
-      "  <assem_size>300</assem_size>  "
-      "  <n_assem_core>1</n_assem_core>  "
-      "  <n_assem_batch>1</n_assem_batch>  ";
+     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+     "  <fuel_prefs>      <val>1.0</val>        </fuel_prefs>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>300</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  ";
 
   int simdur = 50;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -77,24 +77,23 @@ TEST(ReactorTests, JustInTimeOrdering) {
   int id = sim.Run();
 
   QueryResult qr = sim.db().Query("Transactions", NULL);
-  EXPECT_EQ(simdur, qr.rows.size())
-      << "failed to order+run on fresh fuel inside 1 time step";
+  EXPECT_EQ(simdur, qr.rows.size()) << "failed to order+run on fresh fuel inside 1 time step";
 }
 
 // tests that the correct number of assemblies are popped from the core each
 // cycle.
 TEST(ReactorTests, BatchSizes) {
   std::string config =
-      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-      ""
-      "  <cycle_time>1</cycle_time>  "
-      "  <refuel_time>0</refuel_time>  "
-      "  <assem_size>1</assem_size>  "
-      "  <n_assem_core>7</n_assem_core>  "
-      "  <n_assem_batch>3</n_assem_batch>  ";
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>7</n_assem_core>  "
+     "  <n_assem_batch>3</n_assem_batch>  ";
 
   int simdur = 50;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -105,23 +104,23 @@ TEST(ReactorTests, BatchSizes) {
 
   QueryResult qr = sim.db().Query("Transactions", NULL);
   // 7 for initial core, 3 per time step for each new batch for remainder
-  EXPECT_EQ(7 + 3 * (simdur - 1), qr.rows.size());
+  EXPECT_EQ(7+3*(simdur-1), qr.rows.size());
 }
 
 // tests that the refueling period between cycle end and start of the next
 // cycle is honored.
 TEST(ReactorTests, RefuelTimes) {
   std::string config =
-      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-      ""
-      "  <cycle_time>4</cycle_time>  "
-      "  <refuel_time>3</refuel_time>  "
-      "  <assem_size>1</assem_size>  "
-      "  <n_assem_core>1</n_assem_core>  "
-      "  <n_assem_batch>1</n_assem_batch>  ";
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>4</cycle_time>  "
+     "  <refuel_time>3</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  ";
 
   int simdur = 49;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -133,30 +132,30 @@ TEST(ReactorTests, RefuelTimes) {
   QueryResult qr = sim.db().Query("Transactions", NULL);
   int cyclet = 4;
   int refuelt = 3;
-  int n_assem_want = simdur / (cyclet + refuelt) + 1;  // +1 for initial core
+  int n_assem_want = simdur/(cyclet+refuelt)+1; // +1 for initial core
   EXPECT_EQ(n_assem_want, qr.rows.size());
 }
+
 
 // tests that a reactor decommissions on time without producing
 // power at the end of its lifetime.
 TEST(ReactorTests, DecomTimes) {
   std::string config =
-      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-      ""
-      "  <cycle_time>2</cycle_time>  "
-      "  <refuel_time>2</refuel_time>  "
-      "  <assem_size>1</assem_size>  "
-      "  <n_assem_core>3</n_assem_core>  "
-      "  <power_cap>1000</power_cap>  "
-      "  <n_assem_batch>1</n_assem_batch>  ";
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>2</cycle_time>  "
+     "  <refuel_time>2</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>3</n_assem_core>  "
+     "  <power_cap>1000</power_cap>  "
+     "  <n_assem_batch>1</n_assem_batch>  ";
 
   int simdur = 12;
   int lifetime = 7;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur,
-                      lifetime);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur, lifetime);
   sim.AddSource("uox").Finalize();
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("spentuox", c_spentuox());
@@ -176,26 +175,26 @@ TEST(ReactorTests, DecomTimes) {
   EXPECT_EQ(off_time, qr.rows.size());
 }
 
+
 // Tests if a reactor produces power at the time of its decommission
 // given a refuel_time of zero.
 TEST(ReactorTests, DecomZeroRefuel) {
   std::string config =
-      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-      ""
-      "  <cycle_time>2</cycle_time>  "
-      "  <refuel_time>0</refuel_time>  "
-      "  <assem_size>1</assem_size>  "
-      "  <n_assem_core>3</n_assem_core>  "
-      "  <power_cap>1000</power_cap>  "
-      "  <n_assem_batch>1</n_assem_batch>  ";
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>2</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>3</n_assem_core>  "
+     "  <power_cap>1000</power_cap>  "
+     "  <n_assem_batch>1</n_assem_batch>  ";
 
   int simdur = 8;
   int lifetime = 6;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur,
-                      lifetime);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur, lifetime);
   sim.AddSource("uox").Finalize();
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("spentuox", c_spentuox());
@@ -214,16 +213,16 @@ TEST(ReactorTests, DecomZeroRefuel) {
 // different than RefuelTimes test and is not a duplicate of it.
 TEST(ReactorTests, OrderAtRefuelStart) {
   std::string config =
-      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-      ""
-      "  <cycle_time>4</cycle_time>  "
-      "  <refuel_time>3</refuel_time>  "
-      "  <assem_size>1</assem_size>  "
-      "  <n_assem_core>1</n_assem_core>  "
-      "  <n_assem_batch>1</n_assem_batch>  ";
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>4</cycle_time>  "
+     "  <refuel_time>3</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  ";
 
   int simdur = 7;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -235,7 +234,7 @@ TEST(ReactorTests, OrderAtRefuelStart) {
   QueryResult qr = sim.db().Query("Transactions", NULL);
   int cyclet = 4;
   int refuelt = 3;
-  int n_assem_want = simdur / (cyclet + refuelt) + 1;  // +1 for initial core
+  int n_assem_want = simdur/(cyclet+refuelt)+1; // +1 for initial core
   EXPECT_EQ(n_assem_want, qr.rows.size());
 }
 
@@ -243,21 +242,17 @@ TEST(ReactorTests, OrderAtRefuelStart) {
 // - with proper inventory constraint honoring, etc.
 TEST(ReactorTests, MultiFuelMix) {
   std::string config =
-      "  <fuel_inrecipes>  <val>uox</val>      <val>mox</val>      "
-      "</fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>spentuox</val> <val>spentmox</val> "
-      "</fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>uox</val>      <val>mox</val>      "
-      "</fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>    <val>waste</val>    "
-      "</fuel_outcommods>  "
-      ""
-      "  <cycle_time>1</cycle_time>  "
-      "  <refuel_time>0</refuel_time>  "
-      "  <assem_size>1</assem_size>  "
-      "  <n_assem_fresh>3</n_assem_fresh>  "
-      "  <n_assem_core>3</n_assem_core>  "
-      "  <n_assem_batch>3</n_assem_batch>  ";
+     "  <fuel_inrecipes>  <val>uox</val>      <val>mox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> <val>spentmox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      <val>mox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_fresh>3</n_assem_fresh>  "
+     "  <n_assem_core>3</n_assem_core>  "
+     "  <n_assem_batch>3</n_assem_batch>  ";
 
   // it is important that the sources have cumulative capacity greater than
   // the reactor can take on a single time step - to test that inventory
@@ -276,24 +271,24 @@ TEST(ReactorTests, MultiFuelMix) {
 
   QueryResult qr = sim.db().Query("Transactions", NULL);
   // +3 is for fresh fuel inventory
-  EXPECT_EQ(3 * simdur + 3, qr.rows.size());
+  EXPECT_EQ(3*simdur+3, qr.rows.size());
 }
 
 // tests that the reactor halts operation when it has no more room in its
 // spent fuel inventory buffer.
 TEST(ReactorTests, FullSpentInventory) {
   std::string config =
-      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-      ""
-      "  <cycle_time>1</cycle_time>  "
-      "  <refuel_time>0</refuel_time>  "
-      "  <assem_size>1</assem_size>  "
-      "  <n_assem_core>1</n_assem_core>  "
-      "  <n_assem_batch>1</n_assem_batch>  "
-      "  <n_assem_spent>3</n_assem_spent>  ";
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  "
+     "  <n_assem_spent>3</n_assem_spent>  ";
 
   int simdur = 10;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -306,25 +301,25 @@ TEST(ReactorTests, FullSpentInventory) {
   int n_assem_spent = 3;
 
   // +1 is for the assembly in the core + the three in spent
-  EXPECT_EQ(n_assem_spent + 1, qr.rows.size());
+  EXPECT_EQ(n_assem_spent+1, qr.rows.size());
 }
 
 // tests that the reactor shuts down, ie., does not generate power, when the
 // spent fuel inventory is full and the core cannot be unloaded.
 TEST(ReactorTests, FullSpentInventoryShutdown) {
   std::string config =
-      " <fuel_inrecipes> <val>uox</val> </fuel_inrecipes> "
-      " <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes> "
-      " <fuel_incommods> <val>uox</val> </fuel_incommods> "
-      " <fuel_outcommods> <val>waste</val> </fuel_outcommods> "
-      ""
-      " <cycle_time>1</cycle_time> "
-      " <refuel_time>0</refuel_time> "
-      " <assem_size>1</assem_size> "
-      " <n_assem_core>1</n_assem_core> "
-      " <n_assem_batch>1</n_assem_batch> "
-      " <n_assem_spent>1</n_assem_spent> "
-      " <power_cap>100</power_cap> ";
+    " <fuel_inrecipes> <val>uox</val> </fuel_inrecipes> "
+    " <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes> "
+    " <fuel_incommods> <val>uox</val> </fuel_incommods> "
+    " <fuel_outcommods> <val>waste</val> </fuel_outcommods> "
+    ""
+    " <cycle_time>1</cycle_time> "
+    " <refuel_time>0</refuel_time> "
+    " <assem_size>1</assem_size> "
+    " <n_assem_core>1</n_assem_core> "
+    " <n_assem_batch>1</n_assem_batch> "
+    " <n_assem_spent>1</n_assem_spent> "
+    " <power_cap>100</power_cap> ";
 
   int simdur = 3;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -335,37 +330,32 @@ TEST(ReactorTests, FullSpentInventoryShutdown) {
 
   QueryResult qr = sim.db().Query("TimeSeriesPower", NULL);
   EXPECT_EQ(0, qr.GetVal<double>("Value", simdur - 1));
+
 }
 
 // tests that the reactor cycle is delayed as expected when it is unable to
 // acquire fuel in time for the next cycle start.  This checks that after a
-// cycle is delayed past an original scheduled start time, as soon as enough
-// fuel is received, a new cycle pattern is established starting from the
-// delayed start time.
+// cycle is delayed past an original scheduled start time, as soon as enough fuel is
+// received, a new cycle pattern is established starting from the delayed
+// start time.
 TEST(ReactorTests, FuelShortage) {
   std::string config =
-      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-      ""
-      "  <cycle_time>7</cycle_time>  "
-      "  <refuel_time>0</refuel_time>  "
-      "  <assem_size>1</assem_size>  "
-      "  <n_assem_core>3</n_assem_core>  "
-      "  <n_assem_batch>3</n_assem_batch>  ";
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>7</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>3</n_assem_core>  "
+     "  <n_assem_batch>3</n_assem_batch>  ";
 
   int simdur = 50;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
-  sim.AddSource("uox").lifetime(1).Finalize();  // provide initial full batch
-  sim.AddSource("uox")
-      .start(9)
-      .lifetime(1)
-      .capacity(2)
-      .Finalize();  // provide partial batch post cycle-end
-  sim.AddSource("uox")
-      .start(15)
-      .Finalize();  // provide remainder of batch much later
+  sim.AddSource("uox").lifetime(1).Finalize(); // provide initial full batch
+  sim.AddSource("uox").start(9).lifetime(1).capacity(2).Finalize(); // provide partial batch post cycle-end
+  sim.AddSource("uox").start(15).Finalize(); // provide remainder of batch much later
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("spentuox", c_spentuox());
   int id = sim.Run();
@@ -389,8 +379,7 @@ TEST(ReactorTests, FuelShortage) {
   qr = sim.db().Query("Transactions", &conds);
   EXPECT_EQ(6, qr.rows.size());
 
-  // as soon as this delayed cycle ends, we should be requesting/getting 3 new
-  // batches
+  // as soon as this delayed cycle ends, we should be requesting/getting 3 new batches
   conds.clear();
   conds.push_back(Cond("Time", "==", 22));
   qr = sim.db().Query("Transactions", &conds);
@@ -400,16 +389,16 @@ TEST(ReactorTests, FuelShortage) {
 // tests that discharged fuel is transmuted properly immediately at cycle end.
 TEST(ReactorTests, DischargedFuelTransmute) {
   std::string config =
-      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-      ""
-      "  <cycle_time>4</cycle_time>  "
-      "  <refuel_time>3</refuel_time>  "
-      "  <assem_size>1</assem_size>  "
-      "  <n_assem_core>1</n_assem_core>  "
-      "  <n_assem_batch>1</n_assem_batch>  ";
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>4</cycle_time>  "
+     "  <refuel_time>3</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  ";
 
   int simdur = 7;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -426,8 +415,7 @@ TEST(ReactorTests, DischargedFuelTransmute) {
   Material::Ptr m = sim.GetMaterial(resid);
   MatQuery mq(m);
   EXPECT_EQ(spentuox->id(), m->comp()->id());
-  EXPECT_TRUE(mq.mass(942390000) > 0)
-      << "transmuted spent fuel doesn't have Pu239";
+  EXPECT_TRUE(mq.mass(942390000) > 0) << "transmuted spent fuel doesn't have Pu239";
 }
 
 // tests that spent fuel is offerred on correct commods according to the
@@ -435,20 +423,16 @@ TEST(ReactorTests, DischargedFuelTransmute) {
 // simultaneously.
 TEST(ReactorTests, SpentFuelProperCommodTracking) {
   std::string config =
-      "  <fuel_inrecipes>  <val>uox</val>      <val>mox</val>      "
-      "</fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>spentuox</val> <val>spentmox</val> "
-      "</fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>uox</val>      <val>mox</val>      "
-      "</fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste1</val>   <val>waste2</val>   "
-      "</fuel_outcommods>  "
-      ""
-      "  <cycle_time>1</cycle_time>  "
-      "  <refuel_time>0</refuel_time>  "
-      "  <assem_size>1</assem_size>  "
-      "  <n_assem_core>3</n_assem_core>  "
-      "  <n_assem_batch>3</n_assem_batch>  ";
+     "  <fuel_inrecipes>  <val>uox</val>      <val>mox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> <val>spentmox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      <val>mox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste1</val>   <val>waste2</val>   </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>3</n_assem_core>  "
+     "  <n_assem_batch>3</n_assem_batch>  ";
 
   int simdur = 7;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -466,11 +450,11 @@ TEST(ReactorTests, SpentFuelProperCommodTracking) {
   conds.push_back(Cond("SenderId", "==", id));
   conds.push_back(Cond("Commodity", "==", std::string("waste1")));
   QueryResult qr = sim.db().Query("Transactions", &conds);
-  EXPECT_EQ(simdur - 1, qr.rows.size());
+  EXPECT_EQ(simdur-1, qr.rows.size());
 
   conds[1] = Cond("Commodity", "==", std::string("waste2"));
   qr = sim.db().Query("Transactions", &conds);
-  EXPECT_EQ(2 * (simdur - 1), qr.rows.size());
+  EXPECT_EQ(2*(simdur-1), qr.rows.size());
 }
 
 // The user can optionally omit fuel preferences.  In the case where
@@ -480,20 +464,20 @@ TEST(ReactorTests, SpentFuelProperCommodTracking) {
 TEST(ReactorTests, PrefChange) {
   // it is important that the fuel_prefs not be present in the config below.
   std::string config =
-      "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
-      ""
-      "  <cycle_time>1</cycle_time>  "
-      "  <refuel_time>0</refuel_time>  "
-      "  <assem_size>300</assem_size>  "
-      "  <n_assem_core>1</n_assem_core>  "
-      "  <n_assem_batch>1</n_assem_batch>  "
-      ""
-      "  <pref_change_times>   <val>25</val>         </pref_change_times>"
-      "  <pref_change_commods> <val>enriched_u</val> </pref_change_commods>"
-      "  <pref_change_values>  <val>-1</val>         </pref_change_values>";
+     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>300</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  "
+     ""
+     "  <pref_change_times>   <val>25</val>         </pref_change_times>"
+     "  <pref_change_commods> <val>enriched_u</val> </pref_change_commods>"
+     "  <pref_change_values>  <val>-1</val>         </pref_change_values>";
 
   int simdur = 50;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -509,25 +493,21 @@ TEST(ReactorTests, PrefChange) {
 TEST(ReactorTests, RecipeChange) {
   // it is important that the fuel_prefs not be present in the config below.
   std::string config =
-      "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
-      ""
-      "  <cycle_time>1</cycle_time>  "
-      "  <refuel_time>0</refuel_time>  "
-      "  <assem_size>300</assem_size>  "
-      "  <n_assem_core>1</n_assem_core>  "
-      "  <n_assem_batch>1</n_assem_batch>  "
-      ""
-      "  <recipe_change_times>   <val>25</val>         <val>35</val>         "
-      "</recipe_change_times>"
-      "  <recipe_change_commods> <val>enriched_u</val> <val>enriched_u</val> "
-      "</recipe_change_commods>"
-      "  <recipe_change_in>      <val>water</val>      <val>water</val>      "
-      "</recipe_change_in>"
-      "  <recipe_change_out>     <val>lwr_spent</val>  <val>water</val>      "
-      "</recipe_change_out>";
+     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>300</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  "
+     ""
+     "  <recipe_change_times>   <val>25</val>         <val>35</val>         </recipe_change_times>"
+     "  <recipe_change_commods> <val>enriched_u</val> <val>enriched_u</val> </recipe_change_commods>"
+     "  <recipe_change_in>      <val>water</val>      <val>water</val>      </recipe_change_in>"
+     "  <recipe_change_out>     <val>lwr_spent</val>  <val>water</val>      </recipe_change_out>";
 
   int simdur = 50;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -584,26 +564,25 @@ TEST(ReactorTests, RecipeChange) {
 
 TEST(ReactorTests, Retire) {
   std::string config =
-      "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
-      ""
-      "  <cycle_time>7</cycle_time>  "
-      "  <refuel_time>0</refuel_time>  "
-      "  <assem_size>300</assem_size>  "
-      "  <n_assem_fresh>1</n_assem_fresh>  "
-      "  <n_assem_core>3</n_assem_core>  "
-      "  <n_assem_batch>1</n_assem_batch>  "
-      "  <power_cap>1</power_cap>  "
-      "";
+     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+     ""
+     "  <cycle_time>7</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>300</assem_size>  "
+     "  <n_assem_fresh>1</n_assem_fresh>  "
+     "  <n_assem_core>3</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  "
+     "  <power_cap>1</power_cap>  "
+     "";
 
   int dur = 50;
   int life = 36;
   int cycle_time = 7;
   int refuel_time = 0;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, dur,
-                      life);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, dur, life);
   sim.AddSource("enriched_u").Finalize();
   sim.AddSink("waste").Finalize();
   sim.AddRecipe("lwr_fresh", c_uox());
@@ -632,8 +611,7 @@ TEST(ReactorTests, Retire) {
       << "failed to discharge all material by retirement time";
 
   // reactor should record power entry on the time step it retires if operating
-  int time_online = life / (cycle_time + refuel_time) * cycle_time +
-                    std::min(life % (cycle_time + refuel_time), cycle_time);
+  int time_online = life / (cycle_time + refuel_time) * cycle_time + std::min(life % (cycle_time + refuel_time), cycle_time);
   conds.clear();
   conds.push_back(Cond("AgentId", "==", id));
   conds.push_back(Cond("Value", ">", 0));
@@ -644,17 +622,17 @@ TEST(ReactorTests, Retire) {
 
 TEST(ReactorTests, PositionInitialize) {
   std::string config =
-      "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
-      "  <fuel_prefs>      <val>1.0</val>        </fuel_prefs>  "
-      ""
-      "  <cycle_time>1</cycle_time>  "
-      "  <refuel_time>0</refuel_time>  "
-      "  <assem_size>300</assem_size>  "
-      "  <n_assem_core>1</n_assem_core>  "
-      "  <n_assem_batch>1</n_assem_batch>  ";
+     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+     "  <fuel_prefs>      <val>1.0</val>        </fuel_prefs>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>300</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  ";
 
   int simdur = 50;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -670,19 +648,19 @@ TEST(ReactorTests, PositionInitialize) {
 
 TEST(ReactorTests, PositionInitialize2) {
   std::string config =
-      "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
-      "  <fuel_prefs>      <val>1.0</val>        </fuel_prefs>  "
-      ""
-      "  <cycle_time>1</cycle_time>  "
-      "  <refuel_time>0</refuel_time>  "
-      "  <assem_size>300</assem_size>  "
-      "  <n_assem_core>1</n_assem_core>  "
-      "  <n_assem_batch>1</n_assem_batch>  "
-      "  <longitude>30.0</longitude>  "
-      "  <latitude>30.0</latitude>  ";
+     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+     "  <fuel_prefs>      <val>1.0</val>        </fuel_prefs>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>0</refuel_time>  "
+     "  <assem_size>300</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  "
+     "  <longitude>30.0</longitude>  "
+     "  <latitude>30.0</latitude>  ";
 
   int simdur = 50;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -698,19 +676,19 @@ TEST(ReactorTests, PositionInitialize2) {
 
 TEST(ReactorTests, ByProduct) {
   std::string config =
-      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-      ""
-      "  <cycle_time>1</cycle_time>  "
-      "  <refuel_time>1</refuel_time>  "
-      "  <assem_size>1</assem_size>  "
-      "  <n_assem_core>7</n_assem_core>  "
-      "  <n_assem_batch>3</n_assem_batch>  "
-      ""
-      "  <side_products> <val>process_heat</val> </side_products>"
-      "  <side_product_quantity> <val>10</val> </side_product_quantity>";
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>1</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>7</n_assem_core>  "
+     "  <n_assem_batch>3</n_assem_batch>  "
+     ""
+     "  <side_products> <val>process_heat</val> </side_products>"
+     "  <side_product_quantity> <val>10</val> </side_product_quantity>";
 
   int simdur = 10;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -735,21 +713,19 @@ TEST(ReactorTests, ByProduct) {
 
 TEST(ReactorTests, MultipleByProduct) {
   std::string config =
-      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-      ""
-      "  <cycle_time>1</cycle_time>  "
-      "  <refuel_time>1</refuel_time>  "
-      "  <assem_size>1</assem_size>  "
-      "  <n_assem_core>7</n_assem_core>  "
-      "  <n_assem_batch>3</n_assem_batch>  "
-      ""
-      "  <side_products> <val>process_heat</val> <val>water</val> "
-      "</side_products>"
-      "  <side_product_quantity> <val>10</val> <val>100</val> "
-      "</side_product_quantity>";
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     ""
+     "  <cycle_time>1</cycle_time>  "
+     "  <refuel_time>1</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>7</n_assem_core>  "
+     "  <n_assem_batch>3</n_assem_batch>  "
+     ""
+     "  <side_products> <val>process_heat</val> <val>water</val> </side_products>"
+     "  <side_product_quantity> <val>10</val> <val>100</val> </side_product_quantity>";
 
   int simdur = 10;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -757,6 +733,7 @@ TEST(ReactorTests, MultipleByProduct) {
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("spentuox", c_spentuox());
   int id = sim.Run();
+
 
   std::vector<Cond> conds;
   // test if it produces heat when reactor is running
@@ -778,7 +755,9 @@ TEST(ReactorTests, MultipleByProduct) {
   conds.push_back(Cond("Value", "==", 0));
   qr = sim.db().Query("ReactorSideProducts", &conds);
   EXPECT_EQ(10, qr.rows.size());
+
 }
 
-}  // namespace reactortests
-}  // namespace cycamore
+} // namespace reactortests
+} // namespace cycamore
+

--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -4,12 +4,12 @@
 
 #include "cyclus.h"
 
-using pyne::nucname::id;
 using cyclus::Composition;
+using cyclus::Cond;
 using cyclus::Material;
 using cyclus::QueryResult;
-using cyclus::Cond;
 using cyclus::toolkit::MatQuery;
+using pyne::nucname::id;
 
 namespace cycamore {
 namespace reactortests {
@@ -31,24 +31,24 @@ Composition::Ptr c_mox() {
 
 Composition::Ptr c_spentuox() {
   cyclus::CompMap m;
-  m[id("u235")] =  .8;
-  m[id("u238")] =  100;
+  m[id("u235")] = .8;
+  m[id("u238")] = 100;
   m[id("pu239")] = 1;
   return Composition::CreateFromMass(m);
 };
 
 Composition::Ptr c_spentmox() {
   cyclus::CompMap m;
-  m[id("u235")] =  .2;
-  m[id("u238")] =  100;
+  m[id("u235")] = .2;
+  m[id("u238")] = 100;
   m[id("pu239")] = .9;
   return Composition::CreateFromMass(m);
 };
 
 Composition::Ptr c_water() {
   cyclus::CompMap m;
-  m[id("O16")] =  1;
-  m[id("H1")] =  2;
+  m[id("O16")] = 1;
+  m[id("H1")] = 2;
   return Composition::CreateFromAtom(m);
 };
 
@@ -57,17 +57,17 @@ Composition::Ptr c_water() {
 // delay.
 TEST(ReactorTests, JustInTimeOrdering) {
   std::string config =
-     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
-     "  <fuel_prefs>      <val>1.0</val>        </fuel_prefs>  "
-     ""
-     "  <cycle_time>1</cycle_time>  "
-     "  <refuel_time>0</refuel_time>  "
-     "  <assem_size>300</assem_size>  "
-     "  <n_assem_core>1</n_assem_core>  "
-     "  <n_assem_batch>1</n_assem_batch>  ";
+      "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+      "  <fuel_prefs>      <val>1.0</val>        </fuel_prefs>  "
+      ""
+      "  <cycle_time>1</cycle_time>  "
+      "  <refuel_time>0</refuel_time>  "
+      "  <assem_size>300</assem_size>  "
+      "  <n_assem_core>1</n_assem_core>  "
+      "  <n_assem_batch>1</n_assem_batch>  ";
 
   int simdur = 50;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -77,23 +77,24 @@ TEST(ReactorTests, JustInTimeOrdering) {
   int id = sim.Run();
 
   QueryResult qr = sim.db().Query("Transactions", NULL);
-  EXPECT_EQ(simdur, qr.rows.size()) << "failed to order+run on fresh fuel inside 1 time step";
+  EXPECT_EQ(simdur, qr.rows.size())
+      << "failed to order+run on fresh fuel inside 1 time step";
 }
 
 // tests that the correct number of assemblies are popped from the core each
 // cycle.
 TEST(ReactorTests, BatchSizes) {
   std::string config =
-     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-     ""
-     "  <cycle_time>1</cycle_time>  "
-     "  <refuel_time>0</refuel_time>  "
-     "  <assem_size>1</assem_size>  "
-     "  <n_assem_core>7</n_assem_core>  "
-     "  <n_assem_batch>3</n_assem_batch>  ";
+      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+      ""
+      "  <cycle_time>1</cycle_time>  "
+      "  <refuel_time>0</refuel_time>  "
+      "  <assem_size>1</assem_size>  "
+      "  <n_assem_core>7</n_assem_core>  "
+      "  <n_assem_batch>3</n_assem_batch>  ";
 
   int simdur = 50;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -104,23 +105,23 @@ TEST(ReactorTests, BatchSizes) {
 
   QueryResult qr = sim.db().Query("Transactions", NULL);
   // 7 for initial core, 3 per time step for each new batch for remainder
-  EXPECT_EQ(7+3*(simdur-1), qr.rows.size());
+  EXPECT_EQ(7 + 3 * (simdur - 1), qr.rows.size());
 }
 
 // tests that the refueling period between cycle end and start of the next
 // cycle is honored.
 TEST(ReactorTests, RefuelTimes) {
   std::string config =
-     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-     ""
-     "  <cycle_time>4</cycle_time>  "
-     "  <refuel_time>3</refuel_time>  "
-     "  <assem_size>1</assem_size>  "
-     "  <n_assem_core>1</n_assem_core>  "
-     "  <n_assem_batch>1</n_assem_batch>  ";
+      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+      ""
+      "  <cycle_time>4</cycle_time>  "
+      "  <refuel_time>3</refuel_time>  "
+      "  <assem_size>1</assem_size>  "
+      "  <n_assem_core>1</n_assem_core>  "
+      "  <n_assem_batch>1</n_assem_batch>  ";
 
   int simdur = 49;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -132,30 +133,30 @@ TEST(ReactorTests, RefuelTimes) {
   QueryResult qr = sim.db().Query("Transactions", NULL);
   int cyclet = 4;
   int refuelt = 3;
-  int n_assem_want = simdur/(cyclet+refuelt)+1; // +1 for initial core
+  int n_assem_want = simdur / (cyclet + refuelt) + 1;  // +1 for initial core
   EXPECT_EQ(n_assem_want, qr.rows.size());
 }
-
 
 // tests that a reactor decommissions on time without producing
 // power at the end of its lifetime.
 TEST(ReactorTests, DecomTimes) {
   std::string config =
-     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-     ""
-     "  <cycle_time>2</cycle_time>  "
-     "  <refuel_time>2</refuel_time>  "
-     "  <assem_size>1</assem_size>  "
-     "  <n_assem_core>3</n_assem_core>  "
-     "  <power_cap>1000</power_cap>  "
-     "  <n_assem_batch>1</n_assem_batch>  ";
+      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+      ""
+      "  <cycle_time>2</cycle_time>  "
+      "  <refuel_time>2</refuel_time>  "
+      "  <assem_size>1</assem_size>  "
+      "  <n_assem_core>3</n_assem_core>  "
+      "  <power_cap>1000</power_cap>  "
+      "  <n_assem_batch>1</n_assem_batch>  ";
 
   int simdur = 12;
   int lifetime = 7;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur, lifetime);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur,
+                      lifetime);
   sim.AddSource("uox").Finalize();
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("spentuox", c_spentuox());
@@ -175,26 +176,26 @@ TEST(ReactorTests, DecomTimes) {
   EXPECT_EQ(off_time, qr.rows.size());
 }
 
-
 // Tests if a reactor produces power at the time of its decommission
 // given a refuel_time of zero.
 TEST(ReactorTests, DecomZeroRefuel) {
   std::string config =
-     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-     ""
-     "  <cycle_time>2</cycle_time>  "
-     "  <refuel_time>0</refuel_time>  "
-     "  <assem_size>1</assem_size>  "
-     "  <n_assem_core>3</n_assem_core>  "
-     "  <power_cap>1000</power_cap>  "
-     "  <n_assem_batch>1</n_assem_batch>  ";
+      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+      ""
+      "  <cycle_time>2</cycle_time>  "
+      "  <refuel_time>0</refuel_time>  "
+      "  <assem_size>1</assem_size>  "
+      "  <n_assem_core>3</n_assem_core>  "
+      "  <power_cap>1000</power_cap>  "
+      "  <n_assem_batch>1</n_assem_batch>  ";
 
   int simdur = 8;
   int lifetime = 6;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur, lifetime);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur,
+                      lifetime);
   sim.AddSource("uox").Finalize();
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("spentuox", c_spentuox());
@@ -213,16 +214,16 @@ TEST(ReactorTests, DecomZeroRefuel) {
 // different than RefuelTimes test and is not a duplicate of it.
 TEST(ReactorTests, OrderAtRefuelStart) {
   std::string config =
-     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-     ""
-     "  <cycle_time>4</cycle_time>  "
-     "  <refuel_time>3</refuel_time>  "
-     "  <assem_size>1</assem_size>  "
-     "  <n_assem_core>1</n_assem_core>  "
-     "  <n_assem_batch>1</n_assem_batch>  ";
+      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+      ""
+      "  <cycle_time>4</cycle_time>  "
+      "  <refuel_time>3</refuel_time>  "
+      "  <assem_size>1</assem_size>  "
+      "  <n_assem_core>1</n_assem_core>  "
+      "  <n_assem_batch>1</n_assem_batch>  ";
 
   int simdur = 7;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -234,7 +235,7 @@ TEST(ReactorTests, OrderAtRefuelStart) {
   QueryResult qr = sim.db().Query("Transactions", NULL);
   int cyclet = 4;
   int refuelt = 3;
-  int n_assem_want = simdur/(cyclet+refuelt)+1; // +1 for initial core
+  int n_assem_want = simdur / (cyclet + refuelt) + 1;  // +1 for initial core
   EXPECT_EQ(n_assem_want, qr.rows.size());
 }
 
@@ -242,17 +243,21 @@ TEST(ReactorTests, OrderAtRefuelStart) {
 // - with proper inventory constraint honoring, etc.
 TEST(ReactorTests, MultiFuelMix) {
   std::string config =
-     "  <fuel_inrecipes>  <val>uox</val>      <val>mox</val>      </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>spentuox</val> <val>spentmox</val> </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>uox</val>      <val>mox</val>      </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>    <val>waste</val>    </fuel_outcommods>  "
-     ""
-     "  <cycle_time>1</cycle_time>  "
-     "  <refuel_time>0</refuel_time>  "
-     "  <assem_size>1</assem_size>  "
-     "  <n_assem_fresh>3</n_assem_fresh>  "
-     "  <n_assem_core>3</n_assem_core>  "
-     "  <n_assem_batch>3</n_assem_batch>  ";
+      "  <fuel_inrecipes>  <val>uox</val>      <val>mox</val>      "
+      "</fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>spentuox</val> <val>spentmox</val> "
+      "</fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>uox</val>      <val>mox</val>      "
+      "</fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>    <val>waste</val>    "
+      "</fuel_outcommods>  "
+      ""
+      "  <cycle_time>1</cycle_time>  "
+      "  <refuel_time>0</refuel_time>  "
+      "  <assem_size>1</assem_size>  "
+      "  <n_assem_fresh>3</n_assem_fresh>  "
+      "  <n_assem_core>3</n_assem_core>  "
+      "  <n_assem_batch>3</n_assem_batch>  ";
 
   // it is important that the sources have cumulative capacity greater than
   // the reactor can take on a single time step - to test that inventory
@@ -271,24 +276,24 @@ TEST(ReactorTests, MultiFuelMix) {
 
   QueryResult qr = sim.db().Query("Transactions", NULL);
   // +3 is for fresh fuel inventory
-  EXPECT_EQ(3*simdur+3, qr.rows.size());
+  EXPECT_EQ(3 * simdur + 3, qr.rows.size());
 }
 
 // tests that the reactor halts operation when it has no more room in its
 // spent fuel inventory buffer.
 TEST(ReactorTests, FullSpentInventory) {
   std::string config =
-     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-     ""
-     "  <cycle_time>1</cycle_time>  "
-     "  <refuel_time>0</refuel_time>  "
-     "  <assem_size>1</assem_size>  "
-     "  <n_assem_core>1</n_assem_core>  "
-     "  <n_assem_batch>1</n_assem_batch>  "
-     "  <n_assem_spent>3</n_assem_spent>  ";
+      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+      ""
+      "  <cycle_time>1</cycle_time>  "
+      "  <refuel_time>0</refuel_time>  "
+      "  <assem_size>1</assem_size>  "
+      "  <n_assem_core>1</n_assem_core>  "
+      "  <n_assem_batch>1</n_assem_batch>  "
+      "  <n_assem_spent>3</n_assem_spent>  ";
 
   int simdur = 10;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -301,25 +306,25 @@ TEST(ReactorTests, FullSpentInventory) {
   int n_assem_spent = 3;
 
   // +1 is for the assembly in the core + the three in spent
-  EXPECT_EQ(n_assem_spent+1, qr.rows.size());
+  EXPECT_EQ(n_assem_spent + 1, qr.rows.size());
 }
 
 // tests that the reactor shuts down, ie., does not generate power, when the
 // spent fuel inventory is full and the core cannot be unloaded.
 TEST(ReactorTests, FullSpentInventoryShutdown) {
   std::string config =
-    " <fuel_inrecipes> <val>uox</val> </fuel_inrecipes> "
-    " <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes> "
-    " <fuel_incommods> <val>uox</val> </fuel_incommods> "
-    " <fuel_outcommods> <val>waste</val> </fuel_outcommods> "
-    ""
-    " <cycle_time>1</cycle_time> "
-    " <refuel_time>0</refuel_time> "
-    " <assem_size>1</assem_size> "
-    " <n_assem_core>1</n_assem_core> "
-    " <n_assem_batch>1</n_assem_batch> "
-    " <n_assem_spent>1</n_assem_spent> "
-    " <power_cap>100</power_cap> ";
+      " <fuel_inrecipes> <val>uox</val> </fuel_inrecipes> "
+      " <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes> "
+      " <fuel_incommods> <val>uox</val> </fuel_incommods> "
+      " <fuel_outcommods> <val>waste</val> </fuel_outcommods> "
+      ""
+      " <cycle_time>1</cycle_time> "
+      " <refuel_time>0</refuel_time> "
+      " <assem_size>1</assem_size> "
+      " <n_assem_core>1</n_assem_core> "
+      " <n_assem_batch>1</n_assem_batch> "
+      " <n_assem_spent>1</n_assem_spent> "
+      " <power_cap>100</power_cap> ";
 
   int simdur = 3;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -330,32 +335,37 @@ TEST(ReactorTests, FullSpentInventoryShutdown) {
 
   QueryResult qr = sim.db().Query("TimeSeriesPower", NULL);
   EXPECT_EQ(0, qr.GetVal<double>("Value", simdur - 1));
-
 }
 
 // tests that the reactor cycle is delayed as expected when it is unable to
 // acquire fuel in time for the next cycle start.  This checks that after a
-// cycle is delayed past an original scheduled start time, as soon as enough fuel is
-// received, a new cycle pattern is established starting from the delayed
-// start time.
+// cycle is delayed past an original scheduled start time, as soon as enough
+// fuel is received, a new cycle pattern is established starting from the
+// delayed start time.
 TEST(ReactorTests, FuelShortage) {
   std::string config =
-     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-     ""
-     "  <cycle_time>7</cycle_time>  "
-     "  <refuel_time>0</refuel_time>  "
-     "  <assem_size>1</assem_size>  "
-     "  <n_assem_core>3</n_assem_core>  "
-     "  <n_assem_batch>3</n_assem_batch>  ";
+      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+      ""
+      "  <cycle_time>7</cycle_time>  "
+      "  <refuel_time>0</refuel_time>  "
+      "  <assem_size>1</assem_size>  "
+      "  <n_assem_core>3</n_assem_core>  "
+      "  <n_assem_batch>3</n_assem_batch>  ";
 
   int simdur = 50;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
-  sim.AddSource("uox").lifetime(1).Finalize(); // provide initial full batch
-  sim.AddSource("uox").start(9).lifetime(1).capacity(2).Finalize(); // provide partial batch post cycle-end
-  sim.AddSource("uox").start(15).Finalize(); // provide remainder of batch much later
+  sim.AddSource("uox").lifetime(1).Finalize();  // provide initial full batch
+  sim.AddSource("uox")
+      .start(9)
+      .lifetime(1)
+      .capacity(2)
+      .Finalize();  // provide partial batch post cycle-end
+  sim.AddSource("uox")
+      .start(15)
+      .Finalize();  // provide remainder of batch much later
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("spentuox", c_spentuox());
   int id = sim.Run();
@@ -379,7 +389,8 @@ TEST(ReactorTests, FuelShortage) {
   qr = sim.db().Query("Transactions", &conds);
   EXPECT_EQ(6, qr.rows.size());
 
-  // as soon as this delayed cycle ends, we should be requesting/getting 3 new batches
+  // as soon as this delayed cycle ends, we should be requesting/getting 3 new
+  // batches
   conds.clear();
   conds.push_back(Cond("Time", "==", 22));
   qr = sim.db().Query("Transactions", &conds);
@@ -389,16 +400,16 @@ TEST(ReactorTests, FuelShortage) {
 // tests that discharged fuel is transmuted properly immediately at cycle end.
 TEST(ReactorTests, DischargedFuelTransmute) {
   std::string config =
-     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-     ""
-     "  <cycle_time>4</cycle_time>  "
-     "  <refuel_time>3</refuel_time>  "
-     "  <assem_size>1</assem_size>  "
-     "  <n_assem_core>1</n_assem_core>  "
-     "  <n_assem_batch>1</n_assem_batch>  ";
+      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+      ""
+      "  <cycle_time>4</cycle_time>  "
+      "  <refuel_time>3</refuel_time>  "
+      "  <assem_size>1</assem_size>  "
+      "  <n_assem_core>1</n_assem_core>  "
+      "  <n_assem_batch>1</n_assem_batch>  ";
 
   int simdur = 7;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -415,7 +426,8 @@ TEST(ReactorTests, DischargedFuelTransmute) {
   Material::Ptr m = sim.GetMaterial(resid);
   MatQuery mq(m);
   EXPECT_EQ(spentuox->id(), m->comp()->id());
-  EXPECT_TRUE(mq.mass(942390000) > 0) << "transmuted spent fuel doesn't have Pu239";
+  EXPECT_TRUE(mq.mass(942390000) > 0)
+      << "transmuted spent fuel doesn't have Pu239";
 }
 
 // tests that spent fuel is offerred on correct commods according to the
@@ -423,16 +435,20 @@ TEST(ReactorTests, DischargedFuelTransmute) {
 // simultaneously.
 TEST(ReactorTests, SpentFuelProperCommodTracking) {
   std::string config =
-     "  <fuel_inrecipes>  <val>uox</val>      <val>mox</val>      </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>spentuox</val> <val>spentmox</val> </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>uox</val>      <val>mox</val>      </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste1</val>   <val>waste2</val>   </fuel_outcommods>  "
-     ""
-     "  <cycle_time>1</cycle_time>  "
-     "  <refuel_time>0</refuel_time>  "
-     "  <assem_size>1</assem_size>  "
-     "  <n_assem_core>3</n_assem_core>  "
-     "  <n_assem_batch>3</n_assem_batch>  ";
+      "  <fuel_inrecipes>  <val>uox</val>      <val>mox</val>      "
+      "</fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>spentuox</val> <val>spentmox</val> "
+      "</fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>uox</val>      <val>mox</val>      "
+      "</fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste1</val>   <val>waste2</val>   "
+      "</fuel_outcommods>  "
+      ""
+      "  <cycle_time>1</cycle_time>  "
+      "  <refuel_time>0</refuel_time>  "
+      "  <assem_size>1</assem_size>  "
+      "  <n_assem_core>3</n_assem_core>  "
+      "  <n_assem_batch>3</n_assem_batch>  ";
 
   int simdur = 7;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -450,11 +466,11 @@ TEST(ReactorTests, SpentFuelProperCommodTracking) {
   conds.push_back(Cond("SenderId", "==", id));
   conds.push_back(Cond("Commodity", "==", std::string("waste1")));
   QueryResult qr = sim.db().Query("Transactions", &conds);
-  EXPECT_EQ(simdur-1, qr.rows.size());
+  EXPECT_EQ(simdur - 1, qr.rows.size());
 
   conds[1] = Cond("Commodity", "==", std::string("waste2"));
   qr = sim.db().Query("Transactions", &conds);
-  EXPECT_EQ(2*(simdur-1), qr.rows.size());
+  EXPECT_EQ(2 * (simdur - 1), qr.rows.size());
 }
 
 // The user can optionally omit fuel preferences.  In the case where
@@ -464,20 +480,20 @@ TEST(ReactorTests, SpentFuelProperCommodTracking) {
 TEST(ReactorTests, PrefChange) {
   // it is important that the fuel_prefs not be present in the config below.
   std::string config =
-     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
-     ""
-     "  <cycle_time>1</cycle_time>  "
-     "  <refuel_time>0</refuel_time>  "
-     "  <assem_size>300</assem_size>  "
-     "  <n_assem_core>1</n_assem_core>  "
-     "  <n_assem_batch>1</n_assem_batch>  "
-     ""
-     "  <pref_change_times>   <val>25</val>         </pref_change_times>"
-     "  <pref_change_commods> <val>enriched_u</val> </pref_change_commods>"
-     "  <pref_change_values>  <val>-1</val>         </pref_change_values>";
+      "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+      ""
+      "  <cycle_time>1</cycle_time>  "
+      "  <refuel_time>0</refuel_time>  "
+      "  <assem_size>300</assem_size>  "
+      "  <n_assem_core>1</n_assem_core>  "
+      "  <n_assem_batch>1</n_assem_batch>  "
+      ""
+      "  <pref_change_times>   <val>25</val>         </pref_change_times>"
+      "  <pref_change_commods> <val>enriched_u</val> </pref_change_commods>"
+      "  <pref_change_values>  <val>-1</val>         </pref_change_values>";
 
   int simdur = 50;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -493,21 +509,25 @@ TEST(ReactorTests, PrefChange) {
 TEST(ReactorTests, RecipeChange) {
   // it is important that the fuel_prefs not be present in the config below.
   std::string config =
-     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
-     ""
-     "  <cycle_time>1</cycle_time>  "
-     "  <refuel_time>0</refuel_time>  "
-     "  <assem_size>300</assem_size>  "
-     "  <n_assem_core>1</n_assem_core>  "
-     "  <n_assem_batch>1</n_assem_batch>  "
-     ""
-     "  <recipe_change_times>   <val>25</val>         <val>35</val>         </recipe_change_times>"
-     "  <recipe_change_commods> <val>enriched_u</val> <val>enriched_u</val> </recipe_change_commods>"
-     "  <recipe_change_in>      <val>water</val>      <val>water</val>      </recipe_change_in>"
-     "  <recipe_change_out>     <val>lwr_spent</val>  <val>water</val>      </recipe_change_out>";
+      "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+      ""
+      "  <cycle_time>1</cycle_time>  "
+      "  <refuel_time>0</refuel_time>  "
+      "  <assem_size>300</assem_size>  "
+      "  <n_assem_core>1</n_assem_core>  "
+      "  <n_assem_batch>1</n_assem_batch>  "
+      ""
+      "  <recipe_change_times>   <val>25</val>         <val>35</val>         "
+      "</recipe_change_times>"
+      "  <recipe_change_commods> <val>enriched_u</val> <val>enriched_u</val> "
+      "</recipe_change_commods>"
+      "  <recipe_change_in>      <val>water</val>      <val>water</val>      "
+      "</recipe_change_in>"
+      "  <recipe_change_out>     <val>lwr_spent</val>  <val>water</val>      "
+      "</recipe_change_out>";
 
   int simdur = 50;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -564,25 +584,26 @@ TEST(ReactorTests, RecipeChange) {
 
 TEST(ReactorTests, Retire) {
   std::string config =
-     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
-     ""
-     "  <cycle_time>7</cycle_time>  "
-     "  <refuel_time>0</refuel_time>  "
-     "  <assem_size>300</assem_size>  "
-     "  <n_assem_fresh>1</n_assem_fresh>  "
-     "  <n_assem_core>3</n_assem_core>  "
-     "  <n_assem_batch>1</n_assem_batch>  "
-     "  <power_cap>1</power_cap>  "
-     "";
+      "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+      ""
+      "  <cycle_time>7</cycle_time>  "
+      "  <refuel_time>0</refuel_time>  "
+      "  <assem_size>300</assem_size>  "
+      "  <n_assem_fresh>1</n_assem_fresh>  "
+      "  <n_assem_core>3</n_assem_core>  "
+      "  <n_assem_batch>1</n_assem_batch>  "
+      "  <power_cap>1</power_cap>  "
+      "";
 
   int dur = 50;
   int life = 36;
   int cycle_time = 7;
   int refuel_time = 0;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, dur, life);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, dur,
+                      life);
   sim.AddSource("enriched_u").Finalize();
   sim.AddSink("waste").Finalize();
   sim.AddRecipe("lwr_fresh", c_uox());
@@ -611,7 +632,8 @@ TEST(ReactorTests, Retire) {
       << "failed to discharge all material by retirement time";
 
   // reactor should record power entry on the time step it retires if operating
-  int time_online = life / (cycle_time + refuel_time) * cycle_time + std::min(life % (cycle_time + refuel_time), cycle_time);
+  int time_online = life / (cycle_time + refuel_time) * cycle_time +
+                    std::min(life % (cycle_time + refuel_time), cycle_time);
   conds.clear();
   conds.push_back(Cond("AgentId", "==", id));
   conds.push_back(Cond("Value", ">", 0));
@@ -622,17 +644,17 @@ TEST(ReactorTests, Retire) {
 
 TEST(ReactorTests, PositionInitialize) {
   std::string config =
-     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
-     "  <fuel_prefs>      <val>1.0</val>        </fuel_prefs>  "
-     ""
-     "  <cycle_time>1</cycle_time>  "
-     "  <refuel_time>0</refuel_time>  "
-     "  <assem_size>300</assem_size>  "
-     "  <n_assem_core>1</n_assem_core>  "
-     "  <n_assem_batch>1</n_assem_batch>  ";
+      "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+      "  <fuel_prefs>      <val>1.0</val>        </fuel_prefs>  "
+      ""
+      "  <cycle_time>1</cycle_time>  "
+      "  <refuel_time>0</refuel_time>  "
+      "  <assem_size>300</assem_size>  "
+      "  <n_assem_core>1</n_assem_core>  "
+      "  <n_assem_batch>1</n_assem_batch>  ";
 
   int simdur = 50;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -648,19 +670,19 @@ TEST(ReactorTests, PositionInitialize) {
 
 TEST(ReactorTests, PositionInitialize2) {
   std::string config =
-     "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
-     "  <fuel_prefs>      <val>1.0</val>        </fuel_prefs>  "
-     ""
-     "  <cycle_time>1</cycle_time>  "
-     "  <refuel_time>0</refuel_time>  "
-     "  <assem_size>300</assem_size>  "
-     "  <n_assem_core>1</n_assem_core>  "
-     "  <n_assem_batch>1</n_assem_batch>  "
-     "  <longitude>30.0</longitude>  "
-     "  <latitude>30.0</latitude>  ";
+      "  <fuel_inrecipes>  <val>lwr_fresh</val>  </fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>lwr_spent</val>  </fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>enriched_u</val> </fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>      </fuel_outcommods>  "
+      "  <fuel_prefs>      <val>1.0</val>        </fuel_prefs>  "
+      ""
+      "  <cycle_time>1</cycle_time>  "
+      "  <refuel_time>0</refuel_time>  "
+      "  <assem_size>300</assem_size>  "
+      "  <n_assem_core>1</n_assem_core>  "
+      "  <n_assem_batch>1</n_assem_batch>  "
+      "  <longitude>30.0</longitude>  "
+      "  <latitude>30.0</latitude>  ";
 
   int simdur = 50;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -676,19 +698,19 @@ TEST(ReactorTests, PositionInitialize2) {
 
 TEST(ReactorTests, ByProduct) {
   std::string config =
-     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-     ""
-     "  <cycle_time>1</cycle_time>  "
-     "  <refuel_time>1</refuel_time>  "
-     "  <assem_size>1</assem_size>  "
-     "  <n_assem_core>7</n_assem_core>  "
-     "  <n_assem_batch>3</n_assem_batch>  "
-     ""
-     "  <side_products> <val>process_heat</val> </side_products>"
-     "  <side_product_quantity> <val>10</val> </side_product_quantity>";
+      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+      ""
+      "  <cycle_time>1</cycle_time>  "
+      "  <refuel_time>1</refuel_time>  "
+      "  <assem_size>1</assem_size>  "
+      "  <n_assem_core>7</n_assem_core>  "
+      "  <n_assem_batch>3</n_assem_batch>  "
+      ""
+      "  <side_products> <val>process_heat</val> </side_products>"
+      "  <side_product_quantity> <val>10</val> </side_product_quantity>";
 
   int simdur = 10;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -713,19 +735,21 @@ TEST(ReactorTests, ByProduct) {
 
 TEST(ReactorTests, MultipleByProduct) {
   std::string config =
-     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
-     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
-     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
-     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
-     ""
-     "  <cycle_time>1</cycle_time>  "
-     "  <refuel_time>1</refuel_time>  "
-     "  <assem_size>1</assem_size>  "
-     "  <n_assem_core>7</n_assem_core>  "
-     "  <n_assem_batch>3</n_assem_batch>  "
-     ""
-     "  <side_products> <val>process_heat</val> <val>water</val> </side_products>"
-     "  <side_product_quantity> <val>10</val> <val>100</val> </side_product_quantity>";
+      "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+      "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+      "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+      "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+      ""
+      "  <cycle_time>1</cycle_time>  "
+      "  <refuel_time>1</refuel_time>  "
+      "  <assem_size>1</assem_size>  "
+      "  <n_assem_core>7</n_assem_core>  "
+      "  <n_assem_batch>3</n_assem_batch>  "
+      ""
+      "  <side_products> <val>process_heat</val> <val>water</val> "
+      "</side_products>"
+      "  <side_product_quantity> <val>10</val> <val>100</val> "
+      "</side_product_quantity>";
 
   int simdur = 10;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
@@ -733,7 +757,6 @@ TEST(ReactorTests, MultipleByProduct) {
   sim.AddRecipe("uox", c_uox());
   sim.AddRecipe("spentuox", c_spentuox());
   int id = sim.Run();
-
 
   std::vector<Cond> conds;
   // test if it produces heat when reactor is running
@@ -755,9 +778,7 @@ TEST(ReactorTests, MultipleByProduct) {
   conds.push_back(Cond("Value", "==", 0));
   qr = sim.db().Query("ReactorSideProducts", &conds);
   EXPECT_EQ(10, qr.rows.size());
-
 }
 
-} // namespace reactortests
-} // namespace cycamore
-
+}  // namespace reactortests
+}  // namespace cycamore

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -1,10 +1,10 @@
 #include "separations.h"
 
-using cyclus::Material;
 using cyclus::Composition;
-using cyclus::toolkit::ResBuf;
-using cyclus::toolkit::MatVec;
+using cyclus::Material;
 using cyclus::Request;
+using cyclus::toolkit::MatVec;
+using cyclus::toolkit::ResBuf;
 
 namespace cycamore {
 
@@ -25,7 +25,7 @@ cyclus::Inventories Separations::SnapshotInv() {
   invs["feed-inv-name"] = feed.PopNRes(feed.count());
   feed.Push(invs["feed-inv-name"]);
 
-  std::map<std::string, ResBuf<Material> >::iterator it;
+  std::map<std::string, ResBuf<Material>>::iterator it;
   for (it = streambufs.begin(); it != streambufs.end(); ++it) {
     invs[it->first] = it->second.PopNRes(it->second.count());
     it->second.Push(invs[it->first]);
@@ -44,7 +44,7 @@ void Separations::InitInv(cyclus::Inventories& inv) {
   }
 }
 
-typedef std::pair<double, std::map<int, double> > Stream;
+typedef std::pair<double, std::map<int, double>> Stream;
 typedef std::map<std::string, Stream> StreamSet;
 
 void Separations::EnterNotify() {
@@ -131,11 +131,10 @@ void Separations::Tick() {
       if (m->quantity() > mat->quantity()) {
         qty = mat->quantity();
       }
-      streambufs[name].Push(
-          mat->ExtractComp(qty * maxfrac, m->comp()));
+      streambufs[name].Push(mat->ExtractComp(qty * maxfrac, m->comp()));
       Record("Separated", qty * maxfrac, name);
     }
-    cyclus::toolkit::RecordTimeSeries<double>("supply"+name, this,
+    cyclus::toolkit::RecordTimeSeries<double>("supply" + name, this,
                                               streambufs[name].quantity());
   }
 
@@ -153,9 +152,8 @@ void Separations::Tick() {
       leftover.Push(mat);
     }
   }
-  cyclus::toolkit::RecordTimeSeries<double>("supply"+leftover_commod, this,
+  cyclus::toolkit::RecordTimeSeries<double>("supply" + leftover_commod, this,
                                             leftover.quantity());
-
 }
 
 // Note that this returns an untracked material that should just be used for
@@ -204,7 +202,7 @@ Separations::GetMatlRequests() {
   std::vector<double>::iterator result;
   result = std::max_element(feed_commod_prefs.begin(), feed_commod_prefs.end());
   int maxindx = std::distance(feed_commod_prefs.begin(), result);
-  cyclus::toolkit::RecordTimeSeries<double>("demand"+feed_commods[maxindx],
+  cyclus::toolkit::RecordTimeSeries<double>("demand" + feed_commods[maxindx],
                                             this, feed.space());
   if (t_exit >= 0 && (feed.quantity() >= (t_exit - t) * throughput)) {
     return ports;  // already have enough feed for remainder of life
@@ -234,12 +232,11 @@ Separations::GetMatlRequests() {
 }
 
 void Separations::GetMatlTrades(
-    const std::vector<cyclus::Trade<Material> >& trades,
-    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
-        responses) {
+    const std::vector<cyclus::Trade<Material>>& trades,
+    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>& responses) {
   using cyclus::Trade;
 
-  std::vector<Trade<Material> >::const_iterator it;
+  std::vector<Trade<Material>>::const_iterator it;
   for (int i = 0; i < trades.size(); i++) {
     std::string commod = trades[i].request->commodity();
     if (commod == leftover_commod) {
@@ -252,16 +249,16 @@ void Separations::GetMatlTrades(
       responses.push_back(std::make_pair(trades[i], m));
     } else {
       throw cyclus::ValueError("invalid commodity " + commod +
-                       " on trade matched to prototype " + prototype());
+                               " on trade matched to prototype " + prototype());
     }
   }
 }
 
 void Separations::AcceptMatlTrades(
-    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
+    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>&
         responses) {
-  std::vector<std::pair<cyclus::Trade<Material>,
-                        Material::Ptr> >::const_iterator trade;
+  std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>::const_iterator
+      trade;
 
   for (trade = responses.begin(); trade != responses.end(); ++trade) {
     feed.Push(trade->second);
@@ -275,7 +272,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
   std::set<BidPortfolio<Material>::Ptr> ports;
 
   // bid streams
-  std::map<std::string, ResBuf<Material> >::iterator it;
+  std::map<std::string, ResBuf<Material>>::iterator it;
   for (it = streambufs.begin(); it != streambufs.end(); ++it) {
     std::string commod = it->first;
     std::vector<Request<Material>*>& reqs = commod_requests[commod];
@@ -357,7 +354,7 @@ bool Separations::CheckDecommissionCondition() {
     return false;
   }
 
-  std::map<std::string, ResBuf<Material> >::iterator it;
+  std::map<std::string, ResBuf<Material>>::iterator it;
   for (it = streambufs.begin(); it != streambufs.end(); ++it) {
     if (it->second.count() > 0) {
       return false;

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -1,10 +1,10 @@
 #include "separations.h"
 
-using cyclus::Composition;
 using cyclus::Material;
-using cyclus::Request;
-using cyclus::toolkit::MatVec;
+using cyclus::Composition;
 using cyclus::toolkit::ResBuf;
+using cyclus::toolkit::MatVec;
+using cyclus::Request;
 
 namespace cycamore {
 
@@ -25,7 +25,7 @@ cyclus::Inventories Separations::SnapshotInv() {
   invs["feed-inv-name"] = feed.PopNRes(feed.count());
   feed.Push(invs["feed-inv-name"]);
 
-  std::map<std::string, ResBuf<Material>>::iterator it;
+  std::map<std::string, ResBuf<Material> >::iterator it;
   for (it = streambufs.begin(); it != streambufs.end(); ++it) {
     invs[it->first] = it->second.PopNRes(it->second.count());
     it->second.Push(invs[it->first]);
@@ -44,7 +44,7 @@ void Separations::InitInv(cyclus::Inventories& inv) {
   }
 }
 
-typedef std::pair<double, std::map<int, double>> Stream;
+typedef std::pair<double, std::map<int, double> > Stream;
 typedef std::map<std::string, Stream> StreamSet;
 
 void Separations::EnterNotify() {
@@ -131,10 +131,11 @@ void Separations::Tick() {
       if (m->quantity() > mat->quantity()) {
         qty = mat->quantity();
       }
-      streambufs[name].Push(mat->ExtractComp(qty * maxfrac, m->comp()));
+      streambufs[name].Push(
+          mat->ExtractComp(qty * maxfrac, m->comp()));
       Record("Separated", qty * maxfrac, name);
     }
-    cyclus::toolkit::RecordTimeSeries<double>("supply" + name, this,
+    cyclus::toolkit::RecordTimeSeries<double>("supply"+name, this,
                                               streambufs[name].quantity());
   }
 
@@ -152,8 +153,9 @@ void Separations::Tick() {
       leftover.Push(mat);
     }
   }
-  cyclus::toolkit::RecordTimeSeries<double>("supply" + leftover_commod, this,
+  cyclus::toolkit::RecordTimeSeries<double>("supply"+leftover_commod, this,
                                             leftover.quantity());
+
 }
 
 // Note that this returns an untracked material that should just be used for
@@ -202,7 +204,7 @@ Separations::GetMatlRequests() {
   std::vector<double>::iterator result;
   result = std::max_element(feed_commod_prefs.begin(), feed_commod_prefs.end());
   int maxindx = std::distance(feed_commod_prefs.begin(), result);
-  cyclus::toolkit::RecordTimeSeries<double>("demand" + feed_commods[maxindx],
+  cyclus::toolkit::RecordTimeSeries<double>("demand"+feed_commods[maxindx],
                                             this, feed.space());
   if (t_exit >= 0 && (feed.quantity() >= (t_exit - t) * throughput)) {
     return ports;  // already have enough feed for remainder of life
@@ -232,11 +234,12 @@ Separations::GetMatlRequests() {
 }
 
 void Separations::GetMatlTrades(
-    const std::vector<cyclus::Trade<Material>>& trades,
-    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>& responses) {
+    const std::vector<cyclus::Trade<Material> >& trades,
+    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
+        responses) {
   using cyclus::Trade;
 
-  std::vector<Trade<Material>>::const_iterator it;
+  std::vector<Trade<Material> >::const_iterator it;
   for (int i = 0; i < trades.size(); i++) {
     std::string commod = trades[i].request->commodity();
     if (commod == leftover_commod) {
@@ -249,16 +252,16 @@ void Separations::GetMatlTrades(
       responses.push_back(std::make_pair(trades[i], m));
     } else {
       throw cyclus::ValueError("invalid commodity " + commod +
-                               " on trade matched to prototype " + prototype());
+                       " on trade matched to prototype " + prototype());
     }
   }
 }
 
 void Separations::AcceptMatlTrades(
-    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>&
+    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
         responses) {
-  std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>::const_iterator
-      trade;
+  std::vector<std::pair<cyclus::Trade<Material>,
+                        Material::Ptr> >::const_iterator trade;
 
   for (trade = responses.begin(); trade != responses.end(); ++trade) {
     feed.Push(trade->second);
@@ -272,7 +275,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
   std::set<BidPortfolio<Material>::Ptr> ports;
 
   // bid streams
-  std::map<std::string, ResBuf<Material>>::iterator it;
+  std::map<std::string, ResBuf<Material> >::iterator it;
   for (it = streambufs.begin(); it != streambufs.end(); ++it) {
     std::string commod = it->first;
     std::vector<Request<Material>*>& reqs = commod_requests[commod];
@@ -354,7 +357,7 @@ bool Separations::CheckDecommissionCondition() {
     return false;
   }
 
-  std::map<std::string, ResBuf<Material>>::iterator it;
+  std::map<std::string, ResBuf<Material> >::iterator it;
   for (it = streambufs.begin(); it != streambufs.end(); ++it) {
     if (it->second.count() > 0) {
       return false;

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -1,15 +1,14 @@
 #include "separations.h"
 
-using cyclus::Material;
 using cyclus::Composition;
-using cyclus::toolkit::ResBuf;
-using cyclus::toolkit::MatVec;
+using cyclus::Material;
 using cyclus::Request;
+using cyclus::toolkit::MatVec;
+using cyclus::toolkit::ResBuf;
 
 namespace cycamore {
 
-Separations::Separations(cyclus::Context* ctx)
-    : cyclus::Facility(ctx) {}
+Separations::Separations(cyclus::Context* ctx) : cyclus::Facility(ctx) {}
 
 cyclus::Inventories Separations::SnapshotInv() {
   cyclus::Inventories invs;
@@ -22,7 +21,7 @@ cyclus::Inventories Separations::SnapshotInv() {
   invs["feed-inv-name"] = feed.PopNRes(feed.count());
   feed.Push(invs["feed-inv-name"]);
 
-  std::map<std::string, ResBuf<Material> >::iterator it;
+  std::map<std::string, ResBuf<Material>>::iterator it;
   for (it = streambufs.begin(); it != streambufs.end(); ++it) {
     invs[it->first] = it->second.PopNRes(it->second.count());
     it->second.Push(invs[it->first]);
@@ -41,7 +40,7 @@ void Separations::InitInv(cyclus::Inventories& inv) {
   }
 }
 
-typedef std::pair<double, std::map<int, double> > Stream;
+typedef std::pair<double, std::map<int, double>> Stream;
 typedef std::map<std::string, Stream> StreamSet;
 
 void Separations::EnterNotify() {
@@ -129,11 +128,10 @@ void Separations::Tick() {
       if (m->quantity() > mat->quantity()) {
         qty = mat->quantity();
       }
-      streambufs[name].Push(
-          mat->ExtractComp(qty * maxfrac, m->comp()));
+      streambufs[name].Push(mat->ExtractComp(qty * maxfrac, m->comp()));
       Record("Separated", qty * maxfrac, name);
     }
-    cyclus::toolkit::RecordTimeSeries<double>("supply"+name, this,
+    cyclus::toolkit::RecordTimeSeries<double>("supply" + name, this,
                                               streambufs[name].quantity());
   }
 
@@ -151,9 +149,8 @@ void Separations::Tick() {
       leftover.Push(mat);
     }
   }
-  cyclus::toolkit::RecordTimeSeries<double>("supply"+leftover_commod, this,
+  cyclus::toolkit::RecordTimeSeries<double>("supply" + leftover_commod, this,
                                             leftover.quantity());
-
 }
 
 // Note that this returns an untracked material that should just be used for
@@ -202,7 +199,7 @@ Separations::GetMatlRequests() {
   std::vector<double>::iterator result;
   result = std::max_element(feed_commod_prefs.begin(), feed_commod_prefs.end());
   int maxindx = std::distance(feed_commod_prefs.begin(), result);
-  cyclus::toolkit::RecordTimeSeries<double>("demand"+feed_commods[maxindx],
+  cyclus::toolkit::RecordTimeSeries<double>("demand" + feed_commods[maxindx],
                                             this, feed.space());
   if (t_exit >= 0 && (feed.quantity() >= (t_exit - t) * throughput)) {
     return ports;  // already have enough feed for remainder of life
@@ -232,12 +229,11 @@ Separations::GetMatlRequests() {
 }
 
 void Separations::GetMatlTrades(
-    const std::vector<cyclus::Trade<Material> >& trades,
-    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
-        responses) {
+    const std::vector<cyclus::Trade<Material>>& trades,
+    std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>& responses) {
   using cyclus::Trade;
 
-  std::vector<Trade<Material> >::const_iterator it;
+  std::vector<Trade<Material>>::const_iterator it;
   for (int i = 0; i < trades.size(); i++) {
     std::string commod = trades[i].request->commodity();
     if (commod == leftover_commod) {
@@ -250,16 +246,16 @@ void Separations::GetMatlTrades(
       responses.push_back(std::make_pair(trades[i], m));
     } else {
       throw cyclus::ValueError("invalid commodity " + commod +
-                       " on trade matched to prototype " + prototype());
+                               " on trade matched to prototype " + prototype());
     }
   }
 }
 
 void Separations::AcceptMatlTrades(
-    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr> >&
+    const std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>&
         responses) {
-  std::vector<std::pair<cyclus::Trade<Material>,
-                        Material::Ptr> >::const_iterator trade;
+  std::vector<std::pair<cyclus::Trade<Material>, Material::Ptr>>::const_iterator
+      trade;
 
   for (trade = responses.begin(); trade != responses.end(); ++trade) {
     feed.Push(trade->second);
@@ -273,7 +269,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
   std::set<BidPortfolio<Material>::Ptr> ports;
 
   // bid streams
-  std::map<std::string, ResBuf<Material> >::iterator it;
+  std::map<std::string, ResBuf<Material>>::iterator it;
   for (it = streambufs.begin(); it != streambufs.end(); ++it) {
     std::string commod = it->first;
     std::vector<Request<Material>*>& reqs = commod_requests[commod];
@@ -355,7 +351,7 @@ bool Separations::CheckDecommissionCondition() {
     return false;
   }
 
-  std::map<std::string, ResBuf<Material> >::iterator it;
+  std::map<std::string, ResBuf<Material>>::iterator it;
   for (it = streambufs.begin(); it != streambufs.end(); ++it) {
     if (it->second.count() > 0) {
       return false;

--- a/src/separations.h
+++ b/src/separations.h
@@ -1,8 +1,8 @@
 #ifndef CYCAMORE_SRC_SEPARATIONS_H_
 #define CYCAMORE_SRC_SEPARATIONS_H_
 
-#include "cyclus.h"
 #include "cycamore_version.h"
+#include "cyclus.h"
 
 // clang-format off
 #pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
@@ -38,9 +38,7 @@ cyclus::Material::Ptr SepMaterial(std::map<int, double> effs,
 /// reduce its stocks by trading and hits this limit for any of its output
 /// streams, further processing/separations of feed material will halt until
 /// room is again available in the output streams.
-class Separations
-  : public cyclus::Facility,
-    public cyclus::toolkit::Position {
+class Separations : public cyclus::Facility, public cyclus::toolkit::Position {
   // clang-format off
   #pragma cyclus note { \
     "niche": "separations", \
@@ -76,11 +74,12 @@ class Separations
   virtual void Tock();
   virtual void EnterNotify();
 
-  virtual void AcceptMatlTrades(const std::vector<std::pair<
-      cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr>>& responses);
+  virtual void AcceptMatlTrades(
+      const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                                  cyclus::Material::Ptr>>& responses);
 
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-      GetMatlRequests();
+  GetMatlRequests();
 
   virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> GetMatlBids(
       cyclus::CommodMap<cyclus::Material>::type& commod_requests);
@@ -208,7 +207,7 @@ class Separations
 
   // Custom SnapshotInv and InitInv and EnterNotify are used to persist this
   // state var.
-  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material> > streambufs;
+  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material>> streambufs;
 
   // clang-format off
   #pragma cyclus var { \
@@ -233,7 +232,6 @@ class Separations
   /// Records an agent's latitude and longitude to the output db
   void RecordPosition();
   void Record(std::string name, double val, std::string type);
-
 };
 
 }  // namespace cycamore

--- a/src/separations.h
+++ b/src/separations.h
@@ -1,8 +1,8 @@
 #ifndef CYCAMORE_SRC_SEPARATIONS_H_
 #define CYCAMORE_SRC_SEPARATIONS_H_
 
-#include "cycamore_version.h"
 #include "cyclus.h"
+#include "cycamore_version.h"
 
 // clang-format off
 #pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
@@ -38,7 +38,9 @@ cyclus::Material::Ptr SepMaterial(std::map<int, double> effs,
 /// reduce its stocks by trading and hits this limit for any of its output
 /// streams, further processing/separations of feed material will halt until
 /// room is again available in the output streams.
-class Separations : public cyclus::Facility, public cyclus::toolkit::Position {
+class Separations
+  : public cyclus::Facility,
+    public cyclus::toolkit::Position {
   // clang-format off
   #pragma cyclus note { \
     "niche": "separations", \
@@ -74,12 +76,11 @@ class Separations : public cyclus::Facility, public cyclus::toolkit::Position {
   virtual void Tock();
   virtual void EnterNotify();
 
-  virtual void AcceptMatlTrades(
-      const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                                  cyclus::Material::Ptr>>& responses);
+  virtual void AcceptMatlTrades(const std::vector<std::pair<
+      cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr>>& responses);
 
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-  GetMatlRequests();
+      GetMatlRequests();
 
   virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> GetMatlBids(
       cyclus::CommodMap<cyclus::Material>::type& commod_requests);
@@ -207,7 +208,7 @@ class Separations : public cyclus::Facility, public cyclus::toolkit::Position {
 
   // Custom SnapshotInv and InitInv and EnterNotify are used to persist this
   // state var.
-  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material>> streambufs;
+  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material> > streambufs;
 
   // clang-format off
   #pragma cyclus var { \
@@ -232,6 +233,7 @@ class Separations : public cyclus::Facility, public cyclus::toolkit::Position {
   /// Records an agent's latitude and longitude to the output db
   void RecordPosition();
   void Record(std::string name, double val, std::string type);
+
 };
 
 }  // namespace cycamore

--- a/src/separations.h
+++ b/src/separations.h
@@ -4,7 +4,9 @@
 #include "cyclus.h"
 #include "cycamore_version.h"
 
+// clang-format off
 #pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
+// clang-format on
 
 namespace cycamore {
 
@@ -27,7 +29,7 @@ cyclus::Material::Ptr SepMaterial(std::map<int, double> effs,
 /// represents the mass fraction of that component in the feed that is
 /// separated into that stream.  The efficiencies of a particular component
 /// across all streams must sum up to less than or equal to one.  If less than
-/// one, the remainining material is sent to a waste inventory and
+/// one, the remaining material is sent to a waste inventory and
 /// (potentially) traded away from there.
 ///
 /// The facility receives material into a feed inventory that it processes with
@@ -39,29 +41,31 @@ cyclus::Material::Ptr SepMaterial(std::map<int, double> effs,
 class Separations
   : public cyclus::Facility,
     public cyclus::toolkit::Position {
-#pragma cyclus note { \
-  "niche": "separations", \
-  "doc": \
-    "Separations processes feed material into one or more streams containing" \
-    " specific elements and/or nuclides.  It uses mass-based efficiencies." \
-    "\n\n" \
-    "User defined separations streams are specified as groups of" \
-    " component-efficiency pairs where 'component' means either a particular" \
-    " element or a particular nuclide.  Each component's paired efficiency" \
-    " represents the mass fraction of that component in the feed that is" \
-    " separated into that stream.  The efficiencies of a particular component" \
-    " across all streams must sum up to less than or equal to one.  If less than" \
-    " one, the remainining material is sent to a waste inventory and" \
-    " (potentially) traded away from there." \
-    "\n\n" \
-    "The facility receives material into a feed inventory that it processes with" \
-    " a specified throughput each time step.  Each output stream has a" \
-    " corresponding output inventory size/limit.  If the facility is unable to" \
-    " reduce its stocks by trading and hits this limit for any of its output" \
-    " streams, further processing/separations of feed material will halt until" \
-    " room is again available in the output streams." \
-    "", \
-}
+  // clang-format off
+  #pragma cyclus note { \
+    "niche": "separations", \
+    "doc": \
+      "Separations processes feed material into one or more streams containing " \
+      "specific elements and/or nuclides.  It uses mass-based efficiencies." \
+      "\n\n" \
+      "User defined separations streams are specified as groups of " \
+      "component-efficiency pairs where 'component' means either a " \
+      "particular element or a particular nuclide.  Each component's paired " \
+      "efficiency represents the mass fraction of that component in the feed " \
+      "that is separated into that stream.  The efficiencies of a particular " \
+      "component across all streams must sum up to less than or equal to one. " \
+      "If less than one, the remaining material is sent to a waste inventory " \
+      "and (potentially) traded away from there." \
+      "\n\n" \
+      "The facility receives material into a feed inventory that it processes " \
+      "with a specified throughput each time step.  Each output stream has a " \
+      "corresponding output inventory size/limit.  If the facility is unable " \
+      "to reduce its stocks by trading and hits this limit for any of its " \
+      "output streams, further processing/separations of feed material will " \
+      "halt until room is again available in the output streams.", \
+  }
+  // clang-format on
+
  public:
   Separations(cyclus::Context* ctx);
   virtual ~Separations(){};
@@ -73,21 +77,22 @@ class Separations
   virtual void EnterNotify();
 
   virtual void AcceptMatlTrades(const std::vector<std::pair<
-      cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr> >& responses);
+      cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr>>& responses);
 
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-  GetMatlRequests();
+      GetMatlRequests();
 
   virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> GetMatlBids(
       cyclus::CommodMap<cyclus::Material>::type& commod_requests);
 
   virtual void GetMatlTrades(
-      const std::vector<cyclus::Trade<cyclus::Material> >& trades,
+      const std::vector<cyclus::Trade<cyclus::Material>>& trades,
       std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                            cyclus::Material::Ptr> >& responses);
+                            cyclus::Material::Ptr>>& responses);
 
   virtual bool CheckDecommissionCondition();
 
+  // clang-format off
   #pragma cyclus clone
   #pragma cyclus initfromcopy
   #pragma cyclus infiletodb
@@ -95,7 +100,9 @@ class Separations
   #pragma cyclus schema
   #pragma cyclus annotations
   #pragma cyclus snapshot
-  // the following pragmas are ommitted and the functions are written
+  // clang-format on
+
+  // The following pragmas are omitted and the functions are written
   // manually in order to handle the vector of resource buffers:
   //
   //     #pragma cyclus snapshotinv
@@ -105,130 +112,128 @@ class Separations
   virtual void InitInv(cyclus::Inventories& inv);
 
  private:
+  // clang-format off
   #pragma cyclus var { \
-    "doc": "Ordered list of commodities on which to request feed material to " \
-           "separate. Order only matters for matching up with feed commodity " \
-           "preferences if specified.", \
-    "uilabel": "Feed Commodity List", \
-    "uitype": ["oneormore", "incommodity"], \
+      "doc": "Ordered list of commodities on which to request feed material to "\
+             "separate. Order only matters for matching up with feed commodity "\
+             "preferences if specified.", \
+      "uilabel": "Feed Commodity List", \
+      "uitype": ["oneormore", "incommodity"] \
   }
   std::vector<std::string> feed_commods;
 
   #pragma cyclus var { \
-    "default": [], \
-    "uilabel": "Feed Commodity Preference List", \
-    "doc": "Feed commodity request preferences for each of the given feed " \
-           "commodities (same order)." \
-           " If unspecified, default is to use 1.0 for all "\
-           "preferences.",                                                     \
+      "default": [], \
+      "uilabel": "Feed Commodity Preference List", \
+      "doc": "Feed commodity request preferences for each of the given feed "\
+             "commodities (same order). If unspecified, defaults to 1.0.", \
   }
   std::vector<double> feed_commod_prefs;
 
   #pragma cyclus var { \
-    "doc": "Name for recipe to be used in feed requests." \
-           " Empty string results in use of a dummy recipe.", \
-    "uilabel": "Feed Commodity Recipe List", \
-    "uitype": "inrecipe", \
-    "default": "", \
+      "doc": "Name for recipe to be used in feed requests. Empty string "\
+             "results in use of a dummy recipe.", \
+      "uilabel": "Feed Commodity Recipe List", \
+      "uitype": "inrecipe", \
+      "default": "", \
   }
   std::string feed_recipe;
 
   #pragma cyclus var { \
-    "doc" : "Maximum amount of feed material to keep on hand.", \
-    "uilabel": "Maximum Feed Inventory",                     \
-    "units" : "kg", \
+      "doc": "Maximum amount of feed material to keep on hand.", \
+      "uilabel": "Maximum Feed Inventory", \
+      "units": "kg", \
   }
   double feedbuf_size;
 
   #pragma cyclus var { \
-    "capacity" : "feedbuf_size", \
+      "capacity": "feedbuf_size", \
   }
   cyclus::toolkit::ResBuf<cyclus::Material> feed;
 
   #pragma cyclus var { \
-    "doc" : "Maximum quantity of feed material that can be processed per time "\
-            "step.", \
-    "uilabel": "Maximum Separations Throughput", \
-    "default": CY_LARGE_DOUBLE, \
-    "uitype": "range", \
-    "range": [0.0, CY_LARGE_DOUBLE], \
-    "units": "kg/(time step)", \
+      "doc": "Maximum quantity of feed material that can be processed per time "\
+             "step.", \
+      "uilabel": "Maximum Separations Throughput", \
+      "default": CY_LARGE_DOUBLE, \
+      "uitype": "range", \
+      "range": [0.0, CY_LARGE_DOUBLE], \
+      "units": "kg/(time step)", \
   }
   double throughput;
 
   #pragma cyclus var { \
-    "doc": "Commodity on which to trade the leftover separated material " \
-           "stream. This MUST NOT be the same as any commodity used to define "\
-           "the other separations streams.", \
-    "uitype": "outcommodity", \
-    "uilabel": "Leftover Commodity", \
-    "default": "default-waste-stream", \
+      "doc": "Commodity on which to trade the leftover separated material stream. "\
+             "This MUST NOT be the same as any commodity used to define the "\
+             "other separations streams.", \
+      "uitype": "outcommodity", \
+      "uilabel": "Leftover Commodity", \
+      "default": "default-waste-stream", \
   }
   std::string leftover_commod;
 
   #pragma cyclus var { \
-    "doc" : "Maximum amount of leftover separated material (not included in" \
-            " any other stream) that can be stored." \
-            " If full, the facility halts operation until space becomes " \
-            "available.", \
-    "uilabel": "Maximum Leftover Inventory", \
-    "default": CY_LARGE_DOUBLE, \
-    "uitype": "range", \
-    "range": [0.0, CY_LARGE_DOUBLE], \
-    "units": "kg", \
+      "doc": "Maximum amount of leftover separated material (not included in any "\
+             "other stream) that can be stored. If full, the facility halts "\
+             "operation until space is available.", \
+      "uilabel": "Maximum Leftover Inventory", \
+      "default": CY_LARGE_DOUBLE, \
+      "uitype": "range", \
+      "range": [0.0, CY_LARGE_DOUBLE], \
+      "units": "kg", \
   }
   double leftoverbuf_size;
 
- #pragma cyclus var { \
-    "capacity" : "leftoverbuf_size", \
+  #pragma cyclus var { \
+      "capacity": "leftoverbuf_size", \
   }
   cyclus::toolkit::ResBuf<cyclus::Material> leftover;
 
   #pragma cyclus var { \
-    "alias": ["streams", "commod", ["info", "buf_size", ["efficiencies", "comp", "eff"]]], \
-    "uitype": ["oneormore", "outcommodity", ["pair", "double", ["oneormore", "nuclide", "double"]]], \
-    "uilabel": "Separations Streams and Efficiencies", \
-    "doc": "Output streams for separations." \
-           " Each stream must have a unique name identifying the commodity on "\
-           " which its material is traded," \
-           " a max buffer capacity in kg (neg values indicate infinite size)," \
-           " and a set of component efficiencies." \
-           " 'comp' is a component to be separated into the stream" \
-           " (e.g. U, Pu, etc.) and 'eff' is the mass fraction of the" \
-           " component that is separated from the feed into this output" \
-           " stream. If any stream buffer is full, the facility halts" \
-           " operation until space becomes available." \
-           " The sum total of all component efficiencies across streams must" \
-           " be less than or equal to 1" \
-           " (e.g. sum of U efficiencies for all streams must be <= 1).", \
+      "alias": ["streams", "commod", ["info", "buf_size", ["efficiencies", "comp", "eff"]]], \
+      "uitype": ["oneormore", "outcommodity", ["pair", "double", ["oneormore", "nuclide", "double"]]], \
+      "uilabel": "Separations Streams and Efficiencies", \
+      "doc": "Output streams for separations. Each stream must have a unique "\
+             "name identifying the commodity on which its material is traded, "\
+             "a max buffer capacity in kg (neg values indicate infinite size), "\
+             "and a set of component efficiencies. 'comp' is a component to "\
+             "be separated into the stream (e.g. U, Pu, etc.) and 'eff' is the "\
+             "mass fraction of the component that is separated from the feed "\
+             "into this output stream. If any stream buffer is full, the "\
+             "facility halts operation until space becomes available. The sum "\
+             "total of all component efficiencies across streams must be <= 1.", \
   }
   std::map<std::string, std::pair<double, std::map<int, double> > > streams_;
+  // clang-format on
 
-  // custom SnapshotInv and InitInv and EnterNotify are used to persist this
+  // Custom SnapshotInv and InitInv and EnterNotify are used to persist this
   // state var.
   std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material> > streambufs;
 
+  // clang-format off
   #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
+      "default": 0.0, \
+      "uilabel": "Geographical latitude in degrees as a double", \
+      "doc": "Latitude of the agent's geographical position. The value "\
+             "should be expressed in degrees as a double." \
   }
   double latitude;
 
   #pragma cyclus var { \
-    "default": 0.0, \
-    "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
+      "default": 0.0, \
+      "uilabel": "Geographical longitude in degrees as a double", \
+      "doc": "Longitude of the agent's geographical position. The value "\
+             "should be expressed in degrees as a double." \
   }
   double longitude;
+  // clang-format on
 
   cyclus::toolkit::Position coordinates;
 
   /// Records an agent's latitude and longitude to the output db
   void RecordPosition();
   void Record(std::string name, double val, std::string type);
+
 };
 
 }  // namespace cycamore

--- a/src/separations.h
+++ b/src/separations.h
@@ -38,9 +38,7 @@ cyclus::Material::Ptr SepMaterial(std::map<int, double> effs,
 /// reduce its stocks by trading and hits this limit for any of its output
 /// streams, further processing/separations of feed material will halt until
 /// room is again available in the output streams.
-class Separations
-  : public cyclus::Facility,
-    public cyclus::toolkit::Position {
+class Separations : public cyclus::Facility, public cyclus::toolkit::Position {
   // clang-format off
   #pragma cyclus note { \
     "niche": "separations", \
@@ -76,11 +74,12 @@ class Separations
   virtual void Tock();
   virtual void EnterNotify();
 
-  virtual void AcceptMatlTrades(const std::vector<std::pair<
-      cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr>>& responses);
+  virtual void AcceptMatlTrades(
+      const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                                  cyclus::Material::Ptr>>& responses);
 
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-      GetMatlRequests();
+  GetMatlRequests();
 
   virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> GetMatlBids(
       cyclus::CommodMap<cyclus::Material>::type& commod_requests);
@@ -211,10 +210,9 @@ class Separations
 
   // Custom SnapshotInv and InitInv and EnterNotify are used to persist this
   // state var.
-  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material> > streambufs;
+  std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material>> streambufs;
 
   void Record(std::string name, double val, std::string type);
-
 };
 
 }  // namespace cycamore

--- a/src/separations_tests.cc
+++ b/src/separations_tests.cc
@@ -1,17 +1,16 @@
-#include <gtest/gtest.h>
-
-#include <sstream>
-
-#include "cyclus.h"
 #include "separations.h"
 
-using cyclus::CompMap;
+#include <gtest/gtest.h>
+#include <sstream>
+#include "cyclus.h"
+
+using pyne::nucname::id;
 using cyclus::Composition;
-using cyclus::Cond;
+using cyclus::CompMap;
 using cyclus::Material;
 using cyclus::QueryResult;
+using cyclus::Cond;
 using cyclus::toolkit::MatQuery;
-using pyne::nucname::id;
 
 namespace cycamore {
 
@@ -40,14 +39,14 @@ TEST(SeparationsTests, SepMaterial) {
   EXPECT_DOUBLE_EQ(effs[id("U")] * mqorig.mass("U238"), mqsep.mass("U238"));
   EXPECT_DOUBLE_EQ(effs[id("Pu")] * mqorig.mass("Pu239"), mqsep.mass("Pu239"));
   EXPECT_DOUBLE_EQ(effs[id("Pu")] * mqorig.mass("Pu240"), mqsep.mass("Pu240"));
-  EXPECT_DOUBLE_EQ(effs[id("Am241")] * mqorig.mass("Am241"),
-                   mqsep.mass("Am241"));
+  EXPECT_DOUBLE_EQ(effs[id("Am241")] * mqorig.mass("Am241"), mqsep.mass("Am241"));
   EXPECT_DOUBLE_EQ(0, mqsep.mass("Am242"));
 }
 
-// Check that cumulative separations efficiency for a single nuclide of less
-// than or equal to one does not trigger an error.
+
+// Check that cumulative separations efficiency for a single nuclide of less than or equal to one does not trigger an error.
 TEST(SeparationsTests, SeparationEfficiency) {
+
   int simdur = 2;
   std::string config =
       "<streams>"
@@ -83,13 +82,14 @@ TEST(SeparationsTests, SeparationEfficiency) {
       "<leftover_commod>waste</leftover_commod>"
       "<throughput>100</throughput>"
       "<feedbuf_size>100</feedbuf_size>"
-      "<feed_commods> <val>feed</val> </feed_commods>";
+      "<feed_commods> <val>feed</val> </feed_commods>"
+  ;
 
-  cyclus::MockSim sim1(cyclus::AgentSpec(":cycamore:Separations"), config,
-                       simdur);
 
-  EXPECT_NO_THROW(sim1.Run()) << "Cumulative separation efficiency smaler than "
-                                 "1 is throwing an error but should not.";
+  cyclus::MockSim sim1(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
+
+  EXPECT_NO_THROW(sim1.Run()) << "Cumulative separation efficiency smaler than 1 is throwing an error but should not.";
+
 
   config =
       "<streams>"
@@ -128,22 +128,20 @@ TEST(SeparationsTests, SeparationEfficiency) {
       "<leftover_commod>waste</leftover_commod>"
       "<throughput>100</throughput>"
       "<feedbuf_size>100</feedbuf_size>"
-      "<feed_commods> <val>feed</val> </feed_commods>";
+      "<feed_commods> <val>feed</val> </feed_commods>"
+      ;
 
-  cyclus::MockSim sim2(cyclus::AgentSpec(":cycamore:Separations"), config,
-                       simdur);
 
-  EXPECT_NO_THROW(sim2.Run()) << "Cumulative separation efficiency of 1 is "
-                                 "throwing an error but should not.";
+  cyclus::MockSim sim2(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
+
+  EXPECT_NO_THROW(sim2.Run()) << "Cumulative separation efficiency of 1 is throwing an error but should not.";
 }
 
-// Check that an error is correctly thrown when separations efficiency of
-// greater than one.
+// Check that an error is correctly thrown when separations efficiency of greater than one.
 TEST(SeparationsTests, SeparationEfficiencyThrowing) {
   int simdur = 2;
 
-  // Check that single separations efficiency for a single nuclide of greater
-  // than one does not trigger an error.
+  // Check that single separations efficiency for a single nuclide of greater than one does not trigger an error.
   std::string config =
       "<streams>"
       "    <item>"
@@ -161,54 +159,48 @@ TEST(SeparationsTests, SeparationEfficiencyThrowing) {
       "<leftover_commod>waste</leftover_commod>"
       "<throughput>100</throughput>"
       "<feedbuf_size>100</feedbuf_size>"
-      "<feed_commods> <val>feed</val> </feed_commods>";
+      "<feed_commods> <val>feed</val> </feed_commods>"
+      ;
 
-  cyclus::MockSim sim1(cyclus::AgentSpec(":cycamore:Separations"), config,
-                       simdur);
+  cyclus::MockSim sim1(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
 
-  EXPECT_THROW(sim1.Run(), cyclus::ValueError)
-      << "Direct separation efficiency greater than 1 is not throwing an error "
-         "but should.";
+  EXPECT_THROW(sim1.Run(), cyclus::ValueError) << "Direct separation efficiency greater than 1 is not throwing an error but should.";
 
-  // Check if a cumulative separation efficiency greater than 1 for a unique
-  // nuclide throw an error as expected.
+// Check if a cumulative separation efficiency greater than 1 for a unique nuclide throw an error as expected.
   config =
-      "<streams>"
-      "    <item>"
-      "        <commod>stream1</commod>"
-      "        <info>"
-      "            <buf_size>-1</buf_size>"
-      "            <efficiencies>"
-      "                <item><comp>U</comp> <eff>0.6</eff></item>"
-      "                <item><comp>Pu239</comp> <eff>.7</eff></item>"
-      "            </efficiencies>"
-      "        </info>"
-      "    </item>"
-      "    <item>"
-      "        <commod>stream2</commod>"
-      "        <info>"
-      "            <buf_size>-1</buf_size>"
-      "            <efficiencies>"
-      "                <item><comp>U</comp> <eff>0.1</eff></item>"
-      "                <item><comp>Pu239</comp> <eff>.7</eff></item>"
-      "            </efficiencies>"
-      "        </info>"
-      "    </item>"
-      "</streams>"
-      ""
-      "<leftover_commod>waste</leftover_commod>"
-      "<throughput>100</throughput>"
-      "<feedbuf_size>100</feedbuf_size>"
-      "<feed_commods> <val>feed</val> </feed_commods>";
+    "<streams>"
+    "    <item>"
+    "        <commod>stream1</commod>"
+    "        <info>"
+    "            <buf_size>-1</buf_size>"
+    "            <efficiencies>"
+    "                <item><comp>U</comp> <eff>0.6</eff></item>"
+    "                <item><comp>Pu239</comp> <eff>.7</eff></item>"
+    "            </efficiencies>"
+    "        </info>"
+    "    </item>"
+    "    <item>"
+    "        <commod>stream2</commod>"
+    "        <info>"
+    "            <buf_size>-1</buf_size>"
+    "            <efficiencies>"
+    "                <item><comp>U</comp> <eff>0.1</eff></item>"
+    "                <item><comp>Pu239</comp> <eff>.7</eff></item>"
+    "            </efficiencies>"
+    "        </info>"
+    "    </item>"
+    "</streams>"
+    ""
+    "<leftover_commod>waste</leftover_commod>"
+    "<throughput>100</throughput>"
+    "<feedbuf_size>100</feedbuf_size>"
+    "<feed_commods> <val>feed</val> </feed_commods>"
+    ;
 
-  cyclus::MockSim sim2(cyclus::AgentSpec(":cycamore:Separations"), config,
-                       simdur);
+  cyclus::MockSim sim2(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
 
-  EXPECT_THROW(sim2.Run(), cyclus::ValueError)
-      << "Single cumulative separation efficiency greater than 1 is not "
-         "throwing an error but should.";
-  // Check if a cumulative separation efficiency greater than 1 for multiple
-  // nuclides throw an error as expected.
+  EXPECT_THROW(sim2.Run(), cyclus::ValueError) << "Single cumulative separation efficiency greater than 1 is not throwing an error but should.";
+// Check if a cumulative separation efficiency greater than 1 for multiple nuclides throw an error as expected.
   config =
       "<streams>"
       "    <item>"
@@ -236,14 +228,12 @@ TEST(SeparationsTests, SeparationEfficiencyThrowing) {
       "<leftover_commod>waste</leftover_commod>"
       "<throughput>100</throughput>"
       "<feedbuf_size>100</feedbuf_size>"
-      "<feed_commods> <val>feed</val> </feed_commods>";
+      "<feed_commods> <val>feed</val> </feed_commods>"
+      ;
 
-  cyclus::MockSim sim3(cyclus::AgentSpec(":cycamore:Separations"), config,
-                       simdur);
+  cyclus::MockSim sim3(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
 
-  EXPECT_THROW(sim3.Run(), cyclus::ValueError)
-      << "Multiple cumulative separation efficiencies greater than 1 are not "
-         "throwing an error but should.";
+  EXPECT_THROW(sim3.Run(), cyclus::ValueError) << "Multiple cumulative separation efficiencies greater than 1 are not throwing an error but should.";
 }
 
 TEST(SeparationsTests, SepMixElemAndNuclide) {
@@ -264,7 +254,8 @@ TEST(SeparationsTests, SepMixElemAndNuclide) {
       "<leftover_commod>waste</leftover_commod>"
       "<throughput>100</throughput>"
       "<feedbuf_size>100</feedbuf_size>"
-      "<feed_commods> <val>feed</val> </feed_commods>";
+      "<feed_commods> <val>feed</val> </feed_commods>"
+     ;
 
   CompMap m;
   m[id("u235")] = 0.08;
@@ -274,8 +265,7 @@ TEST(SeparationsTests, SepMixElemAndNuclide) {
   Composition::Ptr c = Composition::CreateFromMass(m);
 
   int simdur = 2;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
   sim.AddSource("feed").recipe("recipe1").Finalize();
   sim.AddSink("stream1").capacity(100).Finalize();
   sim.AddRecipe("recipe1", c);
@@ -284,10 +274,10 @@ TEST(SeparationsTests, SepMixElemAndNuclide) {
   std::vector<Cond> conds;
   conds.push_back(Cond("SenderId", "==", id));
   int resid = sim.db().Query("Transactions", &conds).GetVal<int>("ResourceId");
-  MatQuery mq(sim.GetMaterial(resid));
-  EXPECT_DOUBLE_EQ(m[922350000] * 0.6 * 100, mq.mass("U235"));
-  EXPECT_DOUBLE_EQ(m[922380000] * 0.6 * 100, mq.mass("U238"));
-  EXPECT_DOUBLE_EQ(m[942390000] * 0.7 * 100, mq.mass("Pu239"));
+  MatQuery mq (sim.GetMaterial(resid));
+  EXPECT_DOUBLE_EQ(m[922350000]*0.6*100, mq.mass("U235"));
+  EXPECT_DOUBLE_EQ(m[922380000]*0.6*100, mq.mass("U238"));
+  EXPECT_DOUBLE_EQ(m[942390000]*0.7*100, mq.mass("Pu239"));
   EXPECT_DOUBLE_EQ(0, mq.mass("Pu240"));
 }
 
@@ -308,7 +298,8 @@ TEST(SeparationsTests, Retire) {
       "<leftover_commod>waste</leftover_commod>"
       "<throughput>100</throughput>"
       "<feedbuf_size>100</feedbuf_size>"
-      "<feed_commods> <val>feed</val> </feed_commods>";
+      "<feed_commods> <val>feed</val> </feed_commods>"
+     ;
 
   CompMap m;
   m[id("u235")] = 0.1;
@@ -318,8 +309,8 @@ TEST(SeparationsTests, Retire) {
   int simdur = 5;
   int life = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"), config,
-                      simdur, life);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"),
+          config, simdur, life);
   sim.AddSource("feed").recipe("recipe1").Finalize();
   sim.AddSink("stream1").capacity(100).Finalize();
   sim.AddSink("waste").capacity(70).Finalize();
@@ -345,12 +336,12 @@ TEST(SeparationsTests, Retire) {
     tot_mat += m->quantity();
   }
   EXPECT_EQ(100, tot_mat)
-      << "total material traded away does not equal total material separated";
+    << "total material traded away does not equal total material separated";
   EXPECT_EQ(3.0, qr.rows.size())
       << "failed to discharge all material before decomissioning";
-}
+ }
 
-TEST(SeparationsTests, PositionInitialize) {
+ TEST(SeparationsTests, PositionInitialize) {
   std::string config =
       "<streams>"
       "    <item>"
@@ -377,8 +368,7 @@ TEST(SeparationsTests, PositionInitialize) {
   Composition::Ptr c = Composition::CreateFromMass(m);
 
   int simdur = 2;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
   sim.AddSource("feed").recipe("recipe1").Finalize();
   sim.AddSink("stream1").capacity(100).Finalize();
   sim.AddRecipe("recipe1", c);
@@ -387,9 +377,9 @@ TEST(SeparationsTests, PositionInitialize) {
   QueryResult qr = sim.db().Query("AgentPosition", NULL);
   EXPECT_EQ(qr.GetVal<double>("Latitude"), 0.0);
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 0.0);
-}
+ }
 
-TEST(SeparationsTests, PositionInitialize2) {
+  TEST(SeparationsTests, PositionInitialize2) {
   std::string config =
       "<streams>"
       "    <item>"
@@ -418,8 +408,7 @@ TEST(SeparationsTests, PositionInitialize2) {
   Composition::Ptr c = Composition::CreateFromMass(m);
 
   int simdur = 2;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"), config,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
   sim.AddSource("feed").recipe("recipe1").Finalize();
   sim.AddSink("stream1").capacity(100).Finalize();
   sim.AddRecipe("recipe1", c);
@@ -428,5 +417,6 @@ TEST(SeparationsTests, PositionInitialize2) {
   QueryResult qr = sim.db().Query("AgentPosition", NULL);
   EXPECT_EQ(qr.GetVal<double>("Latitude"), 10.0);
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 15.0);
-}
-}  // namespace cycamore
+ }
+} // namespace cycamore
+

--- a/src/separations_tests.cc
+++ b/src/separations_tests.cc
@@ -4,13 +4,13 @@
 #include <sstream>
 #include "cyclus.h"
 
-using pyne::nucname::id;
-using cyclus::Composition;
 using cyclus::CompMap;
+using cyclus::Composition;
+using cyclus::Cond;
 using cyclus::Material;
 using cyclus::QueryResult;
-using cyclus::Cond;
 using cyclus::toolkit::MatQuery;
+using pyne::nucname::id;
 
 namespace cycamore {
 
@@ -39,14 +39,14 @@ TEST(SeparationsTests, SepMaterial) {
   EXPECT_DOUBLE_EQ(effs[id("U")] * mqorig.mass("U238"), mqsep.mass("U238"));
   EXPECT_DOUBLE_EQ(effs[id("Pu")] * mqorig.mass("Pu239"), mqsep.mass("Pu239"));
   EXPECT_DOUBLE_EQ(effs[id("Pu")] * mqorig.mass("Pu240"), mqsep.mass("Pu240"));
-  EXPECT_DOUBLE_EQ(effs[id("Am241")] * mqorig.mass("Am241"), mqsep.mass("Am241"));
+  EXPECT_DOUBLE_EQ(effs[id("Am241")] * mqorig.mass("Am241"),
+                   mqsep.mass("Am241"));
   EXPECT_DOUBLE_EQ(0, mqsep.mass("Am242"));
 }
 
-
-// Check that cumulative separations efficiency for a single nuclide of less than or equal to one does not trigger an error.
+// Check that cumulative separations efficiency for a single nuclide of less
+// than or equal to one does not trigger an error.
 TEST(SeparationsTests, SeparationEfficiency) {
-
   int simdur = 2;
   std::string config =
       "<streams>"
@@ -82,14 +82,13 @@ TEST(SeparationsTests, SeparationEfficiency) {
       "<leftover_commod>waste</leftover_commod>"
       "<throughput>100</throughput>"
       "<feedbuf_size>100</feedbuf_size>"
-      "<feed_commods> <val>feed</val> </feed_commods>"
-  ;
+      "<feed_commods> <val>feed</val> </feed_commods>";
 
+  cyclus::MockSim sim1(cyclus::AgentSpec(":cycamore:Separations"), config,
+                       simdur);
 
-  cyclus::MockSim sim1(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
-
-  EXPECT_NO_THROW(sim1.Run()) << "Cumulative separation efficiency smaler than 1 is throwing an error but should not.";
-
+  EXPECT_NO_THROW(sim1.Run()) << "Cumulative separation efficiency smaler than "
+                                 "1 is throwing an error but should not.";
 
   config =
       "<streams>"
@@ -128,20 +127,22 @@ TEST(SeparationsTests, SeparationEfficiency) {
       "<leftover_commod>waste</leftover_commod>"
       "<throughput>100</throughput>"
       "<feedbuf_size>100</feedbuf_size>"
-      "<feed_commods> <val>feed</val> </feed_commods>"
-      ;
+      "<feed_commods> <val>feed</val> </feed_commods>";
 
+  cyclus::MockSim sim2(cyclus::AgentSpec(":cycamore:Separations"), config,
+                       simdur);
 
-  cyclus::MockSim sim2(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
-
-  EXPECT_NO_THROW(sim2.Run()) << "Cumulative separation efficiency of 1 is throwing an error but should not.";
+  EXPECT_NO_THROW(sim2.Run()) << "Cumulative separation efficiency of 1 is "
+                                 "throwing an error but should not.";
 }
 
-// Check that an error is correctly thrown when separations efficiency of greater than one.
+// Check that an error is correctly thrown when separations efficiency of
+// greater than one.
 TEST(SeparationsTests, SeparationEfficiencyThrowing) {
   int simdur = 2;
 
-  // Check that single separations efficiency for a single nuclide of greater than one does not trigger an error.
+  // Check that single separations efficiency for a single nuclide of greater
+  // than one does not trigger an error.
   std::string config =
       "<streams>"
       "    <item>"
@@ -159,48 +160,54 @@ TEST(SeparationsTests, SeparationEfficiencyThrowing) {
       "<leftover_commod>waste</leftover_commod>"
       "<throughput>100</throughput>"
       "<feedbuf_size>100</feedbuf_size>"
-      "<feed_commods> <val>feed</val> </feed_commods>"
-      ;
+      "<feed_commods> <val>feed</val> </feed_commods>";
 
-  cyclus::MockSim sim1(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
+  cyclus::MockSim sim1(cyclus::AgentSpec(":cycamore:Separations"), config,
+                       simdur);
 
-  EXPECT_THROW(sim1.Run(), cyclus::ValueError) << "Direct separation efficiency greater than 1 is not throwing an error but should.";
+  EXPECT_THROW(sim1.Run(), cyclus::ValueError)
+      << "Direct separation efficiency greater than 1 is not throwing an error "
+         "but should.";
 
-// Check if a cumulative separation efficiency greater than 1 for a unique nuclide throw an error as expected.
+  // Check if a cumulative separation efficiency greater than 1 for a unique
+  // nuclide throw an error as expected.
   config =
-    "<streams>"
-    "    <item>"
-    "        <commod>stream1</commod>"
-    "        <info>"
-    "            <buf_size>-1</buf_size>"
-    "            <efficiencies>"
-    "                <item><comp>U</comp> <eff>0.6</eff></item>"
-    "                <item><comp>Pu239</comp> <eff>.7</eff></item>"
-    "            </efficiencies>"
-    "        </info>"
-    "    </item>"
-    "    <item>"
-    "        <commod>stream2</commod>"
-    "        <info>"
-    "            <buf_size>-1</buf_size>"
-    "            <efficiencies>"
-    "                <item><comp>U</comp> <eff>0.1</eff></item>"
-    "                <item><comp>Pu239</comp> <eff>.7</eff></item>"
-    "            </efficiencies>"
-    "        </info>"
-    "    </item>"
-    "</streams>"
-    ""
-    "<leftover_commod>waste</leftover_commod>"
-    "<throughput>100</throughput>"
-    "<feedbuf_size>100</feedbuf_size>"
-    "<feed_commods> <val>feed</val> </feed_commods>"
-    ;
+      "<streams>"
+      "    <item>"
+      "        <commod>stream1</commod>"
+      "        <info>"
+      "            <buf_size>-1</buf_size>"
+      "            <efficiencies>"
+      "                <item><comp>U</comp> <eff>0.6</eff></item>"
+      "                <item><comp>Pu239</comp> <eff>.7</eff></item>"
+      "            </efficiencies>"
+      "        </info>"
+      "    </item>"
+      "    <item>"
+      "        <commod>stream2</commod>"
+      "        <info>"
+      "            <buf_size>-1</buf_size>"
+      "            <efficiencies>"
+      "                <item><comp>U</comp> <eff>0.1</eff></item>"
+      "                <item><comp>Pu239</comp> <eff>.7</eff></item>"
+      "            </efficiencies>"
+      "        </info>"
+      "    </item>"
+      "</streams>"
+      ""
+      "<leftover_commod>waste</leftover_commod>"
+      "<throughput>100</throughput>"
+      "<feedbuf_size>100</feedbuf_size>"
+      "<feed_commods> <val>feed</val> </feed_commods>";
 
-  cyclus::MockSim sim2(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
+  cyclus::MockSim sim2(cyclus::AgentSpec(":cycamore:Separations"), config,
+                       simdur);
 
-  EXPECT_THROW(sim2.Run(), cyclus::ValueError) << "Single cumulative separation efficiency greater than 1 is not throwing an error but should.";
-// Check if a cumulative separation efficiency greater than 1 for multiple nuclides throw an error as expected.
+  EXPECT_THROW(sim2.Run(), cyclus::ValueError)
+      << "Single cumulative separation efficiency greater than 1 is not "
+         "throwing an error but should.";
+  // Check if a cumulative separation efficiency greater than 1 for multiple
+  // nuclides throw an error as expected.
   config =
       "<streams>"
       "    <item>"
@@ -228,12 +235,14 @@ TEST(SeparationsTests, SeparationEfficiencyThrowing) {
       "<leftover_commod>waste</leftover_commod>"
       "<throughput>100</throughput>"
       "<feedbuf_size>100</feedbuf_size>"
-      "<feed_commods> <val>feed</val> </feed_commods>"
-      ;
+      "<feed_commods> <val>feed</val> </feed_commods>";
 
-  cyclus::MockSim sim3(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
+  cyclus::MockSim sim3(cyclus::AgentSpec(":cycamore:Separations"), config,
+                       simdur);
 
-  EXPECT_THROW(sim3.Run(), cyclus::ValueError) << "Multiple cumulative separation efficiencies greater than 1 are not throwing an error but should.";
+  EXPECT_THROW(sim3.Run(), cyclus::ValueError)
+      << "Multiple cumulative separation efficiencies greater than 1 are not "
+         "throwing an error but should.";
 }
 
 TEST(SeparationsTests, SepMixElemAndNuclide) {
@@ -254,8 +263,7 @@ TEST(SeparationsTests, SepMixElemAndNuclide) {
       "<leftover_commod>waste</leftover_commod>"
       "<throughput>100</throughput>"
       "<feedbuf_size>100</feedbuf_size>"
-      "<feed_commods> <val>feed</val> </feed_commods>"
-     ;
+      "<feed_commods> <val>feed</val> </feed_commods>";
 
   CompMap m;
   m[id("u235")] = 0.08;
@@ -265,7 +273,8 @@ TEST(SeparationsTests, SepMixElemAndNuclide) {
   Composition::Ptr c = Composition::CreateFromMass(m);
 
   int simdur = 2;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"), config,
+                      simdur);
   sim.AddSource("feed").recipe("recipe1").Finalize();
   sim.AddSink("stream1").capacity(100).Finalize();
   sim.AddRecipe("recipe1", c);
@@ -274,10 +283,10 @@ TEST(SeparationsTests, SepMixElemAndNuclide) {
   std::vector<Cond> conds;
   conds.push_back(Cond("SenderId", "==", id));
   int resid = sim.db().Query("Transactions", &conds).GetVal<int>("ResourceId");
-  MatQuery mq (sim.GetMaterial(resid));
-  EXPECT_DOUBLE_EQ(m[922350000]*0.6*100, mq.mass("U235"));
-  EXPECT_DOUBLE_EQ(m[922380000]*0.6*100, mq.mass("U238"));
-  EXPECT_DOUBLE_EQ(m[942390000]*0.7*100, mq.mass("Pu239"));
+  MatQuery mq(sim.GetMaterial(resid));
+  EXPECT_DOUBLE_EQ(m[922350000] * 0.6 * 100, mq.mass("U235"));
+  EXPECT_DOUBLE_EQ(m[922380000] * 0.6 * 100, mq.mass("U238"));
+  EXPECT_DOUBLE_EQ(m[942390000] * 0.7 * 100, mq.mass("Pu239"));
   EXPECT_DOUBLE_EQ(0, mq.mass("Pu240"));
 }
 
@@ -298,8 +307,7 @@ TEST(SeparationsTests, Retire) {
       "<leftover_commod>waste</leftover_commod>"
       "<throughput>100</throughput>"
       "<feedbuf_size>100</feedbuf_size>"
-      "<feed_commods> <val>feed</val> </feed_commods>"
-     ;
+      "<feed_commods> <val>feed</val> </feed_commods>";
 
   CompMap m;
   m[id("u235")] = 0.1;
@@ -309,8 +317,8 @@ TEST(SeparationsTests, Retire) {
   int simdur = 5;
   int life = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"),
-          config, simdur, life);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"), config,
+                      simdur, life);
   sim.AddSource("feed").recipe("recipe1").Finalize();
   sim.AddSink("stream1").capacity(100).Finalize();
   sim.AddSink("waste").capacity(70).Finalize();
@@ -336,12 +344,12 @@ TEST(SeparationsTests, Retire) {
     tot_mat += m->quantity();
   }
   EXPECT_EQ(100, tot_mat)
-    << "total material traded away does not equal total material separated";
+      << "total material traded away does not equal total material separated";
   EXPECT_EQ(3.0, qr.rows.size())
       << "failed to discharge all material before decomissioning";
- }
+}
 
- TEST(SeparationsTests, PositionInitialize) {
+TEST(SeparationsTests, PositionInitialize) {
   std::string config =
       "<streams>"
       "    <item>"
@@ -368,7 +376,8 @@ TEST(SeparationsTests, Retire) {
   Composition::Ptr c = Composition::CreateFromMass(m);
 
   int simdur = 2;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"), config,
+                      simdur);
   sim.AddSource("feed").recipe("recipe1").Finalize();
   sim.AddSink("stream1").capacity(100).Finalize();
   sim.AddRecipe("recipe1", c);
@@ -377,9 +386,9 @@ TEST(SeparationsTests, Retire) {
   QueryResult qr = sim.db().Query("AgentPosition", NULL);
   EXPECT_EQ(qr.GetVal<double>("Latitude"), 0.0);
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 0.0);
- }
+}
 
-  TEST(SeparationsTests, PositionInitialize2) {
+TEST(SeparationsTests, PositionInitialize2) {
   std::string config =
       "<streams>"
       "    <item>"
@@ -408,7 +417,8 @@ TEST(SeparationsTests, Retire) {
   Composition::Ptr c = Composition::CreateFromMass(m);
 
   int simdur = 2;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"), config,
+                      simdur);
   sim.AddSource("feed").recipe("recipe1").Finalize();
   sim.AddSink("stream1").capacity(100).Finalize();
   sim.AddRecipe("recipe1", c);
@@ -417,6 +427,5 @@ TEST(SeparationsTests, Retire) {
   QueryResult qr = sim.db().Query("AgentPosition", NULL);
   EXPECT_EQ(qr.GetVal<double>("Latitude"), 10.0);
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 15.0);
- }
-} // namespace cycamore
-
+}
+}  // namespace cycamore

--- a/src/sink.cc
+++ b/src/sink.cc
@@ -1,9 +1,10 @@
 // Implements the Sink class
-#include "sink.h"
-
 #include <algorithm>
-#include <boost/lexical_cast.hpp>
 #include <sstream>
+
+#include <boost/lexical_cast.hpp>
+
+#include "sink.h"
 
 namespace cycamore {
 
@@ -15,8 +16,7 @@ Sink::Sink(cyclus::Context* ctx)
       longitude(0.0),
       keep_packaging(true),
       coordinates(latitude, longitude) {
-  SetMaxInventorySize(std::numeric_limits<double>::max());
-}
+  SetMaxInventorySize(std::numeric_limits<double>::max());}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Sink::~Sink() {}
@@ -42,8 +42,7 @@ Sink::~Sink() {}
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Sink::EnterNotify() {
   cyclus::Facility::EnterNotify();
-  LOG(cyclus::LEV_INFO4, "SnkFac")
-      << " using random behavior " << random_size_type;
+  LOG(cyclus::LEV_INFO4, "SnkFac") << " using random behavior " << random_size_type;
 
   inventory.keep_packaging(keep_packaging);
 
@@ -63,14 +62,16 @@ void Sink::EnterNotify() {
   SetNextBuyTime();
 
   if (random_size_type != "None") {
-    LOG(cyclus::LEV_INFO4, "SnkFac")
-        << "Sink " << this->id() << " is using random behavior "
-        << random_size_type << " for determining request size.";
+    LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id()
+                                     << " is using random behavior "
+                                     << random_size_type
+                                     << " for determining request size.";
   }
   if (random_frequency_type != "None") {
-    LOG(cyclus::LEV_INFO4, "SnkFac")
-        << "Sink " << this->id() << " is using random behavior "
-        << random_frequency_type << " for determining request frequency.";
+    LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id()
+                                     << " is using random behavior "
+                                     << random_frequency_type
+                                     << " for determining request frequency.";
   }
   RecordPosition();
 }
@@ -98,10 +99,10 @@ std::string Sink::str() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
 Sink::GetMatlRequests() {
-  using cyclus::Composition;
   using cyclus::Material;
-  using cyclus::Request;
   using cyclus::RequestPortfolio;
+  using cyclus::Request;
+  using cyclus::Composition;
 
   std::set<RequestPortfolio<Material>::Ptr> ports;
   RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
@@ -119,11 +120,11 @@ Sink::GetMatlRequests() {
     mat = cyclus::Material::CreateUntracked(requestAmt, rec);
   }
 
-  if (requestAmt > cyclus::eps()) {
+  if (requestAmt > cyclus::eps()) {  
     std::vector<Request<Material>*> mutuals;
     for (int i = 0; i < in_commods.size(); i++) {
-      mutuals.push_back(
-          port->AddRequest(mat, this, in_commods[i], in_commod_prefs[i]));
+      mutuals.push_back(port->AddRequest(mat, this, in_commods[i], in_commod_prefs[i]));
+
     }
     port->AddMutualReqs(mutuals);
     ports.insert(port);
@@ -139,7 +140,8 @@ Sink::GetGenRsrcRequests() {
   using cyclus::RequestPortfolio;
 
   std::set<RequestPortfolio<Product>::Ptr> ports;
-  RequestPortfolio<Product>::Ptr port(new RequestPortfolio<Product>());
+  RequestPortfolio<Product>::Ptr
+      port(new RequestPortfolio<Product>());
 
   if (requestAmt > cyclus::eps()) {
     CapacityConstraint<Product> cc(requestAmt);
@@ -159,10 +161,10 @@ Sink::GetGenRsrcRequests() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Sink::AcceptMatlTrades(
-    const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                                cyclus::Material::Ptr>>& responses) {
-  std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                        cyclus::Material::Ptr>>::const_iterator it;
+    const std::vector< std::pair<cyclus::Trade<cyclus::Material>,
+                                 cyclus::Material::Ptr> >& responses) {
+  std::vector< std::pair<cyclus::Trade<cyclus::Material>,
+                         cyclus::Material::Ptr> >::const_iterator it;
   for (it = responses.begin(); it != responses.end(); ++it) {
     inventory.Push(it->second);
   }
@@ -170,10 +172,10 @@ void Sink::AcceptMatlTrades(
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Sink::AcceptGenRsrcTrades(
-    const std::vector<std::pair<cyclus::Trade<cyclus::Product>,
-                                cyclus::Product::Ptr>>& responses) {
-  std::vector<std::pair<cyclus::Trade<cyclus::Product>,
-                        cyclus::Product::Ptr>>::const_iterator it;
+    const std::vector< std::pair<cyclus::Trade<cyclus::Product>,
+                                 cyclus::Product::Ptr> >& responses) {
+  std::vector< std::pair<cyclus::Trade<cyclus::Product>,
+                         cyclus::Product::Ptr> >::const_iterator it;
   for (it = responses.begin(); it != responses.end(); ++it) {
     inventory.Push(it->second);
   }
@@ -187,31 +189,31 @@ void Sink::Tick() {
 
   if (nextBuyTime == -1) {
     SetRequestAmt();
-  } else if (nextBuyTime == context()->time()) {
+  }
+  else if (nextBuyTime == context()->time()) {
     SetRequestAmt();
     SetNextBuyTime();
 
-    LOG(cyclus::LEV_INFO4, "SnkFac")
-        << "Sink " << this->id()
-        << " has reached buying time. The next buy time will be time step "
-        << nextBuyTime;
-  } else {
+    LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id() 
+                                     << " has reached buying time. The next buy time will be time step " << nextBuyTime;
+  }
+  else {
     requestAmt = 0;
   }
 
   // inform the simulation about what the sink facility will be requesting
   if (requestAmt > cyclus::eps()) {
-    LOG(cyclus::LEV_INFO4, "SnkFac")
-        << "Sink " << this->id() << " has request amount " << requestAmt
-        << " kg of " << in_commods[0] << ".";
+    LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id()
+                                     << " has request amount " << requestAmt
+                                     << " kg of " << in_commods[0] << ".";
     for (vector<string>::iterator commod = in_commods.begin();
          commod != in_commods.end();
          commod++) {
-      LOG(cyclus::LEV_INFO4, "SnkFac")
-          << "Sink " << this->id() << " will request " << requestAmt
-          << " kg of " << *commod << ".";
-      cyclus::toolkit::RecordTimeSeries<double>("demand" + *commod, this,
-                                                requestAmt);
+      LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id() 
+                                       << " will request " << requestAmt
+                                       << " kg of " << *commod << ".";
+      cyclus::toolkit::RecordTimeSeries<double>("demand"+*commod, this,
+                                            requestAmt);
     }
   }
   LOG(cyclus::LEV_INFO3, "SnkFac") << "}";
@@ -224,10 +226,10 @@ void Sink::Tock() {
   // On the tock, the sink facility doesn't really do much.
   // Maybe someday it will record things.
   // For now, lets just print out what we have at each timestep.
-  LOG(cyclus::LEV_INFO4, "SnkFac")
-      << "Sink " << this->id() << " is holding " << inventory.quantity()
-      << " units of material at the close of timestep " << context()->time()
-      << ".";
+  LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id()
+                                   << " is holding " << inventory.quantity()
+                                   << " units of material at the close of timestep "
+                                   << context()->time() << ".";
   LOG(cyclus::LEV_INFO3, "SnkFac") << "}";
 }
 
@@ -250,14 +252,18 @@ void Sink::SetRequestAmt() {
   }
 
   if (random_size_type == "None") {
-    requestAmt = amt;
-  } else if (random_size_type == "UniformReal") {
-    requestAmt = context()->random_uniform_real(0, amt);
-  } else if (random_size_type == "NormalReal") {
-    requestAmt = context()->random_normal_real(
-        amt * random_size_mean, amt * random_size_stddev, 0, amt);
-  } else {
-    requestAmt = amt;
+    requestAmt =  amt;
+  }
+  else if (random_size_type == "UniformReal") {
+    requestAmt =  context()->random_uniform_real(0, amt);
+  }
+  else if (random_size_type == "NormalReal") {
+    requestAmt =  context()->random_normal_real(amt * random_size_mean,
+                                                amt * random_size_stddev, 
+                                                0, amt);
+  }
+  else {
+    requestAmt =  amt;
   }
   return;
 }
@@ -265,16 +271,14 @@ void Sink::SetRequestAmt() {
 void Sink::SetNextBuyTime() {
   if (random_frequency_type == "None") {
     nextBuyTime = -1;
-  } else if (random_frequency_type == "UniformInt") {
-    nextBuyTime =
-        context()->time() + context()->random_uniform_int(random_frequency_min,
-                                                          random_frequency_max);
-  } else if (random_frequency_type == "NormalInt") {
-    nextBuyTime =
-        context()->time() + context()->random_normal_int(
-                                random_frequency_mean, random_frequency_stddev,
-                                random_frequency_min, random_frequency_max);
-  } else {
+  }
+  else if (random_frequency_type == "UniformInt") {
+    nextBuyTime = context()->time() + context()->random_uniform_int(random_frequency_min, random_frequency_max);
+  }
+  else if (random_frequency_type == "NormalInt") {
+    nextBuyTime = context()->time() + context()->random_normal_int(random_frequency_mean, random_frequency_stddev, random_frequency_min, random_frequency_max);
+  }
+  else {
     nextBuyTime = -1;
   }
   return;

--- a/src/sink.cc
+++ b/src/sink.cc
@@ -1,10 +1,9 @@
 // Implements the Sink class
-#include <algorithm>
-#include <sstream>
-
-#include <boost/lexical_cast.hpp>
-
 #include "sink.h"
+
+#include <algorithm>
+#include <boost/lexical_cast.hpp>
+#include <sstream>
 
 namespace cycamore {
 
@@ -16,7 +15,8 @@ Sink::Sink(cyclus::Context* ctx)
       longitude(0.0),
       keep_packaging(true),
       coordinates(latitude, longitude) {
-  SetMaxInventorySize(std::numeric_limits<double>::max());}
+  SetMaxInventorySize(std::numeric_limits<double>::max());
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Sink::~Sink() {}
@@ -42,7 +42,8 @@ Sink::~Sink() {}
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Sink::EnterNotify() {
   cyclus::Facility::EnterNotify();
-  LOG(cyclus::LEV_INFO4, "SnkFac") << " using random behavior " << random_size_type;
+  LOG(cyclus::LEV_INFO4, "SnkFac")
+      << " using random behavior " << random_size_type;
 
   inventory.keep_packaging(keep_packaging);
 
@@ -62,16 +63,14 @@ void Sink::EnterNotify() {
   SetNextBuyTime();
 
   if (random_size_type != "None") {
-    LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id()
-                                     << " is using random behavior "
-                                     << random_size_type
-                                     << " for determining request size.";
+    LOG(cyclus::LEV_INFO4, "SnkFac")
+        << "Sink " << this->id() << " is using random behavior "
+        << random_size_type << " for determining request size.";
   }
   if (random_frequency_type != "None") {
-    LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id()
-                                     << " is using random behavior "
-                                     << random_frequency_type
-                                     << " for determining request frequency.";
+    LOG(cyclus::LEV_INFO4, "SnkFac")
+        << "Sink " << this->id() << " is using random behavior "
+        << random_frequency_type << " for determining request frequency.";
   }
   RecordPosition();
 }
@@ -99,10 +98,10 @@ std::string Sink::str() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
 Sink::GetMatlRequests() {
-  using cyclus::Material;
-  using cyclus::RequestPortfolio;
-  using cyclus::Request;
   using cyclus::Composition;
+  using cyclus::Material;
+  using cyclus::Request;
+  using cyclus::RequestPortfolio;
 
   std::set<RequestPortfolio<Material>::Ptr> ports;
   RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
@@ -120,11 +119,11 @@ Sink::GetMatlRequests() {
     mat = cyclus::Material::CreateUntracked(requestAmt, rec);
   }
 
-  if (requestAmt > cyclus::eps()) {  
+  if (requestAmt > cyclus::eps()) {
     std::vector<Request<Material>*> mutuals;
     for (int i = 0; i < in_commods.size(); i++) {
-      mutuals.push_back(port->AddRequest(mat, this, in_commods[i], in_commod_prefs[i]));
-
+      mutuals.push_back(
+          port->AddRequest(mat, this, in_commods[i], in_commod_prefs[i]));
     }
     port->AddMutualReqs(mutuals);
     ports.insert(port);
@@ -140,8 +139,7 @@ Sink::GetGenRsrcRequests() {
   using cyclus::RequestPortfolio;
 
   std::set<RequestPortfolio<Product>::Ptr> ports;
-  RequestPortfolio<Product>::Ptr
-      port(new RequestPortfolio<Product>());
+  RequestPortfolio<Product>::Ptr port(new RequestPortfolio<Product>());
 
   if (requestAmt > cyclus::eps()) {
     CapacityConstraint<Product> cc(requestAmt);
@@ -161,10 +159,10 @@ Sink::GetGenRsrcRequests() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Sink::AcceptMatlTrades(
-    const std::vector< std::pair<cyclus::Trade<cyclus::Material>,
-                                 cyclus::Material::Ptr> >& responses) {
-  std::vector< std::pair<cyclus::Trade<cyclus::Material>,
-                         cyclus::Material::Ptr> >::const_iterator it;
+    const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                                cyclus::Material::Ptr>>& responses) {
+  std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                        cyclus::Material::Ptr>>::const_iterator it;
   for (it = responses.begin(); it != responses.end(); ++it) {
     inventory.Push(it->second);
   }
@@ -172,10 +170,10 @@ void Sink::AcceptMatlTrades(
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Sink::AcceptGenRsrcTrades(
-    const std::vector< std::pair<cyclus::Trade<cyclus::Product>,
-                                 cyclus::Product::Ptr> >& responses) {
-  std::vector< std::pair<cyclus::Trade<cyclus::Product>,
-                         cyclus::Product::Ptr> >::const_iterator it;
+    const std::vector<std::pair<cyclus::Trade<cyclus::Product>,
+                                cyclus::Product::Ptr>>& responses) {
+  std::vector<std::pair<cyclus::Trade<cyclus::Product>,
+                        cyclus::Product::Ptr>>::const_iterator it;
   for (it = responses.begin(); it != responses.end(); ++it) {
     inventory.Push(it->second);
   }
@@ -189,31 +187,31 @@ void Sink::Tick() {
 
   if (nextBuyTime == -1) {
     SetRequestAmt();
-  }
-  else if (nextBuyTime == context()->time()) {
+  } else if (nextBuyTime == context()->time()) {
     SetRequestAmt();
     SetNextBuyTime();
 
-    LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id() 
-                                     << " has reached buying time. The next buy time will be time step " << nextBuyTime;
-  }
-  else {
+    LOG(cyclus::LEV_INFO4, "SnkFac")
+        << "Sink " << this->id()
+        << " has reached buying time. The next buy time will be time step "
+        << nextBuyTime;
+  } else {
     requestAmt = 0;
   }
 
   // inform the simulation about what the sink facility will be requesting
   if (requestAmt > cyclus::eps()) {
-    LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id()
-                                     << " has request amount " << requestAmt
-                                     << " kg of " << in_commods[0] << ".";
+    LOG(cyclus::LEV_INFO4, "SnkFac")
+        << "Sink " << this->id() << " has request amount " << requestAmt
+        << " kg of " << in_commods[0] << ".";
     for (vector<string>::iterator commod = in_commods.begin();
          commod != in_commods.end();
          commod++) {
-      LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id() 
-                                       << " will request " << requestAmt
-                                       << " kg of " << *commod << ".";
-      cyclus::toolkit::RecordTimeSeries<double>("demand"+*commod, this,
-                                            requestAmt);
+      LOG(cyclus::LEV_INFO4, "SnkFac")
+          << "Sink " << this->id() << " will request " << requestAmt
+          << " kg of " << *commod << ".";
+      cyclus::toolkit::RecordTimeSeries<double>("demand" + *commod, this,
+                                                requestAmt);
     }
   }
   LOG(cyclus::LEV_INFO3, "SnkFac") << "}";
@@ -226,10 +224,10 @@ void Sink::Tock() {
   // On the tock, the sink facility doesn't really do much.
   // Maybe someday it will record things.
   // For now, lets just print out what we have at each timestep.
-  LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id()
-                                   << " is holding " << inventory.quantity()
-                                   << " units of material at the close of timestep "
-                                   << context()->time() << ".";
+  LOG(cyclus::LEV_INFO4, "SnkFac")
+      << "Sink " << this->id() << " is holding " << inventory.quantity()
+      << " units of material at the close of timestep " << context()->time()
+      << ".";
   LOG(cyclus::LEV_INFO3, "SnkFac") << "}";
 }
 
@@ -252,18 +250,14 @@ void Sink::SetRequestAmt() {
   }
 
   if (random_size_type == "None") {
-    requestAmt =  amt;
-  }
-  else if (random_size_type == "UniformReal") {
-    requestAmt =  context()->random_uniform_real(0, amt);
-  }
-  else if (random_size_type == "NormalReal") {
-    requestAmt =  context()->random_normal_real(amt * random_size_mean,
-                                                amt * random_size_stddev, 
-                                                0, amt);
-  }
-  else {
-    requestAmt =  amt;
+    requestAmt = amt;
+  } else if (random_size_type == "UniformReal") {
+    requestAmt = context()->random_uniform_real(0, amt);
+  } else if (random_size_type == "NormalReal") {
+    requestAmt = context()->random_normal_real(
+        amt * random_size_mean, amt * random_size_stddev, 0, amt);
+  } else {
+    requestAmt = amt;
   }
   return;
 }
@@ -271,14 +265,16 @@ void Sink::SetRequestAmt() {
 void Sink::SetNextBuyTime() {
   if (random_frequency_type == "None") {
     nextBuyTime = -1;
-  }
-  else if (random_frequency_type == "UniformInt") {
-    nextBuyTime = context()->time() + context()->random_uniform_int(random_frequency_min, random_frequency_max);
-  }
-  else if (random_frequency_type == "NormalInt") {
-    nextBuyTime = context()->time() + context()->random_normal_int(random_frequency_mean, random_frequency_stddev, random_frequency_min, random_frequency_max);
-  }
-  else {
+  } else if (random_frequency_type == "UniformInt") {
+    nextBuyTime =
+        context()->time() + context()->random_uniform_int(random_frequency_min,
+                                                          random_frequency_max);
+  } else if (random_frequency_type == "NormalInt") {
+    nextBuyTime =
+        context()->time() + context()->random_normal_int(
+                                random_frequency_mean, random_frequency_stddev,
+                                random_frequency_min, random_frequency_max);
+  } else {
     nextBuyTime = -1;
   }
   return;

--- a/src/sink.cc
+++ b/src/sink.cc
@@ -13,7 +13,8 @@ Sink::Sink(cyclus::Context* ctx)
     : cyclus::Facility(ctx),
       capacity(std::numeric_limits<double>::max()),
       keep_packaging(true) {
-  SetMaxInventorySize(std::numeric_limits<double>::max());}
+  SetMaxInventorySize(std::numeric_limits<double>::max());
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Sink::~Sink() {}
@@ -39,7 +40,8 @@ Sink::~Sink() {}
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Sink::EnterNotify() {
   cyclus::Facility::EnterNotify();
-  LOG(cyclus::LEV_INFO4, "SnkFac") << " using random behavior " << random_size_type;
+  LOG(cyclus::LEV_INFO4, "SnkFac")
+      << " using random behavior " << random_size_type;
 
   inventory.keep_packaging(keep_packaging);
 
@@ -59,16 +61,14 @@ void Sink::EnterNotify() {
   SetNextBuyTime();
 
   if (random_size_type != "None") {
-    LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id()
-                                     << " is using random behavior "
-                                     << random_size_type
-                                     << " for determining request size.";
+    LOG(cyclus::LEV_INFO4, "SnkFac")
+        << "Sink " << this->id() << " is using random behavior "
+        << random_size_type << " for determining request size.";
   }
   if (random_frequency_type != "None") {
-    LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id()
-                                     << " is using random behavior "
-                                     << random_frequency_type
-                                     << " for determining request frequency.";
+    LOG(cyclus::LEV_INFO4, "SnkFac")
+        << "Sink " << this->id() << " is using random behavior "
+        << random_frequency_type << " for determining request frequency.";
   }
 
   InitializePosition();
@@ -97,10 +97,10 @@ std::string Sink::str() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
 Sink::GetMatlRequests() {
-  using cyclus::Material;
-  using cyclus::RequestPortfolio;
-  using cyclus::Request;
   using cyclus::Composition;
+  using cyclus::Material;
+  using cyclus::Request;
+  using cyclus::RequestPortfolio;
 
   std::set<RequestPortfolio<Material>::Ptr> ports;
   RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
@@ -118,11 +118,11 @@ Sink::GetMatlRequests() {
     mat = cyclus::Material::CreateUntracked(requestAmt, rec);
   }
 
-  if (requestAmt > cyclus::eps()) {  
+  if (requestAmt > cyclus::eps()) {
     std::vector<Request<Material>*> mutuals;
     for (int i = 0; i < in_commods.size(); i++) {
-      mutuals.push_back(port->AddRequest(mat, this, in_commods[i], in_commod_prefs[i]));
-
+      mutuals.push_back(
+          port->AddRequest(mat, this, in_commods[i], in_commod_prefs[i]));
     }
     port->AddMutualReqs(mutuals);
     ports.insert(port);
@@ -138,8 +138,7 @@ Sink::GetGenRsrcRequests() {
   using cyclus::RequestPortfolio;
 
   std::set<RequestPortfolio<Product>::Ptr> ports;
-  RequestPortfolio<Product>::Ptr
-      port(new RequestPortfolio<Product>());
+  RequestPortfolio<Product>::Ptr port(new RequestPortfolio<Product>());
 
   if (requestAmt > cyclus::eps()) {
     CapacityConstraint<Product> cc(requestAmt);
@@ -159,10 +158,10 @@ Sink::GetGenRsrcRequests() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Sink::AcceptMatlTrades(
-    const std::vector< std::pair<cyclus::Trade<cyclus::Material>,
-                                 cyclus::Material::Ptr> >& responses) {
-  std::vector< std::pair<cyclus::Trade<cyclus::Material>,
-                         cyclus::Material::Ptr> >::const_iterator it;
+    const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                                cyclus::Material::Ptr>>& responses) {
+  std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                        cyclus::Material::Ptr>>::const_iterator it;
   for (it = responses.begin(); it != responses.end(); ++it) {
     inventory.Push(it->second);
   }
@@ -170,10 +169,10 @@ void Sink::AcceptMatlTrades(
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Sink::AcceptGenRsrcTrades(
-    const std::vector< std::pair<cyclus::Trade<cyclus::Product>,
-                                 cyclus::Product::Ptr> >& responses) {
-  std::vector< std::pair<cyclus::Trade<cyclus::Product>,
-                         cyclus::Product::Ptr> >::const_iterator it;
+    const std::vector<std::pair<cyclus::Trade<cyclus::Product>,
+                                cyclus::Product::Ptr>>& responses) {
+  std::vector<std::pair<cyclus::Trade<cyclus::Product>,
+                        cyclus::Product::Ptr>>::const_iterator it;
   for (it = responses.begin(); it != responses.end(); ++it) {
     inventory.Push(it->second);
   }
@@ -187,31 +186,31 @@ void Sink::Tick() {
 
   if (nextBuyTime == -1) {
     SetRequestAmt();
-  }
-  else if (nextBuyTime == context()->time()) {
+  } else if (nextBuyTime == context()->time()) {
     SetRequestAmt();
     SetNextBuyTime();
 
-    LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id() 
-                                     << " has reached buying time. The next buy time will be time step " << nextBuyTime;
-  }
-  else {
+    LOG(cyclus::LEV_INFO4, "SnkFac")
+        << "Sink " << this->id()
+        << " has reached buying time. The next buy time will be time step "
+        << nextBuyTime;
+  } else {
     requestAmt = 0;
   }
 
   // inform the simulation about what the sink facility will be requesting
   if (requestAmt > cyclus::eps()) {
-    LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id()
-                                     << " has request amount " << requestAmt
-                                     << " kg of " << in_commods[0] << ".";
+    LOG(cyclus::LEV_INFO4, "SnkFac")
+        << "Sink " << this->id() << " has request amount " << requestAmt
+        << " kg of " << in_commods[0] << ".";
     for (vector<string>::iterator commod = in_commods.begin();
          commod != in_commods.end();
          commod++) {
-      LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id() 
-                                       << " will request " << requestAmt
-                                       << " kg of " << *commod << ".";
-      cyclus::toolkit::RecordTimeSeries<double>("demand"+*commod, this,
-                                            requestAmt);
+      LOG(cyclus::LEV_INFO4, "SnkFac")
+          << "Sink " << this->id() << " will request " << requestAmt
+          << " kg of " << *commod << ".";
+      cyclus::toolkit::RecordTimeSeries<double>("demand" + *commod, this,
+                                                requestAmt);
     }
   }
   LOG(cyclus::LEV_INFO3, "SnkFac") << "}";
@@ -224,10 +223,10 @@ void Sink::Tock() {
   // On the tock, the sink facility doesn't really do much.
   // Maybe someday it will record things.
   // For now, lets just print out what we have at each timestep.
-  LOG(cyclus::LEV_INFO4, "SnkFac") << "Sink " << this->id()
-                                   << " is holding " << inventory.quantity()
-                                   << " units of material at the close of timestep "
-                                   << context()->time() << ".";
+  LOG(cyclus::LEV_INFO4, "SnkFac")
+      << "Sink " << this->id() << " is holding " << inventory.quantity()
+      << " units of material at the close of timestep " << context()->time()
+      << ".";
   LOG(cyclus::LEV_INFO3, "SnkFac") << "}";
 }
 
@@ -238,18 +237,14 @@ void Sink::SetRequestAmt() {
   }
 
   if (random_size_type == "None") {
-    requestAmt =  amt;
-  }
-  else if (random_size_type == "UniformReal") {
-    requestAmt =  context()->random_uniform_real(0, amt);
-  }
-  else if (random_size_type == "NormalReal") {
-    requestAmt =  context()->random_normal_real(amt * random_size_mean,
-                                                amt * random_size_stddev, 
-                                                0, amt);
-  }
-  else {
-    requestAmt =  amt;
+    requestAmt = amt;
+  } else if (random_size_type == "UniformReal") {
+    requestAmt = context()->random_uniform_real(0, amt);
+  } else if (random_size_type == "NormalReal") {
+    requestAmt = context()->random_normal_real(
+        amt * random_size_mean, amt * random_size_stddev, 0, amt);
+  } else {
+    requestAmt = amt;
   }
   return;
 }
@@ -257,14 +252,16 @@ void Sink::SetRequestAmt() {
 void Sink::SetNextBuyTime() {
   if (random_frequency_type == "None") {
     nextBuyTime = -1;
-  }
-  else if (random_frequency_type == "UniformInt") {
-    nextBuyTime = context()->time() + context()->random_uniform_int(random_frequency_min, random_frequency_max);
-  }
-  else if (random_frequency_type == "NormalInt") {
-    nextBuyTime = context()->time() + context()->random_normal_int(random_frequency_mean, random_frequency_stddev, random_frequency_min, random_frequency_max);
-  }
-  else {
+  } else if (random_frequency_type == "UniformInt") {
+    nextBuyTime =
+        context()->time() + context()->random_uniform_int(random_frequency_min,
+                                                          random_frequency_max);
+  } else if (random_frequency_type == "NormalInt") {
+    nextBuyTime =
+        context()->time() + context()->random_normal_int(
+                                random_frequency_mean, random_frequency_stddev,
+                                random_frequency_min, random_frequency_max);
+  } else {
     nextBuyTime = -1;
   }
   return;

--- a/src/sink.h
+++ b/src/sink.h
@@ -6,8 +6,8 @@
 #include <utility>
 #include <vector>
 
-#include "cyclus.h"
 #include "cycamore_version.h"
+#include "cyclus.h"
 
 // clang-format off
 #pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, \
@@ -23,16 +23,14 @@ class Context;
 /// total inventory size.  The inventory size and throughput capacity both
 /// default to infinite. If a recipe is provided, it will request material with
 /// that recipe. Requests are made for any number of specified commodities.
-class Sink : public cyclus::Facility,
-             public cyclus::toolkit::Position {
-              
+class Sink : public cyclus::Facility, public cyclus::toolkit::Position {
  public:
   Sink(cyclus::Context* ctx);
   virtual ~Sink();
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-    // clang-format off
+  // clang-format off
   #pragma cyclus note { \
     "doc": \
       " A sink facility that accepts materials and products with a fixed\n" \
@@ -54,12 +52,12 @@ class Sink : public cyclus::Facility,
   /// @brief SinkFacilities request Materials of their given commodity.  Note
   /// that it is assumed the Sink operates on a single resource type!
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-      GetMatlRequests();
+  GetMatlRequests();
 
   /// @brief SinkFacilities request Products of their given commodity.  Note
   /// that it is assumed the Sink operates on a single resource type!
   virtual std::set<cyclus::RequestPortfolio<cyclus::Product>::Ptr>
-      GetGenRsrcRequests();
+  GetGenRsrcRequests();
 
   /// @brief SinkFacilities place accepted trade Materials in their Inventory
   virtual void AcceptMatlTrades(
@@ -78,9 +76,7 @@ class Sink : public cyclus::Facility,
   virtual void SetNextBuyTime();
 
   /// add a commodity to the set of input commodities
-  inline void AddCommodity(std::string name) {
-    in_commods.push_back(name);
-  }
+  inline void AddCommodity(std::string name) { in_commods.push_back(name); }
 
   /// sets the size of the storage inventory for received material
   inline void SetMaxInventorySize(double size) {
@@ -89,14 +85,10 @@ class Sink : public cyclus::Facility,
   }
 
   /// @return the maximum inventory storage size
-  inline double MaxInventorySize() const {
-    return inventory.capacity();
-  }
+  inline double MaxInventorySize() const { return inventory.capacity(); }
 
   /// @return the current inventory storage size
-  inline double InventorySize() const {
-    return inventory.quantity();
-  }
+  inline double InventorySize() const { return inventory.quantity(); }
 
   /// determines the amount to request
   inline double SpaceAvailable() const {
@@ -119,7 +111,7 @@ class Sink : public cyclus::Facility,
     return in_commod_prefs;
   }
 
-  private:
+ private:
   double requestAmt;
   int nextBuyTime;
 

--- a/src/sink.h
+++ b/src/sink.h
@@ -9,7 +9,10 @@
 #include "cyclus.h"
 #include "cycamore_version.h"
 
-#pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
+// clang-format off
+#pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, \
+    CY_NEAR_ZERO
+// clang-format on
 
 namespace cycamore {
 
@@ -20,56 +23,53 @@ class Context;
 /// total inventory size.  The inventory size and throughput capacity both
 /// default to infinite. If a recipe is provided, it will request material with
 /// that recipe. Requests are made for any number of specified commodities.
-class Sink
-  : public cyclus::Facility,
-    public cyclus::toolkit::Position  {
+class Sink : public cyclus::Facility,
+             public cyclus::toolkit::Position {
+              
  public:
   Sink(cyclus::Context* ctx);
-
   virtual ~Sink();
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
+    // clang-format off
   #pragma cyclus note { \
     "doc": \
-    " A sink facility that accepts materials and products with a fixed\n"\
-    " throughput (per time step) capacity and a lifetime capacity defined by\n"\
-    " a total inventory size. The inventory size and throughput capacity\n"\
-    " both default to infinite. If a recipe is provided, it will request\n"\
-    " material with that recipe. Requests are made for any number of\n"\
-    " specified commodities.\n" \
-    }
+      " A sink facility that accepts materials and products with a fixed\n" \
+      " throughput (per time step) capacity and a lifetime capacity defined by\n" \
+      " a total inventory size. The inventory size and throughput capacity\n" \
+      " both default to infinite. If a recipe is provided, it will request\n" \
+      " material with that recipe. Requests are made for any number of\n" \
+      " specified commodities.\n", \
+  }
 
   #pragma cyclus decl
+  // clang-format on
 
   virtual std::string str();
-
   virtual void EnterNotify();
-
   virtual void Tick();
-
   virtual void Tock();
 
-  /// @brief SinkFacilities request Materials of their given commodity. Note
+  /// @brief SinkFacilities request Materials of their given commodity.  Note
   /// that it is assumed the Sink operates on a single resource type!
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
       GetMatlRequests();
 
-  /// @brief SinkFacilities request Products of their given
-  /// commodity. Note that it is assumed the Sink operates on a single
-  /// resource type!
+  /// @brief SinkFacilities request Products of their given commodity.  Note
+  /// that it is assumed the Sink operates on a single resource type!
   virtual std::set<cyclus::RequestPortfolio<cyclus::Product>::Ptr>
       GetGenRsrcRequests();
 
   /// @brief SinkFacilities place accepted trade Materials in their Inventory
   virtual void AcceptMatlTrades(
-      const std::vector< std::pair<cyclus::Trade<cyclus::Material>,
-      cyclus::Material::Ptr> >& responses);
+      const std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                                  cyclus::Material::Ptr>>& responses);
 
   /// @brief SinkFacilities place accepted trade Materials in their Inventory
   virtual void AcceptGenRsrcTrades(
-      const std::vector< std::pair<cyclus::Trade<cyclus::Product>,
-      cyclus::Product::Ptr> >& responses);
+      const std::vector<std::pair<cyclus::Trade<cyclus::Product>,
+                                  cyclus::Product::Ptr>>& responses);
 
   /// @brief SinkFacilities update request amount using random behavior
   virtual void SetRequestAmt();
@@ -77,22 +77,26 @@ class Sink
   /// @brief SinkFacilities update request time using random behavior
   virtual void SetNextBuyTime();
 
-  ///  add a commodity to the set of input commodities
-  ///  @param name the commodity name
-  inline void AddCommodity(std::string name) { in_commods.push_back(name); }
+  /// add a commodity to the set of input commodities
+  inline void AddCommodity(std::string name) {
+    in_commods.push_back(name);
+  }
 
-  ///  sets the size of the storage inventory for received material
-  ///  @param size the storage size
+  /// sets the size of the storage inventory for received material
   inline void SetMaxInventorySize(double size) {
     max_inv_size = size;
     inventory.capacity(size);
   }
 
   /// @return the maximum inventory storage size
-  inline double MaxInventorySize() const { return inventory.capacity(); }
+  inline double MaxInventorySize() const {
+    return inventory.capacity();
+  }
 
   /// @return the current inventory storage size
-  inline double InventorySize() const { return inventory.quantity(); }
+  inline double InventorySize() const {
+    return inventory.quantity();
+  }
 
   /// determines the amount to request
   inline double SpaceAvailable() const {
@@ -100,179 +104,192 @@ class Sink
   }
 
   /// sets the capacity of a material generated at any given time step
-  /// @param capacity the reception capacity
   inline void Capacity(double cap) { capacity = cap; }
 
   /// @return the reception capacity at any given time step
   inline double Capacity() const { return capacity; }
 
   /// @return the input commodities
-  inline const std::vector<std::string>&
-      input_commodities() const { return in_commods; }
+  inline const std::vector<std::string>& input_commodities() const {
+    return in_commods;
+  }
 
-  /// @return the input commodities preferences
-  inline const std::vector<double>&
-      input_commodity_preferences() const { return in_commod_prefs; }
+  /// @return the input commodity preferences
+  inline const std::vector<double>& input_commodity_preferences() const {
+    return in_commod_prefs;
+  }
 
- private:
+  private:
   double requestAmt;
   int nextBuyTime;
-  /// all facilities must have at least one input commodity
-  #pragma cyclus var {"tooltip": "input commodities", \
-                      "doc": "commodities that the sink facility accepts", \
-                      "uilabel": "List of Input Commodities", \
-                      "uitype": ["oneormore", "incommodity"]}
+
+  // clang-format off
+  #pragma cyclus var { \
+    "tooltip": "input commodities", \
+    "doc": "commodities that the sink facility accepts", \
+    "uilabel": "List of Input Commodities", \
+    "uitype": ["oneormore", "incommodity"] \
+  }
   std::vector<std::string> in_commods;
 
-  #pragma cyclus var {"default": [],\
-                      "doc":"preferences for each of the given commodities, in the same order."\
-                      "Defauts to 1 if unspecified",\
-                      "uilabel":"In Commody Preferences", \
-                      "range": [None, [CY_NEAR_ZERO, CY_LARGE_DOUBLE]], \
-                      "uitype":["oneormore", "range"]}
+  #pragma cyclus var { \
+    "default": [], \
+    "doc": "preferences for each of the given commodities, in the same order. " \
+           "Defaults to 1 if unspecified", \
+    "uilabel": "In Commodity Preferences", \
+    "range": [None, [CY_NEAR_ZERO, CY_LARGE_DOUBLE]], \
+    "uitype": ["oneormore", "range"] \
+  }
   std::vector<double> in_commod_prefs;
 
-  #pragma cyclus var {"default": "", \
-                      "tooltip": "requested composition", \
-                      "doc": "name of recipe to use for material requests, " \
-                             "where the default (empty string) is to accept " \
-                             "everything", \
-                      "uilabel": "Input Recipe", \
-                      "uitype": "inrecipe"}
+  #pragma cyclus var { \
+    "default": "", \
+    "tooltip": "requested composition", \
+    "doc": "name of recipe to use for material requests, where the default " \
+           "(empty string) is to accept everything", \
+    "uilabel": "Input Recipe", \
+    "uitype": "inrecipe" \
+  }
   std::string recipe_name;
 
-  /// max inventory size
-  #pragma cyclus var {"default": CY_LARGE_DOUBLE, \
-                      "tooltip": "sink maximum inventory size", \
-                      "uilabel": "Maximum Inventory", \
-                      "uitype": "range", \
-                      "range": [0.0, CY_LARGE_DOUBLE], \
-                      "doc": "total maximum inventory size of sink facility"}
+  #pragma cyclus var { \
+    "default": CY_LARGE_DOUBLE, \
+    "tooltip": "sink maximum inventory size", \
+    "uilabel": "Maximum Inventory", \
+    "uitype": "range", \
+    "range": [0.0, CY_LARGE_DOUBLE], \
+    "doc": "total maximum inventory size of sink facility" \
+  }
   double max_inv_size;
 
-  /// monthly acceptance capacity
-  #pragma cyclus var {"default": CY_LARGE_DOUBLE, \
-                      "tooltip": "sink capacity", \
-                      "uilabel": "Maximum Throughput", \
-                      "uitype": "range", \
-                      "range": [0.0, CY_LARGE_DOUBLE], \
-                      "doc": "capacity the sink facility can " \
-                             "accept at each time step"}
+  #pragma cyclus var { \
+    "default": CY_LARGE_DOUBLE, \
+    "tooltip": "sink capacity", \
+    "uilabel": "Maximum Throughput", \
+    "uitype": "range", \
+    "range": [0.0, CY_LARGE_DOUBLE], \
+    "doc": "capacity the sink facility can accept at each time step" \
+  }
   double capacity;
 
-  /// this facility holds material in storage.
-  #pragma cyclus var {'capacity': 'max_inv_size'}
+  #pragma cyclus var { \
+    "capacity": "max_inv_size" \
+  }
   cyclus::toolkit::ResBuf<cyclus::Resource> inventory;
 
-  /// random status (size of request)
-  #pragma cyclus var {"default": "None", \
-                      "tooltip": "type of random behavior when setting the " \
-                      "size of the request", \
-                      "uitype": "combobox", \
-                      "uilabel": "Random Size", \
-                      "categorical": ["None", "UniformReal", "UniformInt", "NormalReal", "NormalInt"], \
-                      "doc": "type of random behavior to use. Default None, " \
-                      "other options are 'UniformReal', 'UniformInt', " \
-                      "'NormalReal', and 'NormalInt'"}
+  #pragma cyclus var { \
+    "default": "None", \
+    "tooltip": "type of random behavior when setting the size of the request", \
+    "uitype": "combobox", \
+    "uilabel": "Random Size", \
+    "categorical": ["None", "UniformReal", "UniformInt", "NormalReal", \
+                    "NormalInt"], \
+    "doc": "type of random behavior to use. Default None; other options are " \
+           "'UniformReal', 'UniformInt', 'NormalReal', and 'NormalInt'" \
+  }
   std::string random_size_type;
 
-  // random size mean (as a fraction of available space)
-  #pragma cyclus var {"default": 1.0, \
-                      "tooltip": "fraction of available space to determine the mean", \
-                      "uilabel": "Random Size Mean", \
-                      "uitype": "range", \
-                      "range": [0.0, CY_LARGE_DOUBLE], \
-                      "doc": "When a normal distribution is used to determine the " \
-                             "size of the request, this is the fraction of available " \
-                             "space to use as the mean. Default 1.0. Note " \
-                             "that values significantly above 1 without a " \
-                             "correspondingly large std dev may result in " \
-                             "inefficient use of the random number generator."}
+  #pragma cyclus var { \
+    "default": 1.0, \
+    "tooltip": "fraction of available space to determine the mean", \
+    "uilabel": "Random Size Mean", \
+    "uitype": "range", \
+    "range": [0.0, CY_LARGE_DOUBLE], \
+    "doc": "When a normal distribution is used to determine the size of the "\
+           "request, this is the fraction of available space to use as the "\
+           "mean. Default 1.0; note that values significantly above 1 without "\
+           "a correspondingly large std dev may be inefficient." \
+  }
   double random_size_mean;
 
-  // random size std dev (as a fraction of available space)
-  #pragma cyclus var {"default": 0.1, \
-                      "tooltip": "fraction of available space to determine the std dev", \
-                      "uilabel": "Random Size Std Dev", \
-                      "uitype": "range", \
-                      "range": [0.0, CY_LARGE_DOUBLE], \
-                      "doc": "When a normal distribution is used to determine the " \
-                             "size of the request, this is the fraction of available " \
-                             "space to use as the standard deviation. Default 0.1"}
+  #pragma cyclus var { \
+    "default": 0.1, \
+    "tooltip": "fraction of available space to determine the std dev", \
+    "uilabel": "Random Size Std Dev", \
+    "uitype": "range", \
+    "range": [0.0, CY_LARGE_DOUBLE], \
+    "doc": "When a normal distribution is used to determine the size of the "\
+           "request, this is the fraction of available space to use as the "\
+           "standard deviation. Default 0.1" \
+  }
   double random_size_stddev;
 
-  // random status (frequencing/timing of request)
-  #pragma cyclus var {"default": "None", \
-                      "tooltip": "type of random behavior when setting the " \
-                      "timing of the request", \
-                      "uitype": "combobox", \
-                      "uilabel": "Random Timing", \
-                      "categorical": ["None", "UniformInt", "NormalInt"], \
-                      "doc": "type of random behavior to use. Default None, " \
-                      "other options are, 'UniformInt', and 'NormalInt'. " \
-                      "When using 'UniformInt', also set "\
-                      "'random_frequency_min' and 'random_frequency_max'. " \
-                      "For 'NormalInt', set 'random_frequency_mean' and " \
-                      "'random_fequency_stddev', min and max values are " \
-                      "optional. "}
+  #pragma cyclus var { \
+    "default": "None", \
+    "tooltip": "type of random behavior when setting the timing of the "\
+               "request", \
+    "uitype": "combobox", \
+    "uilabel": "Random Timing", \
+    "categorical": ["None", "UniformInt", "NormalInt"], \
+    "doc": "type of random behavior to use. Default None; other options are "\
+           "'UniformInt' and 'NormalInt'. When using 'UniformInt', also "\
+           "set 'random_frequency_min' and 'random_frequency_max'. For "\
+           "'NormalInt', set 'random_frequency_mean' and "\
+           "'random_frequency_stddev'; min and max are optional." \
+  }
   std::string random_frequency_type;
 
-  // random frequency mean 
-  #pragma cyclus var {"default": 1, \
-                      "tooltip": "mean of the random frequency", \
-                      "uilabel": "Random Frequency Mean", \
-                      "uitype": "range", \
-                      "range": [0.0, CY_LARGE_DOUBLE], \
-                      "doc": "When a normal distribution is used to determine the " \
-                             "frequency of the request, this is the mean. Default 1"}
+  #pragma cyclus var { \
+    "default": 1, \
+    "tooltip": "mean of the random frequency", \
+    "uilabel": "Random Frequency Mean", \
+    "uitype": "range", \
+    "range": [0.0, CY_LARGE_DOUBLE], \
+    "doc": "When a normal distribution is used to determine the frequency of "\
+           "the request, this is the mean. Default 1" \
+  }
   double random_frequency_mean;
 
-  // random frequency std dev
-  #pragma cyclus var {"default": 1, \
-                      "tooltip": "std dev of the random frequency", \
-                      "uilabel": "Random Frequency Std Dev", \
-                      "uitype": "range", \
-                      "range": [0.0, CY_LARGE_DOUBLE], \
-                      "doc": "When a normal distribution is used to determine the " \
-                             "frequency of the request, this is the standard deviation. Default 1"}
+  #pragma cyclus var { \
+    "default": 1, \
+    "tooltip": "std dev of the random frequency", \
+    "uilabel": "Random Frequency Std Dev", \
+    "uitype": "range", \
+    "range": [0.0, CY_LARGE_DOUBLE], \
+    "doc": "When a normal distribution is used to determine the frequency of "\
+           "the request, this is the standard deviation. Default 1" \
+  }
   double random_frequency_stddev;
 
-  // random frequency lower bound
-  #pragma cyclus var {"default": 1, \
-                      "tooltip": "lower bound of the random frequency", \
-                      "uilabel": "Random Frequency Lower Bound", \
-                      "uitype": "range", \
-                      "range": [1, CY_LARGE_INT], \
-                      "doc": "When a random distribution is used to determine the " \
-                             "frequency of the request, this is the lower bound. Default 1"}
+  #pragma cyclus var { \
+    "default": 1, \
+    "tooltip": "lower bound of the random frequency", \
+    "uilabel": "Random Frequency Lower Bound", \
+    "uitype": "range", \
+    "range": [1, CY_LARGE_INT], \
+    "doc": "When a random distribution is used to determine the frequency of "\
+           "the request, this is the lower bound. Default 1" \
+  }
   int random_frequency_min;
 
-  // random frequency upper bound
-  #pragma cyclus var {"default": CY_LARGE_INT, \
-                      "tooltip": "upper bound of the random frequency", \
-                      "uilabel": "Random Frequency Upper Bound", \
-                      "uitype": "range", \
-                      "range": [1, CY_LARGE_INT], \
-                      "doc": "When a random distribution is used to determine the " \
-                             f"frequency of the request, this is the upper bound. Default {CY_LARGE_INT} (CY_LARGE_INT)"}
+  #pragma cyclus var { \
+    "default": CY_LARGE_INT, \
+    "tooltip": "upper bound of the random frequency", \
+    "uilabel": "Random Frequency Upper Bound", \
+    "uitype": "range", \
+    "range": [1, CY_LARGE_INT], \
+    "doc": "When a random distribution is used to determine the frequency of "\
+           "the request, this is the upper bound. Default CY_LARGE_INT" \
+  }
   int random_frequency_max;
 
   #pragma cyclus var { \
     "default": True, \
     "tooltip": "Whether to persist packaging in the sink.", \
-    "doc": "Boolean value about whether to keep packaging. If true, " \
-           "packaging will not be stripped upon acceptance into the " \
-           "sink. If false, package type will be stripped immediately " \
-           "upon acceptance. Has no effect if the incoming material is not " \
+    "doc": "Boolean value about whether to keep packaging. If true, "\
+           "packaging will not be stripped upon acceptance into the sink. "\
+           "If false, package type will be stripped immediately upon "\
+           "acceptance. Has no effect if the incoming material is not "\
            "packaged.", \
     "uilabel": "Keep Packaging", \
-    "uitype": "bool"}
+    "uitype": "bool" \
+  }
   bool keep_packaging;
 
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
+    "doc": "Latitude of the agent's geographical position. The value should "\
            "be expressed in degrees as a double." \
   }
   double latitude;
@@ -280,10 +297,11 @@ class Sink
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
+    "doc": "Longitude of the agent's geographical position. The value should "\
            "be expressed in degrees as a double." \
   }
   double longitude;
+  // clang-format on
 
   cyclus::toolkit::Position coordinates;
 

--- a/src/sink.h
+++ b/src/sink.h
@@ -6,8 +6,8 @@
 #include <utility>
 #include <vector>
 
-#include "cycamore_version.h"
 #include "cyclus.h"
+#include "cycamore_version.h"
 
 // clang-format off
 #pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, \
@@ -23,14 +23,16 @@ class Context;
 /// total inventory size.  The inventory size and throughput capacity both
 /// default to infinite. If a recipe is provided, it will request material with
 /// that recipe. Requests are made for any number of specified commodities.
-class Sink : public cyclus::Facility, public cyclus::toolkit::Position {
+class Sink : public cyclus::Facility,
+             public cyclus::toolkit::Position {
+              
  public:
   Sink(cyclus::Context* ctx);
   virtual ~Sink();
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-  // clang-format off
+    // clang-format off
   #pragma cyclus note { \
     "doc": \
       " A sink facility that accepts materials and products with a fixed\n" \
@@ -52,12 +54,12 @@ class Sink : public cyclus::Facility, public cyclus::toolkit::Position {
   /// @brief SinkFacilities request Materials of their given commodity.  Note
   /// that it is assumed the Sink operates on a single resource type!
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-  GetMatlRequests();
+      GetMatlRequests();
 
   /// @brief SinkFacilities request Products of their given commodity.  Note
   /// that it is assumed the Sink operates on a single resource type!
   virtual std::set<cyclus::RequestPortfolio<cyclus::Product>::Ptr>
-  GetGenRsrcRequests();
+      GetGenRsrcRequests();
 
   /// @brief SinkFacilities place accepted trade Materials in their Inventory
   virtual void AcceptMatlTrades(
@@ -76,7 +78,9 @@ class Sink : public cyclus::Facility, public cyclus::toolkit::Position {
   virtual void SetNextBuyTime();
 
   /// add a commodity to the set of input commodities
-  inline void AddCommodity(std::string name) { in_commods.push_back(name); }
+  inline void AddCommodity(std::string name) {
+    in_commods.push_back(name);
+  }
 
   /// sets the size of the storage inventory for received material
   inline void SetMaxInventorySize(double size) {
@@ -85,10 +89,14 @@ class Sink : public cyclus::Facility, public cyclus::toolkit::Position {
   }
 
   /// @return the maximum inventory storage size
-  inline double MaxInventorySize() const { return inventory.capacity(); }
+  inline double MaxInventorySize() const {
+    return inventory.capacity();
+  }
 
   /// @return the current inventory storage size
-  inline double InventorySize() const { return inventory.quantity(); }
+  inline double InventorySize() const {
+    return inventory.quantity();
+  }
 
   /// determines the amount to request
   inline double SpaceAvailable() const {
@@ -111,7 +119,7 @@ class Sink : public cyclus::Facility, public cyclus::toolkit::Position {
     return in_commod_prefs;
   }
 
- private:
+  private:
   double requestAmt;
   int nextBuyTime;
 

--- a/src/sink.h
+++ b/src/sink.h
@@ -23,16 +23,14 @@ class Context;
 /// total inventory size.  The inventory size and throughput capacity both
 /// default to infinite. If a recipe is provided, it will request material with
 /// that recipe. Requests are made for any number of specified commodities.
-class Sink : public cyclus::Facility,
-             public cyclus::toolkit::Position {
-              
+class Sink : public cyclus::Facility, public cyclus::toolkit::Position {
  public:
   Sink(cyclus::Context* ctx);
   virtual ~Sink();
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
-    // clang-format off
+  // clang-format off
   #pragma cyclus note { \
     "doc": \
       " A sink facility that accepts materials and products with a fixed\n" \
@@ -54,12 +52,12 @@ class Sink : public cyclus::Facility,
   /// @brief SinkFacilities request Materials of their given commodity.  Note
   /// that it is assumed the Sink operates on a single resource type!
   virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
-      GetMatlRequests();
+  GetMatlRequests();
 
   /// @brief SinkFacilities request Products of their given commodity.  Note
   /// that it is assumed the Sink operates on a single resource type!
   virtual std::set<cyclus::RequestPortfolio<cyclus::Product>::Ptr>
-      GetGenRsrcRequests();
+  GetGenRsrcRequests();
 
   /// @brief SinkFacilities place accepted trade Materials in their Inventory
   virtual void AcceptMatlTrades(
@@ -79,9 +77,7 @@ class Sink : public cyclus::Facility,
 
   /// add a commodity to the set of input commodities
   /// @param name the commodity name
-  inline void AddCommodity(std::string name) {
-    in_commods.push_back(name);
-  }
+  inline void AddCommodity(std::string name) { in_commods.push_back(name); }
 
   /// sets the size of the storage inventory for received material
   inline void SetMaxInventorySize(double size) {
@@ -90,14 +86,10 @@ class Sink : public cyclus::Facility,
   }
 
   /// @return the maximum inventory storage size
-  inline double MaxInventorySize() const {
-    return inventory.capacity();
-  }
+  inline double MaxInventorySize() const { return inventory.capacity(); }
 
   /// @return the current inventory storage size
-  inline double InventorySize() const {
-    return inventory.quantity();
-  }
+  inline double InventorySize() const { return inventory.quantity(); }
 
   /// determines the amount to request
   inline double SpaceAvailable() const {
@@ -121,8 +113,8 @@ class Sink : public cyclus::Facility,
   }
 
  private:
-  // Code Injection:
-  #include "toolkit/position.cycpp.h"
+// Code Injection:
+#include "toolkit/position.cycpp.h"
 
   double requestAmt;
   int nextBuyTime;
@@ -290,7 +282,6 @@ class Sink : public cyclus::Facility,
   }
   bool keep_packaging;
   // clang-format on
-
 };
 
 }  // namespace cycamore

--- a/src/sink.h
+++ b/src/sink.h
@@ -78,6 +78,7 @@ class Sink : public cyclus::Facility,
   virtual void SetNextBuyTime();
 
   /// add a commodity to the set of input commodities
+  /// @param name the commodity name
   inline void AddCommodity(std::string name) {
     in_commods.push_back(name);
   }
@@ -288,6 +289,7 @@ class Sink : public cyclus::Facility,
     "uitype": "bool" \
   }
   bool keep_packaging;
+  // clang-format on
 
 };
 

--- a/src/sink.h
+++ b/src/sink.h
@@ -80,6 +80,7 @@ class Sink : public cyclus::Facility, public cyclus::toolkit::Position {
   inline void AddCommodity(std::string name) { in_commods.push_back(name); }
 
   /// sets the size of the storage inventory for received material
+  /// @param size the storage size
   inline void SetMaxInventorySize(double size) {
     max_inv_size = size;
     inventory.capacity(size);
@@ -97,6 +98,7 @@ class Sink : public cyclus::Facility, public cyclus::toolkit::Position {
   }
 
   /// sets the capacity of a material generated at any given time step
+  /// @param cap the reception capacity
   inline void Capacity(double cap) { capacity = cap; }
 
   /// @return the reception capacity at any given time step
@@ -120,6 +122,8 @@ class Sink : public cyclus::Facility, public cyclus::toolkit::Position {
   int nextBuyTime;
 
   // clang-format off
+
+  /// all facilities must have at least one input commodity
   #pragma cyclus var { \
     "tooltip": "input commodities", \
     "doc": "commodities that the sink facility accepts", \

--- a/src/sink_tests.cc
+++ b/src/sink_tests.cc
@@ -1,12 +1,12 @@
+#include "sink_tests.h"
+
 #include <gtest/gtest.h>
 
-#include "facility_tests.h"
 #include "agent_tests.h"
-#include "resource_helpers.h"
+#include "facility_tests.h"
 #include "infile_tree.h"
+#include "resource_helpers.h"
 #include "xml_parser.h"
-
-#include "sink_tests.h"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void SinkTest::SetUp() {
@@ -48,27 +48,26 @@ TEST_F(SinkTest, InitialState) {
   EXPECT_DOUBLE_EQ(capacity_, src_facility->SpaceAvailable());
   EXPECT_DOUBLE_EQ(0.0, src_facility->InventorySize());
   std::string arr[] = {commod1_, commod2_};
-  std::vector<std::string> vexp (arr, arr + sizeof(arr) / sizeof(arr[0]) );
+  std::vector<std::string> vexp(arr, arr + sizeof(arr) / sizeof(arr[0]));
   EXPECT_EQ(vexp, src_facility->input_commodities());
 
   src_facility->EnterNotify();
   double pref[] = {cyclus::kDefaultPref, cyclus::kDefaultPref};
-  std::vector<double> vpref (pref, pref + sizeof(pref) / sizeof(pref[0]) );
+  std::vector<double> vpref(pref, pref + sizeof(pref) / sizeof(pref[0]));
   EXPECT_EQ(vpref, src_facility->input_commodity_preferences());
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(SinkTest, Clone) {
   using cycamore::Sink;
-  Sink* cloned_fac = dynamic_cast<cycamore::Sink*>
-                             (src_facility->Clone());
+  Sink* cloned_fac = dynamic_cast<cycamore::Sink*>(src_facility->Clone());
 
   EXPECT_DOUBLE_EQ(0.0, cloned_fac->InventorySize());
   EXPECT_DOUBLE_EQ(capacity_, cloned_fac->Capacity());
   EXPECT_DOUBLE_EQ(inv_, cloned_fac->MaxInventorySize());
   EXPECT_DOUBLE_EQ(capacity_, cloned_fac->SpaceAvailable());
   std::string arr[] = {commod1_, commod2_};
-  std::vector<std::string> vexp (arr, arr + sizeof(arr) / sizeof(arr[0]) );
+  std::vector<std::string> vexp(arr, arr + sizeof(arr) / sizeof(arr[0]));
   EXPECT_EQ(vexp, cloned_fac->input_commodities());
 
   delete cloned_fac;
@@ -77,21 +76,12 @@ TEST_F(SinkTest, Clone) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(SinkTest, DISABLED_XMLInit) {
   std::stringstream ss;
-  ss << "<start>"
-     << "<name>fooname</name>"
-     << "<config>"
-     << "<UNSPECIFIED>"
-     << "<input>"
-     << "  <commodities>"
-     << "  <incommodity>" << commod1_ << "</incommodity>"
-     << "  <incommodity>" << commod2_ << "</incommodity>"
-     << "  </commodities>"
-     << "  <input_capacity>" << capacity_ << "</input_capacity>"
-     << "  <inventorysize>" << inv_ << "</inventorysize>"
-     << "</input>"
-     << "</UNSPECIFIED>"
-     << "</config>"
-     << "</start>";
+  ss << "<start>" << "<name>fooname</name>" << "<config>" << "<UNSPECIFIED>"
+     << "<input>" << "  <commodities>" << "  <incommodity>" << commod1_
+     << "</incommodity>" << "  <incommodity>" << commod2_ << "</incommodity>"
+     << "  </commodities>" << "  <input_capacity>" << capacity_
+     << "</input_capacity>" << "  <inventorysize>" << inv_ << "</inventorysize>"
+     << "</input>" << "</UNSPECIFIED>" << "</config>" << "</start>";
 
   cyclus::XMLParser p;
   p.Init(ss);
@@ -100,7 +90,7 @@ TEST_F(SinkTest, DISABLED_XMLInit) {
 
   // EXPECT_NO_THROW(fac.InitFrom(&engine););
   std::string arr[] = {commod1_, commod2_};
-  std::vector<std::string> vexp (arr, arr + sizeof(arr) / sizeof(arr[0]) );
+  std::vector<std::string> vexp(arr, arr + sizeof(arr) / sizeof(arr[0]));
   EXPECT_EQ(vexp, fac.input_commodities());
   EXPECT_DOUBLE_EQ(capacity_, fac.Capacity());
   EXPECT_DOUBLE_EQ(inv_, fac.MaxInventorySize());
@@ -110,13 +100,13 @@ TEST_F(SinkTest, DISABLED_XMLInit) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(SinkTest, Requests) {
-  using cyclus::Request;
-  using cyclus::RequestPortfolio;
   using cyclus::CapacityConstraint;
   using cyclus::Material;
+  using cyclus::Request;
+  using cyclus::RequestPortfolio;
 
   std::string arr[] = {commod1_, commod2_};
-  std::vector<std::string> commods (arr, arr + sizeof(arr) / sizeof(arr[0]) );
+  std::vector<std::string> commods(arr, arr + sizeof(arr) / sizeof(arr[0]));
 
   src_facility->EnterNotify();
   std::set<RequestPortfolio<Material>::Ptr> ports =
@@ -134,7 +124,7 @@ TEST_F(SinkTest, Requests) {
     EXPECT_EQ(req->commodity(), commods[i]);
   }
 
-  const std::set< CapacityConstraint<Material> >& constraints =
+  const std::set<CapacityConstraint<Material>>& constraints =
       ports.begin()->get()->constraints();
   EXPECT_EQ(constraints.size(), 0);
 }
@@ -159,17 +149,14 @@ TEST_F(SinkTest, Accept) {
   using test_helpers::get_mat;
 
   double qty = qty_ * 2;
-  std::vector< std::pair<Trade<Material>,
-                         Material::Ptr> > responses;
+  std::vector<std::pair<Trade<Material>, Material::Ptr>> responses;
 
-  Request<Material>* req1 =
-      Request<Material>::Create(get_mat(922350000, qty_), src_facility,
-                                commod1_);
+  Request<Material>* req1 = Request<Material>::Create(get_mat(922350000, qty_),
+                                                      src_facility, commod1_);
   Bid<Material>* bid1 = Bid<Material>::Create(req1, get_mat(), trader);
 
-  Request<Material>* req2 =
-      Request<Material>::Create(get_mat(922350000, qty_), src_facility,
-                                commod2_);
+  Request<Material>* req2 = Request<Material>::Create(get_mat(922350000, qty_),
+                                                      src_facility, commod2_);
   Bid<Material>* bid2 =
       Bid<Material>::Create(req2, get_mat(922350000, qty_), trader);
 
@@ -183,11 +170,11 @@ TEST_F(SinkTest, Accept) {
   EXPECT_DOUBLE_EQ(qty, src_facility->InventorySize());
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(SinkTest, InRecipe){
-// Create a context
-  using cyclus::RequestPortfolio;
+TEST_F(SinkTest, InRecipe) {
+  // Create a context
   using cyclus::Material;
   using cyclus::Request;
+  using cyclus::RequestPortfolio;
   cyclus::Recorder rec;
   cyclus::Timer ti;
   cyclus::Context ctx(&ti, &rec);
@@ -198,54 +185,48 @@ TEST_F(SinkTest, InRecipe){
   m[922580000] = 2;
 
   cyclus::Composition::Ptr c = cyclus::Composition::CreateFromMass(m);
-  ctx.AddRecipe("some_u",c) ;
+  ctx.AddRecipe("some_u", c);
 
   // create a sink facility to interact with the DRE
   cycamore::Sink* snk = new cycamore::Sink(&ctx);
   snk->AddCommodity("some_u");
   snk->EnterNotify();
 
-  std::set<RequestPortfolio<Material>::Ptr> ports =
-    snk->GetMatlRequests();
+  std::set<RequestPortfolio<Material>::Ptr> ports = snk->GetMatlRequests();
   ASSERT_EQ(ports.size(), 1);
 
   const std::vector<Request<Material>*>& requests =
-    ports.begin()->get()->requests();
+      ports.begin()->get()->requests();
   ASSERT_EQ(requests.size(), 1);
 
   Request<Material>* req = *requests.begin();
   EXPECT_EQ(req->requester(), snk);
-  EXPECT_EQ(req->commodity(),"some_u");
+  EXPECT_EQ(req->commodity(), "some_u");
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(SinkTest, BidPrefs) {
-  using cyclus::QueryResult;
   using cyclus::Cond;
+  using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "     <val>commods_2</val>"
-    "   </in_commods>"
-    "   <in_commod_prefs>"
-    "     <val>10</val> "
-    "     <val>1</val> "
-    "   </in_commod_prefs>"
-    "   <capacity>1</capacity>"
-    "   <input_capacity>1.0</input_capacity> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "     <val>commods_2</val>"
+      "   </in_commods>"
+      "   <in_commod_prefs>"
+      "     <val>10</val> "
+      "     <val>1</val> "
+      "   </in_commod_prefs>"
+      "   <capacity>1</capacity>"
+      "   <input_capacity>1.0</input_capacity> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
 
-  sim.AddSource("commods_1")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("commods_1").capacity(1).Finalize();
 
-  sim.AddSource("commods_2")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("commods_2").capacity(1).Finalize();
 
   int id = sim.Run();
 
@@ -262,7 +243,6 @@ TEST_F(SinkTest, BidPrefs) {
 
   // should trade only with #1 since it has highier priority
   EXPECT_EQ(0, qr2.rows.size());
-
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(SinkTest, Print) {
@@ -273,28 +253,23 @@ TEST_F(SinkTest, PositionInitialize) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "     <val>commods_2</val>"
-    "   </in_commods>"
-    "   <in_commod_prefs>"
-    "     <val>10</val> "
-    "     <val>1</val> "
-    "   </in_commod_prefs>"
-    "   <capacity>1</capacity>"
-    "   <input_capacity>1.0</input_capacity> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "     <val>commods_2</val>"
+      "   </in_commods>"
+      "   <in_commod_prefs>"
+      "     <val>10</val> "
+      "     <val>1</val> "
+      "   </in_commod_prefs>"
+      "   <capacity>1</capacity>"
+      "   <input_capacity>1.0</input_capacity> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
 
-  sim.AddSource("commods_1")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("commods_1").capacity(1).Finalize();
 
-  sim.AddSource("commods_2")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("commods_2").capacity(1).Finalize();
 
   int id = sim.Run();
 
@@ -307,37 +282,31 @@ TEST_F(SinkTest, PositionInitialize2) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "     <val>commods_2</val>"
-    "   </in_commods>"
-    "   <in_commod_prefs>"
-    "     <val>10</val> "
-    "     <val>1</val> "
-    "   </in_commod_prefs>"
-    "   <capacity>1</capacity>"
-    "   <input_capacity>1.0</input_capacity> "
-    "   <latitude>50.0</latitude> "
-    "   <longitude>35.0</longitude> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "     <val>commods_2</val>"
+      "   </in_commods>"
+      "   <in_commod_prefs>"
+      "     <val>10</val> "
+      "     <val>1</val> "
+      "   </in_commod_prefs>"
+      "   <capacity>1</capacity>"
+      "   <input_capacity>1.0</input_capacity> "
+      "   <latitude>50.0</latitude> "
+      "   <longitude>35.0</longitude> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
 
-  sim.AddSource("commods_1")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("commods_1").capacity(1).Finalize();
 
-  sim.AddSource("commods_2")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("commods_2").capacity(1).Finalize();
 
   int id = sim.Run();
 
   QueryResult qr = sim.db().Query("AgentPosition", NULL);
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 35.0);
   EXPECT_EQ(qr.GetVal<double>("Latitude"), 50.0);
-
 }
 
 // A random number pulled from a uniform integer distribution can be
@@ -346,15 +315,14 @@ TEST_F(SinkTest, RandomUniformSize) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "   </in_commods>"
-    "   <capacity>10</capacity>"
-    "   <random_size_type>UniformReal</random_size_type> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "   </in_commods>"
+      "   <capacity>10</capacity>"
+      "   <random_size_type>UniformReal</random_size_type> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -370,15 +338,14 @@ TEST_F(SinkTest, RandomNormalSize) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "   </in_commods>"
-    "   <capacity>10</capacity>"
-    "   <random_size_type>NormalReal</random_size_type> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "   </in_commods>"
+      "   <capacity>10</capacity>"
+      "   <random_size_type>NormalReal</random_size_type> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -394,17 +361,16 @@ TEST_F(SinkTest, RandomNormalSizeWithMeanSttdev) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "   </in_commods>"
-    "   <capacity>10</capacity>"
-    "   <random_size_type>NormalReal</random_size_type> "
-    "   <random_size_mean>0.5</random_size_mean> "
-    "   <random_size_stddev>0.2</random_size_stddev> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "   </in_commods>"
+      "   <capacity>10</capacity>"
+      "   <random_size_type>NormalReal</random_size_type> "
+      "   <random_size_mean>0.5</random_size_mean> "
+      "   <random_size_stddev>0.2</random_size_stddev> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -420,17 +386,16 @@ TEST_F(SinkTest, RandomUniformFreq) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "   </in_commods>"
-    "   <capacity>10</capacity>"
-    "   <random_frequency_type>UniformInt</random_frequency_type> "
-    "   <random_frequency_min>2</random_frequency_min> "
-    "   <random_frequency_max>4</random_frequency_max> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "   </in_commods>"
+      "   <capacity>10</capacity>"
+      "   <random_frequency_type>UniformInt</random_frequency_type> "
+      "   <random_frequency_min>2</random_frequency_min> "
+      "   <random_frequency_max>4</random_frequency_max> ";
 
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -449,15 +414,14 @@ TEST_F(SinkTest, RandomNormalFreq) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "   </in_commods>"
-    "   <capacity>10</capacity>"
-    "   <random_frequency_type>NormalInt</random_frequency_type> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "   </in_commods>"
+      "   <capacity>10</capacity>"
+      "   <random_frequency_type>NormalInt</random_frequency_type> ";
 
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -476,17 +440,16 @@ TEST_F(SinkTest, RandomNormalFreqWithMeanSttdev) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "   </in_commods>"
-    "   <capacity>10</capacity>"
-    "   <random_frequency_type>NormalInt</random_frequency_type> "
-    "   <random_frequency_mean>2</random_frequency_mean> "
-    "   <random_frequency_stddev>0.2</random_frequency_stddev> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "   </in_commods>"
+      "   <capacity>10</capacity>"
+      "   <random_frequency_type>NormalInt</random_frequency_type> "
+      "   <random_frequency_mean>2</random_frequency_mean> "
+      "   <random_frequency_stddev>0.2</random_frequency_stddev> ";
 
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -504,17 +467,16 @@ TEST_F(SinkTest, RandomNormalFreqMultipleCycles) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "   </in_commods>"
-    "   <capacity>10</capacity>"
-    "   <random_frequency_type>NormalInt</random_frequency_type> "
-    "   <random_frequency_mean>4</random_frequency_mean> "
-    "   <random_frequency_stddev>1</random_frequency_stddev> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "   </in_commods>"
+      "   <capacity>10</capacity>"
+      "   <random_frequency_type>NormalInt</random_frequency_type> "
+      "   <random_frequency_mean>4</random_frequency_mean> "
+      "   <random_frequency_stddev>1</random_frequency_stddev> ";
 
   int simdur = 12;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -530,7 +492,7 @@ TEST_F(SinkTest, RandomNormalFreqMultipleCycles) {
   int second_trans_time = qr.GetVal<int>("Time", 1);
   EXPECT_EQ(7, second_trans_time);
   int third_trans_time = qr.GetVal<int>("Time", 2);
-  EXPECT_EQ(11, third_trans_time);  
+  EXPECT_EQ(11, third_trans_time);
 }
 
 // Check that randomness can be implemented in both size of request and
@@ -539,20 +501,19 @@ TEST_F(SinkTest, RandomNormalSizeUniformFreq) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "   </in_commods>"
-    "   <capacity>10</capacity>"
-    "   <random_size_type>NormalReal</random_size_type>"
-    "   <random_size_mean>0.8</random_size_mean>"
-    "   <random_size_stddev>0.2</random_size_stddev>"
-    "   <random_frequency_type>UniformInt</random_frequency_type> "
-    "   <random_frequency_min>2</random_frequency_min> "
-    "   <random_frequency_max>4</random_frequency_max> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "   </in_commods>"
+      "   <capacity>10</capacity>"
+      "   <random_size_type>NormalReal</random_size_type>"
+      "   <random_size_mean>0.8</random_size_mean>"
+      "   <random_size_stddev>0.2</random_size_stddev>"
+      "   <random_frequency_type>UniformInt</random_frequency_type> "
+      "   <random_frequency_min>2</random_frequency_min> "
+      "   <random_frequency_max>4</random_frequency_max> ";
 
   int simdur = 6;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(20).Finalize();
   int id = sim.Run();
 

--- a/src/sink_tests.cc
+++ b/src/sink_tests.cc
@@ -1,12 +1,12 @@
-#include "sink_tests.h"
-
 #include <gtest/gtest.h>
 
-#include "agent_tests.h"
 #include "facility_tests.h"
-#include "infile_tree.h"
+#include "agent_tests.h"
 #include "resource_helpers.h"
+#include "infile_tree.h"
 #include "xml_parser.h"
+
+#include "sink_tests.h"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void SinkTest::SetUp() {
@@ -48,26 +48,27 @@ TEST_F(SinkTest, InitialState) {
   EXPECT_DOUBLE_EQ(capacity_, src_facility->SpaceAvailable());
   EXPECT_DOUBLE_EQ(0.0, src_facility->InventorySize());
   std::string arr[] = {commod1_, commod2_};
-  std::vector<std::string> vexp(arr, arr + sizeof(arr) / sizeof(arr[0]));
+  std::vector<std::string> vexp (arr, arr + sizeof(arr) / sizeof(arr[0]) );
   EXPECT_EQ(vexp, src_facility->input_commodities());
 
   src_facility->EnterNotify();
   double pref[] = {cyclus::kDefaultPref, cyclus::kDefaultPref};
-  std::vector<double> vpref(pref, pref + sizeof(pref) / sizeof(pref[0]));
+  std::vector<double> vpref (pref, pref + sizeof(pref) / sizeof(pref[0]) );
   EXPECT_EQ(vpref, src_facility->input_commodity_preferences());
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(SinkTest, Clone) {
   using cycamore::Sink;
-  Sink* cloned_fac = dynamic_cast<cycamore::Sink*>(src_facility->Clone());
+  Sink* cloned_fac = dynamic_cast<cycamore::Sink*>
+                             (src_facility->Clone());
 
   EXPECT_DOUBLE_EQ(0.0, cloned_fac->InventorySize());
   EXPECT_DOUBLE_EQ(capacity_, cloned_fac->Capacity());
   EXPECT_DOUBLE_EQ(inv_, cloned_fac->MaxInventorySize());
   EXPECT_DOUBLE_EQ(capacity_, cloned_fac->SpaceAvailable());
   std::string arr[] = {commod1_, commod2_};
-  std::vector<std::string> vexp(arr, arr + sizeof(arr) / sizeof(arr[0]));
+  std::vector<std::string> vexp (arr, arr + sizeof(arr) / sizeof(arr[0]) );
   EXPECT_EQ(vexp, cloned_fac->input_commodities());
 
   delete cloned_fac;
@@ -76,12 +77,21 @@ TEST_F(SinkTest, Clone) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(SinkTest, DISABLED_XMLInit) {
   std::stringstream ss;
-  ss << "<start>" << "<name>fooname</name>" << "<config>" << "<UNSPECIFIED>"
-     << "<input>" << "  <commodities>" << "  <incommodity>" << commod1_
-     << "</incommodity>" << "  <incommodity>" << commod2_ << "</incommodity>"
-     << "  </commodities>" << "  <input_capacity>" << capacity_
-     << "</input_capacity>" << "  <inventorysize>" << inv_ << "</inventorysize>"
-     << "</input>" << "</UNSPECIFIED>" << "</config>" << "</start>";
+  ss << "<start>"
+     << "<name>fooname</name>"
+     << "<config>"
+     << "<UNSPECIFIED>"
+     << "<input>"
+     << "  <commodities>"
+     << "  <incommodity>" << commod1_ << "</incommodity>"
+     << "  <incommodity>" << commod2_ << "</incommodity>"
+     << "  </commodities>"
+     << "  <input_capacity>" << capacity_ << "</input_capacity>"
+     << "  <inventorysize>" << inv_ << "</inventorysize>"
+     << "</input>"
+     << "</UNSPECIFIED>"
+     << "</config>"
+     << "</start>";
 
   cyclus::XMLParser p;
   p.Init(ss);
@@ -90,7 +100,7 @@ TEST_F(SinkTest, DISABLED_XMLInit) {
 
   // EXPECT_NO_THROW(fac.InitFrom(&engine););
   std::string arr[] = {commod1_, commod2_};
-  std::vector<std::string> vexp(arr, arr + sizeof(arr) / sizeof(arr[0]));
+  std::vector<std::string> vexp (arr, arr + sizeof(arr) / sizeof(arr[0]) );
   EXPECT_EQ(vexp, fac.input_commodities());
   EXPECT_DOUBLE_EQ(capacity_, fac.Capacity());
   EXPECT_DOUBLE_EQ(inv_, fac.MaxInventorySize());
@@ -100,13 +110,13 @@ TEST_F(SinkTest, DISABLED_XMLInit) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(SinkTest, Requests) {
-  using cyclus::CapacityConstraint;
-  using cyclus::Material;
   using cyclus::Request;
   using cyclus::RequestPortfolio;
+  using cyclus::CapacityConstraint;
+  using cyclus::Material;
 
   std::string arr[] = {commod1_, commod2_};
-  std::vector<std::string> commods(arr, arr + sizeof(arr) / sizeof(arr[0]));
+  std::vector<std::string> commods (arr, arr + sizeof(arr) / sizeof(arr[0]) );
 
   src_facility->EnterNotify();
   std::set<RequestPortfolio<Material>::Ptr> ports =
@@ -124,7 +134,7 @@ TEST_F(SinkTest, Requests) {
     EXPECT_EQ(req->commodity(), commods[i]);
   }
 
-  const std::set<CapacityConstraint<Material>>& constraints =
+  const std::set< CapacityConstraint<Material> >& constraints =
       ports.begin()->get()->constraints();
   EXPECT_EQ(constraints.size(), 0);
 }
@@ -149,14 +159,17 @@ TEST_F(SinkTest, Accept) {
   using test_helpers::get_mat;
 
   double qty = qty_ * 2;
-  std::vector<std::pair<Trade<Material>, Material::Ptr>> responses;
+  std::vector< std::pair<Trade<Material>,
+                         Material::Ptr> > responses;
 
-  Request<Material>* req1 = Request<Material>::Create(get_mat(922350000, qty_),
-                                                      src_facility, commod1_);
+  Request<Material>* req1 =
+      Request<Material>::Create(get_mat(922350000, qty_), src_facility,
+                                commod1_);
   Bid<Material>* bid1 = Bid<Material>::Create(req1, get_mat(), trader);
 
-  Request<Material>* req2 = Request<Material>::Create(get_mat(922350000, qty_),
-                                                      src_facility, commod2_);
+  Request<Material>* req2 =
+      Request<Material>::Create(get_mat(922350000, qty_), src_facility,
+                                commod2_);
   Bid<Material>* bid2 =
       Bid<Material>::Create(req2, get_mat(922350000, qty_), trader);
 
@@ -170,11 +183,11 @@ TEST_F(SinkTest, Accept) {
   EXPECT_DOUBLE_EQ(qty, src_facility->InventorySize());
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(SinkTest, InRecipe) {
-  // Create a context
+TEST_F(SinkTest, InRecipe){
+// Create a context
+  using cyclus::RequestPortfolio;
   using cyclus::Material;
   using cyclus::Request;
-  using cyclus::RequestPortfolio;
   cyclus::Recorder rec;
   cyclus::Timer ti;
   cyclus::Context ctx(&ti, &rec);
@@ -185,48 +198,54 @@ TEST_F(SinkTest, InRecipe) {
   m[922580000] = 2;
 
   cyclus::Composition::Ptr c = cyclus::Composition::CreateFromMass(m);
-  ctx.AddRecipe("some_u", c);
+  ctx.AddRecipe("some_u",c) ;
 
   // create a sink facility to interact with the DRE
   cycamore::Sink* snk = new cycamore::Sink(&ctx);
   snk->AddCommodity("some_u");
   snk->EnterNotify();
 
-  std::set<RequestPortfolio<Material>::Ptr> ports = snk->GetMatlRequests();
+  std::set<RequestPortfolio<Material>::Ptr> ports =
+    snk->GetMatlRequests();
   ASSERT_EQ(ports.size(), 1);
 
   const std::vector<Request<Material>*>& requests =
-      ports.begin()->get()->requests();
+    ports.begin()->get()->requests();
   ASSERT_EQ(requests.size(), 1);
 
   Request<Material>* req = *requests.begin();
   EXPECT_EQ(req->requester(), snk);
-  EXPECT_EQ(req->commodity(), "some_u");
+  EXPECT_EQ(req->commodity(),"some_u");
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(SinkTest, BidPrefs) {
-  using cyclus::Cond;
   using cyclus::QueryResult;
+  using cyclus::Cond;
 
   std::string config =
-      "   <in_commods>"
-      "     <val>commods_1</val>"
-      "     <val>commods_2</val>"
-      "   </in_commods>"
-      "   <in_commod_prefs>"
-      "     <val>10</val> "
-      "     <val>1</val> "
-      "   </in_commod_prefs>"
-      "   <capacity>1</capacity>"
-      "   <input_capacity>1.0</input_capacity> ";
+    "   <in_commods>"
+    "     <val>commods_1</val>"
+    "     <val>commods_2</val>"
+    "   </in_commods>"
+    "   <in_commod_prefs>"
+    "     <val>10</val> "
+    "     <val>1</val> "
+    "   </in_commod_prefs>"
+    "   <capacity>1</capacity>"
+    "   <input_capacity>1.0</input_capacity> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Sink"), config, simdur);
 
-  sim.AddSource("commods_1").capacity(1).Finalize();
+  sim.AddSource("commods_1")
+    .capacity(1)
+    .Finalize();
 
-  sim.AddSource("commods_2").capacity(1).Finalize();
+  sim.AddSource("commods_2")
+    .capacity(1)
+    .Finalize();
 
   int id = sim.Run();
 
@@ -243,6 +262,7 @@ TEST_F(SinkTest, BidPrefs) {
 
   // should trade only with #1 since it has highier priority
   EXPECT_EQ(0, qr2.rows.size());
+
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(SinkTest, Print) {
@@ -253,23 +273,28 @@ TEST_F(SinkTest, PositionInitialize) {
   using cyclus::QueryResult;
 
   std::string config =
-      "   <in_commods>"
-      "     <val>commods_1</val>"
-      "     <val>commods_2</val>"
-      "   </in_commods>"
-      "   <in_commod_prefs>"
-      "     <val>10</val> "
-      "     <val>1</val> "
-      "   </in_commod_prefs>"
-      "   <capacity>1</capacity>"
-      "   <input_capacity>1.0</input_capacity> ";
+    "   <in_commods>"
+    "     <val>commods_1</val>"
+    "     <val>commods_2</val>"
+    "   </in_commods>"
+    "   <in_commod_prefs>"
+    "     <val>10</val> "
+    "     <val>1</val> "
+    "   </in_commod_prefs>"
+    "   <capacity>1</capacity>"
+    "   <input_capacity>1.0</input_capacity> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Sink"), config, simdur);
 
-  sim.AddSource("commods_1").capacity(1).Finalize();
+  sim.AddSource("commods_1")
+    .capacity(1)
+    .Finalize();
 
-  sim.AddSource("commods_2").capacity(1).Finalize();
+  sim.AddSource("commods_2")
+    .capacity(1)
+    .Finalize();
 
   int id = sim.Run();
 
@@ -282,31 +307,37 @@ TEST_F(SinkTest, PositionInitialize2) {
   using cyclus::QueryResult;
 
   std::string config =
-      "   <in_commods>"
-      "     <val>commods_1</val>"
-      "     <val>commods_2</val>"
-      "   </in_commods>"
-      "   <in_commod_prefs>"
-      "     <val>10</val> "
-      "     <val>1</val> "
-      "   </in_commod_prefs>"
-      "   <capacity>1</capacity>"
-      "   <input_capacity>1.0</input_capacity> "
-      "   <latitude>50.0</latitude> "
-      "   <longitude>35.0</longitude> ";
+    "   <in_commods>"
+    "     <val>commods_1</val>"
+    "     <val>commods_2</val>"
+    "   </in_commods>"
+    "   <in_commod_prefs>"
+    "     <val>10</val> "
+    "     <val>1</val> "
+    "   </in_commod_prefs>"
+    "   <capacity>1</capacity>"
+    "   <input_capacity>1.0</input_capacity> "
+    "   <latitude>50.0</latitude> "
+    "   <longitude>35.0</longitude> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Sink"), config, simdur);
 
-  sim.AddSource("commods_1").capacity(1).Finalize();
+  sim.AddSource("commods_1")
+    .capacity(1)
+    .Finalize();
 
-  sim.AddSource("commods_2").capacity(1).Finalize();
+  sim.AddSource("commods_2")
+    .capacity(1)
+    .Finalize();
 
   int id = sim.Run();
 
   QueryResult qr = sim.db().Query("AgentPosition", NULL);
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 35.0);
   EXPECT_EQ(qr.GetVal<double>("Latitude"), 50.0);
+
 }
 
 // A random number pulled from a uniform integer distribution can be
@@ -315,14 +346,15 @@ TEST_F(SinkTest, RandomUniformSize) {
   using cyclus::QueryResult;
 
   std::string config =
-      "   <in_commods>"
-      "     <val>commods_1</val>"
-      "   </in_commods>"
-      "   <capacity>10</capacity>"
-      "   <random_size_type>UniformReal</random_size_type> ";
+    "   <in_commods>"
+    "     <val>commods_1</val>"
+    "   </in_commods>"
+    "   <capacity>10</capacity>"
+    "   <random_size_type>UniformReal</random_size_type> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -338,14 +370,15 @@ TEST_F(SinkTest, RandomNormalSize) {
   using cyclus::QueryResult;
 
   std::string config =
-      "   <in_commods>"
-      "     <val>commods_1</val>"
-      "   </in_commods>"
-      "   <capacity>10</capacity>"
-      "   <random_size_type>NormalReal</random_size_type> ";
+    "   <in_commods>"
+    "     <val>commods_1</val>"
+    "   </in_commods>"
+    "   <capacity>10</capacity>"
+    "   <random_size_type>NormalReal</random_size_type> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -361,16 +394,17 @@ TEST_F(SinkTest, RandomNormalSizeWithMeanSttdev) {
   using cyclus::QueryResult;
 
   std::string config =
-      "   <in_commods>"
-      "     <val>commods_1</val>"
-      "   </in_commods>"
-      "   <capacity>10</capacity>"
-      "   <random_size_type>NormalReal</random_size_type> "
-      "   <random_size_mean>0.5</random_size_mean> "
-      "   <random_size_stddev>0.2</random_size_stddev> ";
+    "   <in_commods>"
+    "     <val>commods_1</val>"
+    "   </in_commods>"
+    "   <capacity>10</capacity>"
+    "   <random_size_type>NormalReal</random_size_type> "
+    "   <random_size_mean>0.5</random_size_mean> "
+    "   <random_size_stddev>0.2</random_size_stddev> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -386,16 +420,17 @@ TEST_F(SinkTest, RandomUniformFreq) {
   using cyclus::QueryResult;
 
   std::string config =
-      "   <in_commods>"
-      "     <val>commods_1</val>"
-      "   </in_commods>"
-      "   <capacity>10</capacity>"
-      "   <random_frequency_type>UniformInt</random_frequency_type> "
-      "   <random_frequency_min>2</random_frequency_min> "
-      "   <random_frequency_max>4</random_frequency_max> ";
+    "   <in_commods>"
+    "     <val>commods_1</val>"
+    "   </in_commods>"
+    "   <capacity>10</capacity>"
+    "   <random_frequency_type>UniformInt</random_frequency_type> "
+    "   <random_frequency_min>2</random_frequency_min> "
+    "   <random_frequency_max>4</random_frequency_max> ";
 
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -414,14 +449,15 @@ TEST_F(SinkTest, RandomNormalFreq) {
   using cyclus::QueryResult;
 
   std::string config =
-      "   <in_commods>"
-      "     <val>commods_1</val>"
-      "   </in_commods>"
-      "   <capacity>10</capacity>"
-      "   <random_frequency_type>NormalInt</random_frequency_type> ";
+    "   <in_commods>"
+    "     <val>commods_1</val>"
+    "   </in_commods>"
+    "   <capacity>10</capacity>"
+    "   <random_frequency_type>NormalInt</random_frequency_type> ";
 
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -440,16 +476,17 @@ TEST_F(SinkTest, RandomNormalFreqWithMeanSttdev) {
   using cyclus::QueryResult;
 
   std::string config =
-      "   <in_commods>"
-      "     <val>commods_1</val>"
-      "   </in_commods>"
-      "   <capacity>10</capacity>"
-      "   <random_frequency_type>NormalInt</random_frequency_type> "
-      "   <random_frequency_mean>2</random_frequency_mean> "
-      "   <random_frequency_stddev>0.2</random_frequency_stddev> ";
+    "   <in_commods>"
+    "     <val>commods_1</val>"
+    "   </in_commods>"
+    "   <capacity>10</capacity>"
+    "   <random_frequency_type>NormalInt</random_frequency_type> "
+    "   <random_frequency_mean>2</random_frequency_mean> "
+    "   <random_frequency_stddev>0.2</random_frequency_stddev> ";
 
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -467,16 +504,17 @@ TEST_F(SinkTest, RandomNormalFreqMultipleCycles) {
   using cyclus::QueryResult;
 
   std::string config =
-      "   <in_commods>"
-      "     <val>commods_1</val>"
-      "   </in_commods>"
-      "   <capacity>10</capacity>"
-      "   <random_frequency_type>NormalInt</random_frequency_type> "
-      "   <random_frequency_mean>4</random_frequency_mean> "
-      "   <random_frequency_stddev>1</random_frequency_stddev> ";
+    "   <in_commods>"
+    "     <val>commods_1</val>"
+    "   </in_commods>"
+    "   <capacity>10</capacity>"
+    "   <random_frequency_type>NormalInt</random_frequency_type> "
+    "   <random_frequency_mean>4</random_frequency_mean> "
+    "   <random_frequency_stddev>1</random_frequency_stddev> ";
 
   int simdur = 12;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -492,7 +530,7 @@ TEST_F(SinkTest, RandomNormalFreqMultipleCycles) {
   int second_trans_time = qr.GetVal<int>("Time", 1);
   EXPECT_EQ(7, second_trans_time);
   int third_trans_time = qr.GetVal<int>("Time", 2);
-  EXPECT_EQ(11, third_trans_time);
+  EXPECT_EQ(11, third_trans_time);  
 }
 
 // Check that randomness can be implemented in both size of request and
@@ -501,19 +539,20 @@ TEST_F(SinkTest, RandomNormalSizeUniformFreq) {
   using cyclus::QueryResult;
 
   std::string config =
-      "   <in_commods>"
-      "     <val>commods_1</val>"
-      "   </in_commods>"
-      "   <capacity>10</capacity>"
-      "   <random_size_type>NormalReal</random_size_type>"
-      "   <random_size_mean>0.8</random_size_mean>"
-      "   <random_size_stddev>0.2</random_size_stddev>"
-      "   <random_frequency_type>UniformInt</random_frequency_type> "
-      "   <random_frequency_min>2</random_frequency_min> "
-      "   <random_frequency_max>4</random_frequency_max> ";
+    "   <in_commods>"
+    "     <val>commods_1</val>"
+    "   </in_commods>"
+    "   <capacity>10</capacity>"
+    "   <random_size_type>NormalReal</random_size_type>"
+    "   <random_size_mean>0.8</random_size_mean>"
+    "   <random_size_stddev>0.2</random_size_stddev>"
+    "   <random_frequency_type>UniformInt</random_frequency_type> "
+    "   <random_frequency_min>2</random_frequency_min> "
+    "   <random_frequency_max>4</random_frequency_max> ";
 
   int simdur = 6;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(20).Finalize();
   int id = sim.Run();
 

--- a/src/sink_tests.cc
+++ b/src/sink_tests.cc
@@ -48,27 +48,26 @@ TEST_F(SinkTest, InitialState) {
   EXPECT_DOUBLE_EQ(capacity_, src_facility->SpaceAvailable());
   EXPECT_DOUBLE_EQ(0.0, src_facility->InventorySize());
   std::string arr[] = {commod1_, commod2_};
-  std::vector<std::string> vexp (arr, arr + sizeof(arr) / sizeof(arr[0]) );
+  std::vector<std::string> vexp(arr, arr + sizeof(arr) / sizeof(arr[0]));
   EXPECT_EQ(vexp, src_facility->input_commodities());
 
   src_facility->EnterNotify();
   double pref[] = {cyclus::kDefaultPref, cyclus::kDefaultPref};
-  std::vector<double> vpref (pref, pref + sizeof(pref) / sizeof(pref[0]) );
+  std::vector<double> vpref(pref, pref + sizeof(pref) / sizeof(pref[0]));
   EXPECT_EQ(vpref, src_facility->input_commodity_preferences());
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(SinkTest, Clone) {
   using cycamore::Sink;
-  Sink* cloned_fac = dynamic_cast<cycamore::Sink*>
-                             (src_facility->Clone());
+  Sink* cloned_fac = dynamic_cast<cycamore::Sink*>(src_facility->Clone());
 
   EXPECT_DOUBLE_EQ(0.0, cloned_fac->InventorySize());
   EXPECT_DOUBLE_EQ(capacity_, cloned_fac->Capacity());
   EXPECT_DOUBLE_EQ(inv_, cloned_fac->MaxInventorySize());
   EXPECT_DOUBLE_EQ(capacity_, cloned_fac->SpaceAvailable());
   std::string arr[] = {commod1_, commod2_};
-  std::vector<std::string> vexp (arr, arr + sizeof(arr) / sizeof(arr[0]) );
+  std::vector<std::string> vexp(arr, arr + sizeof(arr) / sizeof(arr[0]));
   EXPECT_EQ(vexp, cloned_fac->input_commodities());
 
   delete cloned_fac;
@@ -77,21 +76,12 @@ TEST_F(SinkTest, Clone) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(SinkTest, DISABLED_XMLInit) {
   std::stringstream ss;
-  ss << "<start>"
-     << "<name>fooname</name>"
-     << "<config>"
-     << "<UNSPECIFIED>"
-     << "<input>"
-     << "  <commodities>"
-     << "  <incommodity>" << commod1_ << "</incommodity>"
-     << "  <incommodity>" << commod2_ << "</incommodity>"
-     << "  </commodities>"
-     << "  <input_capacity>" << capacity_ << "</input_capacity>"
-     << "  <inventorysize>" << inv_ << "</inventorysize>"
-     << "</input>"
-     << "</UNSPECIFIED>"
-     << "</config>"
-     << "</start>";
+  ss << "<start>" << "<name>fooname</name>" << "<config>" << "<UNSPECIFIED>"
+     << "<input>" << "  <commodities>" << "  <incommodity>" << commod1_
+     << "</incommodity>" << "  <incommodity>" << commod2_ << "</incommodity>"
+     << "  </commodities>" << "  <input_capacity>" << capacity_
+     << "</input_capacity>" << "  <inventorysize>" << inv_ << "</inventorysize>"
+     << "</input>" << "</UNSPECIFIED>" << "</config>" << "</start>";
 
   cyclus::XMLParser p;
   p.Init(ss);
@@ -100,7 +90,7 @@ TEST_F(SinkTest, DISABLED_XMLInit) {
 
   // EXPECT_NO_THROW(fac.InitFrom(&engine););
   std::string arr[] = {commod1_, commod2_};
-  std::vector<std::string> vexp (arr, arr + sizeof(arr) / sizeof(arr[0]) );
+  std::vector<std::string> vexp(arr, arr + sizeof(arr) / sizeof(arr[0]));
   EXPECT_EQ(vexp, fac.input_commodities());
   EXPECT_DOUBLE_EQ(capacity_, fac.Capacity());
   EXPECT_DOUBLE_EQ(inv_, fac.MaxInventorySize());
@@ -110,13 +100,13 @@ TEST_F(SinkTest, DISABLED_XMLInit) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(SinkTest, Requests) {
-  using cyclus::Request;
-  using cyclus::RequestPortfolio;
   using cyclus::CapacityConstraint;
   using cyclus::Material;
+  using cyclus::Request;
+  using cyclus::RequestPortfolio;
 
   std::string arr[] = {commod1_, commod2_};
-  std::vector<std::string> commods (arr, arr + sizeof(arr) / sizeof(arr[0]) );
+  std::vector<std::string> commods(arr, arr + sizeof(arr) / sizeof(arr[0]));
 
   src_facility->EnterNotify();
   std::set<RequestPortfolio<Material>::Ptr> ports =
@@ -134,7 +124,7 @@ TEST_F(SinkTest, Requests) {
     EXPECT_EQ(req->commodity(), commods[i]);
   }
 
-  const std::set< CapacityConstraint<Material> >& constraints =
+  const std::set<CapacityConstraint<Material>>& constraints =
       ports.begin()->get()->constraints();
   EXPECT_EQ(constraints.size(), 0);
 }
@@ -159,17 +149,14 @@ TEST_F(SinkTest, Accept) {
   using test_helpers::get_mat;
 
   double qty = qty_ * 2;
-  std::vector< std::pair<Trade<Material>,
-                         Material::Ptr> > responses;
+  std::vector<std::pair<Trade<Material>, Material::Ptr>> responses;
 
-  Request<Material>* req1 =
-      Request<Material>::Create(get_mat(922350000, qty_), src_facility,
-                                commod1_);
+  Request<Material>* req1 = Request<Material>::Create(get_mat(922350000, qty_),
+                                                      src_facility, commod1_);
   Bid<Material>* bid1 = Bid<Material>::Create(req1, get_mat(), trader);
 
-  Request<Material>* req2 =
-      Request<Material>::Create(get_mat(922350000, qty_), src_facility,
-                                commod2_);
+  Request<Material>* req2 = Request<Material>::Create(get_mat(922350000, qty_),
+                                                      src_facility, commod2_);
   Bid<Material>* bid2 =
       Bid<Material>::Create(req2, get_mat(922350000, qty_), trader);
 
@@ -183,11 +170,11 @@ TEST_F(SinkTest, Accept) {
   EXPECT_DOUBLE_EQ(qty, src_facility->InventorySize());
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(SinkTest, InRecipe){
-// Create a context
-  using cyclus::RequestPortfolio;
+TEST_F(SinkTest, InRecipe) {
+  // Create a context
   using cyclus::Material;
   using cyclus::Request;
+  using cyclus::RequestPortfolio;
   cyclus::Recorder rec;
   cyclus::Timer ti;
   cyclus::Context ctx(&ti, &rec);
@@ -198,54 +185,48 @@ TEST_F(SinkTest, InRecipe){
   m[922580000] = 2;
 
   cyclus::Composition::Ptr c = cyclus::Composition::CreateFromMass(m);
-  ctx.AddRecipe("some_u",c) ;
+  ctx.AddRecipe("some_u", c);
 
   // create a sink facility to interact with the DRE
   cycamore::Sink* snk = new cycamore::Sink(&ctx);
   snk->AddCommodity("some_u");
   snk->EnterNotify();
 
-  std::set<RequestPortfolio<Material>::Ptr> ports =
-    snk->GetMatlRequests();
+  std::set<RequestPortfolio<Material>::Ptr> ports = snk->GetMatlRequests();
   ASSERT_EQ(ports.size(), 1);
 
   const std::vector<Request<Material>*>& requests =
-    ports.begin()->get()->requests();
+      ports.begin()->get()->requests();
   ASSERT_EQ(requests.size(), 1);
 
   Request<Material>* req = *requests.begin();
   EXPECT_EQ(req->requester(), snk);
-  EXPECT_EQ(req->commodity(),"some_u");
+  EXPECT_EQ(req->commodity(), "some_u");
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(SinkTest, BidPrefs) {
-  using cyclus::QueryResult;
   using cyclus::Cond;
+  using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "     <val>commods_2</val>"
-    "   </in_commods>"
-    "   <in_commod_prefs>"
-    "     <val>10</val> "
-    "     <val>1</val> "
-    "   </in_commod_prefs>"
-    "   <capacity>1</capacity>"
-    "   <input_capacity>1.0</input_capacity> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "     <val>commods_2</val>"
+      "   </in_commods>"
+      "   <in_commod_prefs>"
+      "     <val>10</val> "
+      "     <val>1</val> "
+      "   </in_commod_prefs>"
+      "   <capacity>1</capacity>"
+      "   <input_capacity>1.0</input_capacity> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
 
-  sim.AddSource("commods_1")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("commods_1").capacity(1).Finalize();
 
-  sim.AddSource("commods_2")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("commods_2").capacity(1).Finalize();
 
   int id = sim.Run();
 
@@ -262,7 +243,6 @@ TEST_F(SinkTest, BidPrefs) {
 
   // should trade only with #1 since it has highier priority
   EXPECT_EQ(0, qr2.rows.size());
-
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(SinkTest, Print) {
@@ -273,28 +253,23 @@ TEST_F(SinkTest, PositionInitialize) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "     <val>commods_2</val>"
-    "   </in_commods>"
-    "   <in_commod_prefs>"
-    "     <val>10</val> "
-    "     <val>1</val> "
-    "   </in_commod_prefs>"
-    "   <capacity>1</capacity>"
-    "   <input_capacity>1.0</input_capacity> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "     <val>commods_2</val>"
+      "   </in_commods>"
+      "   <in_commod_prefs>"
+      "     <val>10</val> "
+      "     <val>1</val> "
+      "   </in_commod_prefs>"
+      "   <capacity>1</capacity>"
+      "   <input_capacity>1.0</input_capacity> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
 
-  sim.AddSource("commods_1")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("commods_1").capacity(1).Finalize();
 
-  sim.AddSource("commods_2")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("commods_2").capacity(1).Finalize();
 
   int id = sim.Run();
 
@@ -307,37 +282,31 @@ TEST_F(SinkTest, PositionInitialize2) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "     <val>commods_2</val>"
-    "   </in_commods>"
-    "   <in_commod_prefs>"
-    "     <val>10</val> "
-    "     <val>1</val> "
-    "   </in_commod_prefs>"
-    "   <capacity>1</capacity>"
-    "   <input_capacity>1.0</input_capacity> "
-    "   <latitude>50.0</latitude> "
-    "   <longitude>35.0</longitude> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "     <val>commods_2</val>"
+      "   </in_commods>"
+      "   <in_commod_prefs>"
+      "     <val>10</val> "
+      "     <val>1</val> "
+      "   </in_commod_prefs>"
+      "   <capacity>1</capacity>"
+      "   <input_capacity>1.0</input_capacity> "
+      "   <latitude>50.0</latitude> "
+      "   <longitude>35.0</longitude> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
 
-  sim.AddSource("commods_1")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("commods_1").capacity(1).Finalize();
 
-  sim.AddSource("commods_2")
-    .capacity(1)
-    .Finalize();
+  sim.AddSource("commods_2").capacity(1).Finalize();
 
   int id = sim.Run();
 
   QueryResult qr = sim.db().Query("AgentPosition", NULL);
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 35.0);
   EXPECT_EQ(qr.GetVal<double>("Latitude"), 50.0);
-
 }
 
 // A random number pulled from a uniform integer distribution can be
@@ -346,15 +315,14 @@ TEST_F(SinkTest, RandomUniformSize) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "   </in_commods>"
-    "   <capacity>10</capacity>"
-    "   <random_size_type>UniformReal</random_size_type> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "   </in_commods>"
+      "   <capacity>10</capacity>"
+      "   <random_size_type>UniformReal</random_size_type> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -370,15 +338,14 @@ TEST_F(SinkTest, RandomNormalSize) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "   </in_commods>"
-    "   <capacity>10</capacity>"
-    "   <random_size_type>NormalReal</random_size_type> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "   </in_commods>"
+      "   <capacity>10</capacity>"
+      "   <random_size_type>NormalReal</random_size_type> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -394,17 +361,16 @@ TEST_F(SinkTest, RandomNormalSizeWithMeanSttdev) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "   </in_commods>"
-    "   <capacity>10</capacity>"
-    "   <random_size_type>NormalReal</random_size_type> "
-    "   <random_size_mean>0.5</random_size_mean> "
-    "   <random_size_stddev>0.2</random_size_stddev> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "   </in_commods>"
+      "   <capacity>10</capacity>"
+      "   <random_size_type>NormalReal</random_size_type> "
+      "   <random_size_mean>0.5</random_size_mean> "
+      "   <random_size_stddev>0.2</random_size_stddev> ";
 
   int simdur = 1;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -420,17 +386,16 @@ TEST_F(SinkTest, RandomUniformFreq) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "   </in_commods>"
-    "   <capacity>10</capacity>"
-    "   <random_frequency_type>UniformInt</random_frequency_type> "
-    "   <random_frequency_min>2</random_frequency_min> "
-    "   <random_frequency_max>4</random_frequency_max> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "   </in_commods>"
+      "   <capacity>10</capacity>"
+      "   <random_frequency_type>UniformInt</random_frequency_type> "
+      "   <random_frequency_min>2</random_frequency_min> "
+      "   <random_frequency_max>4</random_frequency_max> ";
 
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -449,15 +414,14 @@ TEST_F(SinkTest, RandomNormalFreq) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "   </in_commods>"
-    "   <capacity>10</capacity>"
-    "   <random_frequency_type>NormalInt</random_frequency_type> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "   </in_commods>"
+      "   <capacity>10</capacity>"
+      "   <random_frequency_type>NormalInt</random_frequency_type> ";
 
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -476,17 +440,16 @@ TEST_F(SinkTest, RandomNormalFreqWithMeanSttdev) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "   </in_commods>"
-    "   <capacity>10</capacity>"
-    "   <random_frequency_type>NormalInt</random_frequency_type> "
-    "   <random_frequency_mean>2</random_frequency_mean> "
-    "   <random_frequency_stddev>0.2</random_frequency_stddev> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "   </in_commods>"
+      "   <capacity>10</capacity>"
+      "   <random_frequency_type>NormalInt</random_frequency_type> "
+      "   <random_frequency_mean>2</random_frequency_mean> "
+      "   <random_frequency_stddev>0.2</random_frequency_stddev> ";
 
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -504,17 +467,16 @@ TEST_F(SinkTest, RandomNormalFreqMultipleCycles) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "   </in_commods>"
-    "   <capacity>10</capacity>"
-    "   <random_frequency_type>NormalInt</random_frequency_type> "
-    "   <random_frequency_mean>4</random_frequency_mean> "
-    "   <random_frequency_stddev>1</random_frequency_stddev> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "   </in_commods>"
+      "   <capacity>10</capacity>"
+      "   <random_frequency_type>NormalInt</random_frequency_type> "
+      "   <random_frequency_mean>4</random_frequency_mean> "
+      "   <random_frequency_stddev>1</random_frequency_stddev> ";
 
   int simdur = 12;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(10).Finalize();
   int id = sim.Run();
 
@@ -530,7 +492,7 @@ TEST_F(SinkTest, RandomNormalFreqMultipleCycles) {
   int second_trans_time = qr.GetVal<int>("Time", 1);
   EXPECT_EQ(7, second_trans_time);
   int third_trans_time = qr.GetVal<int>("Time", 2);
-  EXPECT_EQ(11, third_trans_time);  
+  EXPECT_EQ(11, third_trans_time);
 }
 
 // Check that randomness can be implemented in both size of request and
@@ -539,20 +501,19 @@ TEST_F(SinkTest, RandomNormalSizeUniformFreq) {
   using cyclus::QueryResult;
 
   std::string config =
-    "   <in_commods>"
-    "     <val>commods_1</val>"
-    "   </in_commods>"
-    "   <capacity>10</capacity>"
-    "   <random_size_type>NormalReal</random_size_type>"
-    "   <random_size_mean>0.8</random_size_mean>"
-    "   <random_size_stddev>0.2</random_size_stddev>"
-    "   <random_frequency_type>UniformInt</random_frequency_type> "
-    "   <random_frequency_min>2</random_frequency_min> "
-    "   <random_frequency_max>4</random_frequency_max> ";
+      "   <in_commods>"
+      "     <val>commods_1</val>"
+      "   </in_commods>"
+      "   <capacity>10</capacity>"
+      "   <random_size_type>NormalReal</random_size_type>"
+      "   <random_size_mean>0.8</random_size_mean>"
+      "   <random_size_stddev>0.2</random_size_stddev>"
+      "   <random_frequency_type>UniformInt</random_frequency_type> "
+      "   <random_frequency_min>2</random_frequency_min> "
+      "   <random_frequency_max>4</random_frequency_max> ";
 
   int simdur = 6;
-  cyclus::MockSim sim(cyclus::AgentSpec
-          (":cycamore:Sink"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Sink"), config, simdur);
   sim.AddSource("commods_1").capacity(20).Finalize();
   int id = sim.Run();
 

--- a/src/sink_tests.h
+++ b/src/sink_tests.h
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include "sink.h"
+
 #include "test_context.h"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/sink_tests.h
+++ b/src/sink_tests.h
@@ -4,7 +4,6 @@
 #include <gtest/gtest.h>
 
 #include "sink.h"
-
 #include "test_context.h"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/source.cc
+++ b/src/source.cc
@@ -1,8 +1,9 @@
 #include "source.h"
 
-#include <boost/lexical_cast.hpp>
-#include <limits>
 #include <sstream>
+#include <limits>
+
+#include <boost/lexical_cast.hpp>
 
 namespace cycamore {
 
@@ -19,12 +20,12 @@ Source::Source(cyclus::Context* ctx)
 Source::~Source() {}
 
 void Source::InitFrom(Source* m) {
-#pragma cyclus impl initfromcopy cycamore::Source
+  #pragma cyclus impl initfromcopy cycamore::Source
   cyclus::toolkit::CommodityProducer::Copy(m);
 }
 
 void Source::InitFrom(cyclus::QueryableBackend* b) {
-#pragma cyclus impl initfromdb cycamore::Source
+  #pragma cyclus impl initfromdb cycamore::Source
   namespace tk = cyclus::toolkit;
   tk::CommodityProducer::Add(tk::Commodity(outcommod),
                              tk::CommodInfo(throughput, throughput));
@@ -41,10 +42,11 @@ std::string Source::str() {
     ans = "no";
   }
   ss << cyclus::Facility::str() << " supplies commodity '" << outcommod
-     << "' with recipe '" << outrecipe << "' at a throughput of " << throughput
-     << " kg per time step " << " commod producer members: " << " produces "
-     << outcommod << "?: " << ans << " throughput: "
-     << cyclus::toolkit::CommodityProducer::Capacity(outcommod)
+     << "' with recipe '" << outrecipe << "' at a throughput of "
+     << throughput << " kg per time step "
+     << " commod producer members: "
+     << " produces " << outcommod << "?: " << ans
+     << " throughput: " << cyclus::toolkit::CommodityProducer::Capacity(outcommod)
      << " with package type: " << package
      << " and transport unit type: " << transport_unit
      << " cost: " << cyclus::toolkit::CommodityProducer::Cost(outcommod);
@@ -66,11 +68,11 @@ void Source::Build(cyclus::Agent* parent) {
   // create all source inventory and place into buf
   cyclus::Material::Ptr all_inv;
   Composition::Ptr blank_comp = Composition::CreateFromMass(CompMap());
-  all_inv = (outrecipe.empty() || context() == NULL)
-                ? Material::Create(this, inventory_size, blank_comp)
-                : Material::Create(this, inventory_size,
-                                   context()->GetRecipe(outrecipe));
+  all_inv = (outrecipe.empty() || context() == NULL) ? \
+          Material::Create(this, inventory_size, blank_comp) : \
+          Material::Create(this, inventory_size, context()->GetRecipe(outrecipe));
   inventory.Push(all_inv);
+
 }
 
 std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
@@ -83,7 +85,7 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
   using cyclus::TransportUnit;
 
   double max_qty = std::min(throughput, inventory.quantity());
-  cyclus::toolkit::RecordTimeSeries<double>("supply" + outcommod, this,
+  cyclus::toolkit::RecordTimeSeries<double>("supply"+outcommod, this,
                                             max_qty);
   LOG(cyclus::LEV_INFO3, "Source") << prototype() << " is bidding up to "
                                    << max_qty << " kg of " << outcommod;
@@ -108,9 +110,8 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
     std::vector<double> bids = context()->GetPackage(package)->GetFillMass(qty);
 
     // calculate transport units
-    int shippable_pkgs = context()
-                             ->GetTransportUnit(transport_unit)
-                             ->MaxShippablePackages(bids.size());
+    int shippable_pkgs = context()->GetTransportUnit(transport_unit)
+                         ->MaxShippablePackages(bids.size());
     if (shippable_pkgs < bids.size()) {
       bids.erase(bids.begin() + shippable_pkgs, bids.end());
     }
@@ -118,9 +119,9 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
     std::vector<double>::iterator bit;
     for (bit = bids.begin(); bit != bids.end(); ++bit) {
       Material::Ptr m;
-      m = outrecipe.empty() ? Material::CreateUntracked(*bit, target->comp())
-                            : Material::CreateUntracked(
-                                  *bit, context()->GetRecipe(outrecipe));
+      m = outrecipe.empty() ? \
+          Material::CreateUntracked(*bit, target->comp()) : \
+          Material::CreateUntracked(*bit, context()->GetRecipe(outrecipe));
       port->AddBid(req, m, this);
     }
   }
@@ -132,25 +133,23 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
 }
 
 void Source::GetMatlTrades(
-    const std::vector<cyclus::Trade<cyclus::Material>>& trades,
+    const std::vector<cyclus::Trade<cyclus::Material> >& trades,
     std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                          cyclus::Material::Ptr>>& responses) {
+                          cyclus::Material::Ptr> >& responses) {
   using cyclus::Material;
   using cyclus::Trade;
 
-  int shippable_trades = context()
-                             ->GetTransportUnit(transport_unit)
-                             ->MaxShippablePackages(trades.size());
+  int shippable_trades = context()->GetTransportUnit(transport_unit)
+                         ->MaxShippablePackages(trades.size());
 
-  std::vector<Trade<Material>>::const_iterator it;
+  std::vector<Trade<Material> >::const_iterator it;
   for (it = trades.begin(); it != trades.end(); ++it) {
     if (shippable_trades > 0) {
       double qty = it->amt;
 
       Material::Ptr m = inventory.Pop(qty);
-
-      std::vector<Material::Ptr> m_pkgd =
-          m->Package<Material>(context()->GetPackage(package));
+      
+      std::vector<Material::Ptr> m_pkgd = m->Package<Material>(context()->GetPackage(package));
 
       if (m->quantity() > cyclus::eps()) {
         // If not all material is packaged successfully, return the excess
@@ -170,15 +169,13 @@ void Source::GetMatlTrades(
         response = Material::CreateUntracked(0, m->comp());
       }
 
-      if (outrecipe.empty() &&
-          response->comp() != it->request->target()->comp()) {
+      if (outrecipe.empty() && response->comp() != it->request->target()->comp()) {
         response->Transmute(it->request->target()->comp());
       }
 
       responses.push_back(std::make_pair(*it, response));
-      LOG(cyclus::LEV_INFO5, "Source")
-          << prototype() << " sent an order" << " for " << response->quantity()
-          << " of " << outcommod;
+      LOG(cyclus::LEV_INFO5, "Source") << prototype() << " sent an order"
+                                      << " for " << response->quantity() << " of " << outcommod;
     }
   }
 }

--- a/src/source.cc
+++ b/src/source.cc
@@ -17,12 +17,12 @@ Source::Source(cyclus::Context* ctx)
 Source::~Source() {}
 
 void Source::InitFrom(Source* m) {
-  #pragma cyclus impl initfromcopy cycamore::Source
+#pragma cyclus impl initfromcopy cycamore::Source
   cyclus::toolkit::CommodityProducer::Copy(m);
 }
 
 void Source::InitFrom(cyclus::QueryableBackend* b) {
-  #pragma cyclus impl initfromdb cycamore::Source
+#pragma cyclus impl initfromdb cycamore::Source
   namespace tk = cyclus::toolkit;
   tk::CommodityProducer::Add(tk::Commodity(outcommod),
                              tk::CommodInfo(throughput, throughput));
@@ -39,11 +39,10 @@ std::string Source::str() {
     ans = "no";
   }
   ss << cyclus::Facility::str() << " supplies commodity '" << outcommod
-     << "' with recipe '" << outrecipe << "' at a throughput of "
-     << throughput << " kg per time step "
-     << " commod producer members: "
-     << " produces " << outcommod << "?: " << ans
-     << " throughput: " << cyclus::toolkit::CommodityProducer::Capacity(outcommod)
+     << "' with recipe '" << outrecipe << "' at a throughput of " << throughput
+     << " kg per time step " << " commod producer members: " << " produces "
+     << outcommod << "?: " << ans << " throughput: "
+     << cyclus::toolkit::CommodityProducer::Capacity(outcommod)
      << " with package type: " << package
      << " and transport unit type: " << transport_unit
      << " cost: " << cyclus::toolkit::CommodityProducer::Cost(outcommod);
@@ -65,11 +64,11 @@ void Source::Build(cyclus::Agent* parent) {
   // create all source inventory and place into buf
   cyclus::Material::Ptr all_inv;
   Composition::Ptr blank_comp = Composition::CreateFromMass(CompMap());
-  all_inv = (outrecipe.empty() || context() == NULL) ? \
-          Material::Create(this, inventory_size, blank_comp) : \
-          Material::Create(this, inventory_size, context()->GetRecipe(outrecipe));
+  all_inv = (outrecipe.empty() || context() == NULL)
+                ? Material::Create(this, inventory_size, blank_comp)
+                : Material::Create(this, inventory_size,
+                                   context()->GetRecipe(outrecipe));
   inventory.Push(all_inv);
-
 }
 
 std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
@@ -82,7 +81,7 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
   using cyclus::TransportUnit;
 
   double max_qty = std::min(throughput, inventory.quantity());
-  cyclus::toolkit::RecordTimeSeries<double>("supply"+outcommod, this,
+  cyclus::toolkit::RecordTimeSeries<double>("supply" + outcommod, this,
                                             max_qty);
   LOG(cyclus::LEV_INFO3, "Source") << prototype() << " is bidding up to "
                                    << max_qty << " kg of " << outcommod;
@@ -107,8 +106,9 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
     std::vector<double> bids = context()->GetPackage(package)->GetFillMass(qty);
 
     // calculate transport units
-    int shippable_pkgs = context()->GetTransportUnit(transport_unit)
-                         ->MaxShippablePackages(bids.size());
+    int shippable_pkgs = context()
+                             ->GetTransportUnit(transport_unit)
+                             ->MaxShippablePackages(bids.size());
     if (shippable_pkgs < bids.size()) {
       bids.erase(bids.begin() + shippable_pkgs, bids.end());
     }
@@ -116,9 +116,9 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
     std::vector<double>::iterator bit;
     for (bit = bids.begin(); bit != bids.end(); ++bit) {
       Material::Ptr m;
-      m = outrecipe.empty() ? \
-          Material::CreateUntracked(*bit, target->comp()) : \
-          Material::CreateUntracked(*bit, context()->GetRecipe(outrecipe));
+      m = outrecipe.empty() ? Material::CreateUntracked(*bit, target->comp())
+                            : Material::CreateUntracked(
+                                  *bit, context()->GetRecipe(outrecipe));
       port->AddBid(req, m, this);
     }
   }
@@ -130,23 +130,25 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
 }
 
 void Source::GetMatlTrades(
-    const std::vector<cyclus::Trade<cyclus::Material> >& trades,
+    const std::vector<cyclus::Trade<cyclus::Material>>& trades,
     std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                          cyclus::Material::Ptr> >& responses) {
+                          cyclus::Material::Ptr>>& responses) {
   using cyclus::Material;
   using cyclus::Trade;
 
-  int shippable_trades = context()->GetTransportUnit(transport_unit)
-                         ->MaxShippablePackages(trades.size());
+  int shippable_trades = context()
+                             ->GetTransportUnit(transport_unit)
+                             ->MaxShippablePackages(trades.size());
 
-  std::vector<Trade<Material> >::const_iterator it;
+  std::vector<Trade<Material>>::const_iterator it;
   for (it = trades.begin(); it != trades.end(); ++it) {
     if (shippable_trades > 0) {
       double qty = it->amt;
 
       Material::Ptr m = inventory.Pop(qty);
-      
-      std::vector<Material::Ptr> m_pkgd = m->Package<Material>(context()->GetPackage(package));
+
+      std::vector<Material::Ptr> m_pkgd =
+          m->Package<Material>(context()->GetPackage(package));
 
       if (m->quantity() > cyclus::eps()) {
         // If not all material is packaged successfully, return the excess
@@ -166,13 +168,15 @@ void Source::GetMatlTrades(
         response = Material::CreateUntracked(0, m->comp());
       }
 
-      if (outrecipe.empty() && response->comp() != it->request->target()->comp()) {
+      if (outrecipe.empty() &&
+          response->comp() != it->request->target()->comp()) {
         response->Transmute(it->request->target()->comp());
       }
 
       responses.push_back(std::make_pair(*it, response));
-      LOG(cyclus::LEV_INFO5, "Source") << prototype() << " sent an order"
-                                      << " for " << response->quantity() << " of " << outcommod;
+      LOG(cyclus::LEV_INFO5, "Source")
+          << prototype() << " sent an order" << " for " << response->quantity()
+          << " of " << outcommod;
     }
   }
 }

--- a/src/source.h
+++ b/src/source.h
@@ -7,7 +7,10 @@
 #include "cyclus.h"
 #include "cycamore_version.h"
 
-#pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
+// clang-format off
+#pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, \
+    CY_NEAR_ZERO
+// clang-format on
 
 namespace cycamore {
 
@@ -23,28 +26,28 @@ class Context;
 /// inventory, and when the inventory size reaches zero, the source can provide
 /// no more material.
 class Source : public cyclus::Facility,
-  public cyclus::toolkit::CommodityProducer,
-  public cyclus::toolkit::Position {
+               public cyclus::toolkit::CommodityProducer,
+               public cyclus::toolkit::Position {
   friend class SourceTest;
+
  public:
-
   Source(cyclus::Context* ctx);
-
   virtual ~Source();
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
+  // clang-format off
   #pragma cyclus note { \
-    "doc": "This facility acts as a source of material with a fixed throughput (per\n" \
-           "time step) capacity and a lifetime capacity defined by a total inventory\n" \
-           "size.  It offers its material as a single commodity. If a composition\n" \
-           "recipe is specified, it provides that single material composition to\n" \
-           "requesters.  If unspecified, the source provides materials with the exact\n" \
-           "requested compositions.  The inventory size and throughput both default to\n" \
-           "infinite.  Supplies material results in corresponding decrease in\n" \
-           "inventory, and when the inventory size reaches zero, the source can provide\n" \
-           "no more material.\n" \
-           "", \
+    "doc": \
+      "This facility acts as a source of material with a fixed throughput " \
+      "(per time step) capacity and a lifetime capacity defined by a total " \
+      "inventory size.  It offers its material as a single commodity. If a " \
+      "composition recipe is specified, it provides that single material " \
+      "composition to requesters.  If unspecified, the source provides " \
+      "materials with the exact requested compositions.  The inventory size " \
+      "and throughput both default to infinite.  Supplies material results " \
+      "in corresponding decrease in inventory, and when the inventory size " \
+      "reaches zero, the source can provide no more material.", \
   }
 
   #pragma cyclus def clone
@@ -54,13 +57,12 @@ class Source : public cyclus::Facility,
   #pragma cyclus def snapshot
   #pragma cyclus def snapshotinv
   #pragma cyclus def initinv
+  // clang-format on
 
   virtual void InitFrom(Source* m);
-
   virtual void InitFrom(cyclus::QueryableBackend* b);
 
   virtual void Tick() {};
-
   virtual void Tock() {};
 
   virtual std::string str();
@@ -76,61 +78,60 @@ class Source : public cyclus::Facility,
   virtual void Build(cyclus::Agent* parent);
 
   virtual void GetMatlTrades(
-    const std::vector< cyclus::Trade<cyclus::Material> >& trades,
+    const std::vector<cyclus::Trade<cyclus::Material>>& trades,
     std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-    cyclus::Material::Ptr> >& responses);
-
+                          cyclus::Material::Ptr>>& responses);
  private:
+  // clang-format off
   #pragma cyclus var { \
     "tooltip": "source output commodity", \
     "doc": "Output commodity on which the source offers material.", \
     "uilabel": "Output Commodity", \
-    "uitype": "outcommodity", \
+    "uitype": "outcommodity" \
   }
   std::string outcommod;
 
   #pragma cyclus var { \
     "tooltip": "name of material recipe to provide", \
     "doc": "Name of composition recipe that this source provides regardless " \
-           "of requested composition. If empty, source creates and provides " \
-           "whatever compositions are requested.", \
+           "of requested composition. If empty, source provides whatever " \
+           "compositions are requested.", \
     "uilabel": "Output Recipe", \
     "default": "", \
-    "uitype": "outrecipe", \
+    "uitype": "outrecipe" \
   }
   std::string outrecipe;
 
   #pragma cyclus var { \
-    "doc": "Total amount of material this source has remaining." \
-           " Every trade decreases this value by the supplied material " \
-           "quantity.  When it reaches zero, the source cannot provide any " \
-           " more material.", \
+    "doc": "Total amount of material this source has remaining. Every trade " \
+           "decreases this value by the supplied material quantity. When it " \
+           "reaches zero, the source cannot provide any more material.", \
     "default": CY_LARGE_DOUBLE, \
     "uitype": "range", \
     "range": [0.0, CY_LARGE_DOUBLE], \
     "uilabel": "Initial Inventory", \
-    "units": "kg", \
+    "units": "kg" \
   }
   double inventory_size;
 
-  #pragma cyclus var {  \
+  #pragma cyclus var { \
     "default": CY_LARGE_DOUBLE, \
     "tooltip": "per time step throughput", \
     "units": "kg/(time step)", \
     "uilabel": "Maximum Throughput", \
     "uitype": "range", \
     "range": [0.0, CY_LARGE_DOUBLE], \
-    "doc": "amount of commodity that can be supplied at each time step", \
+    "doc": "Amount of commodity that can be supplied at each time step." \
   }
   double throughput;
 
   #pragma cyclus var { \
     "default": "unpackaged", \
     "tooltip": "name of package to provide material in", \
-    "doc": "Name of package that this source provides. Offers will only be" \
-           "made in packagable quantities of material.", \
+    "doc": "Name of package that this source provides. Offers will only be " \
+           "made in packagable quantities.", \
     "uilabel": "Output Package Type", \
-    "uitype": "package", \
+    "uitype": "package" \
   }
   std::string package;
 
@@ -138,11 +139,10 @@ class Source : public cyclus::Facility,
     "default": "unrestricted", \
     "tooltip": "name of transport unit to ship packages in", \
     "doc": "Name of transport unit that this source uses to ship packages of " \
-           "material. Offers will only be made in shippable quantities of " \
-           "packages. Optional if packaging is used, but use of transport " \
-           "units requires packaging type to also be set", \
+           "material. Offers will only be made in shippable quantities. " \
+           "Optional if packaging is used.", \
     "uilabel": "Output Transport Unit Type", \
-    "uitype": "transportunit", \
+    "uitype": "transportunit" \
   }
   std::string transport_unit;
 
@@ -163,8 +163,10 @@ class Source : public cyclus::Facility,
   double longitude;
 
   #pragma cyclus var { \
-    "tooltip":"Material buffer"}
+    "tooltip": "Material buffer" \
+  }
   cyclus::toolkit::ResBuf<cyclus::Material> inventory;
+  // clang-format on
 
   cyclus::toolkit::Position coordinates;
 

--- a/src/source.h
+++ b/src/source.h
@@ -4,8 +4,8 @@
 #include <set>
 #include <vector>
 
-#include "cycamore_version.h"
 #include "cyclus.h"
+#include "cycamore_version.h"
 
 // clang-format off
 #pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, \
@@ -67,8 +67,9 @@ class Source : public cyclus::Facility,
 
   virtual std::string str();
 
-  virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> GetMatlBids(
-      cyclus::CommodMap<cyclus::Material>::type& commod_requests);
+  virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
+      GetMatlBids(cyclus::CommodMap<cyclus::Material>::type&
+                  commod_requests);
 
   virtual void EnterNotify();
 
@@ -77,10 +78,9 @@ class Source : public cyclus::Facility,
   virtual void Build(cyclus::Agent* parent);
 
   virtual void GetMatlTrades(
-      const std::vector<cyclus::Trade<cyclus::Material>>& trades,
-      std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                            cyclus::Material::Ptr>>& responses);
-
+    const std::vector<cyclus::Trade<cyclus::Material>>& trades,
+    std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                          cyclus::Material::Ptr>>& responses);
  private:
   // clang-format off
   #pragma cyclus var { \

--- a/src/source.h
+++ b/src/source.h
@@ -4,8 +4,8 @@
 #include <set>
 #include <vector>
 
-#include "cyclus.h"
 #include "cycamore_version.h"
+#include "cyclus.h"
 
 // clang-format off
 #pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, \
@@ -67,9 +67,8 @@ class Source : public cyclus::Facility,
 
   virtual std::string str();
 
-  virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
-      GetMatlBids(cyclus::CommodMap<cyclus::Material>::type&
-                  commod_requests);
+  virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> GetMatlBids(
+      cyclus::CommodMap<cyclus::Material>::type& commod_requests);
 
   virtual void EnterNotify();
 
@@ -78,9 +77,10 @@ class Source : public cyclus::Facility,
   virtual void Build(cyclus::Agent* parent);
 
   virtual void GetMatlTrades(
-    const std::vector<cyclus::Trade<cyclus::Material>>& trades,
-    std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                          cyclus::Material::Ptr>>& responses);
+      const std::vector<cyclus::Trade<cyclus::Material>>& trades,
+      std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                            cyclus::Material::Ptr>>& responses);
+
  private:
   // clang-format off
   #pragma cyclus var { \

--- a/src/source.h
+++ b/src/source.h
@@ -67,9 +67,8 @@ class Source : public cyclus::Facility,
 
   virtual std::string str();
 
-  virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
-      GetMatlBids(cyclus::CommodMap<cyclus::Material>::type&
-                  commod_requests);
+  virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> GetMatlBids(
+      cyclus::CommodMap<cyclus::Material>::type& commod_requests);
 
   virtual void EnterNotify();
 
@@ -78,9 +77,10 @@ class Source : public cyclus::Facility,
   virtual void Build(cyclus::Agent* parent);
 
   virtual void GetMatlTrades(
-    const std::vector<cyclus::Trade<cyclus::Material>>& trades,
-    std::vector<std::pair<cyclus::Trade<cyclus::Material>,
-                          cyclus::Material::Ptr>>& responses);
+      const std::vector<cyclus::Trade<cyclus::Material>>& trades,
+      std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+                            cyclus::Material::Ptr>>& responses);
+
  private:
   // clang-format off
  // Code Injection:

--- a/src/source_tests.cc
+++ b/src/source_tests.cc
@@ -41,12 +41,12 @@ void SourceTest::SetUpSource() {
 
 TEST_F(SourceTest, Clone) {
   cyclus::Context* ctx = tc.get();
-  cycamore::Source* cloned_fac = dynamic_cast<cycamore::Source*>
-                                         (src_facility->Clone());
+  cycamore::Source* cloned_fac =
+      dynamic_cast<cycamore::Source*>(src_facility->Clone());
 
-  EXPECT_EQ(outcommod(src_facility),  outcommod(cloned_fac));
+  EXPECT_EQ(outcommod(src_facility), outcommod(cloned_fac));
   EXPECT_EQ(throughput(src_facility), throughput(cloned_fac));
-  EXPECT_EQ(outrecipe(src_facility),  outrecipe(cloned_fac));
+  EXPECT_EQ(outrecipe(src_facility), outrecipe(cloned_fac));
 
   delete cloned_fac;
 }
@@ -64,8 +64,7 @@ TEST_F(SourceTest, AddBids) {
 
   int nreqs = 5;
 
-  boost::shared_ptr< ExchangeContext<Material> >
-      ec = GetContext(nreqs, commod);
+  boost::shared_ptr<ExchangeContext<Material>> ec = GetContext(nreqs, commod);
 
   src_facility->EnterNotify();
 
@@ -79,7 +78,7 @@ TEST_F(SourceTest, AddBids) {
   EXPECT_EQ(port->bidder(), src_facility);
   EXPECT_EQ(port->bids().size(), nreqs);
 
-  const std::set< CapacityConstraint<Material> >& constrs = port->constraints();
+  const std::set<CapacityConstraint<Material>>& constrs = port->constraints();
   ASSERT_TRUE(constrs.size() > 0);
   EXPECT_EQ(constrs.size(), 1);
   EXPECT_EQ(*constrs.begin(), CapacityConstraint<Material>(capacity));
@@ -92,9 +91,8 @@ TEST_F(SourceTest, Response) {
   using cyclus::Trade;
   using test_helpers::get_mat;
 
-  std::vector< Trade<Material> > trades;
-  std::vector<std::pair<Trade<Material>,
-                        Material::Ptr> > responses;
+  std::vector<Trade<Material>> trades;
+  std::vector<std::pair<Trade<Material>, Material::Ptr>> responses;
 
   // Null response
   EXPECT_NO_THROW(src_facility->GetMatlTrades(trades, responses));
@@ -103,8 +101,7 @@ TEST_F(SourceTest, Response) {
   double qty = capacity / 3;
   Request<Material>* request =
       Request<Material>::Create(get_mat(), trader, commod);
-  Bid<Material>* bid =
-      Bid<Material>::Create(request, get_mat(), src_facility);
+  Bid<Material>* bid = Bid<Material>::Create(request, get_mat(), src_facility);
 
   Trade<Material> trade(request, bid, qty);
   trades.push_back(trade);
@@ -129,93 +126,88 @@ TEST_F(SourceTest, Response) {
 }
 
 TEST_F(SourceTest, PositionInitialize) {
-  std::string config =
-    "<outcommod>spent_fuel</outcommod>"
-  ;
+  std::string config = "<outcommod>spent_fuel</outcommod>";
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Source"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Source"), config, simdur);
   int id = sim.Run();
 
   cyclus::QueryResult qr = sim.db().Query("AgentPosition", NULL);
   EXPECT_EQ(qr.GetVal<double>("Latitude"), 0.0);
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 0.0);
-
 }
 
 TEST_F(SourceTest, Longitude) {
   std::string config =
-    "<outcommod>spent_fuel</outcommod>"
-    "<latitude>-0.01</latitude>"
-    "<longitude>0.01</longitude>"
-  ;
+      "<outcommod>spent_fuel</outcommod>"
+      "<latitude>-0.01</latitude>"
+      "<longitude>0.01</longitude>";
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Source"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Source"), config, simdur);
   int id = sim.Run();
 
   cyclus::QueryResult qr = sim.db().Query("AgentPosition", NULL);
   EXPECT_EQ(qr.GetVal<double>("Latitude"), -0.01);
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 0.01);
-
 }
 
 TEST_F(SourceTest, Package) {
-  using cyclus::QueryResult;
   using cyclus::Cond;
+  using cyclus::QueryResult;
 
   std::string config =
-    "<outcommod>commod</outcommod>"
-    "<outrecipe>recipe</outrecipe>"
-    "<package>testpackage</package>"
-    "<throughput>5</throughput>";
+      "<outcommod>commod</outcommod>"
+      "<outrecipe>recipe</outrecipe>"
+      "<package>testpackage</package>"
+      "<throughput>5</throughput>";
 
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Source"), config, simdur);
-  
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Source"), config, simdur);
+
   sim.context()->AddRecipe(recipe_name, recipe);
   sim.context()->AddPackage(package_name, 3, 4, "first");
   package = sim.context()->GetPackage(package_name);
-  
+
   sim.AddSink("commod").Finalize();
 
   EXPECT_NO_THROW(sim.Run());
 
   QueryResult qr_tr = sim.db().Query("Transactions", NULL);
   EXPECT_EQ(qr_tr.rows.size(), 3);
-  
+
   std::vector<Cond> conds;
   conds.push_back(Cond("PackageName", "==", package->name()));
   QueryResult qr_res = sim.db().Query("Resources", &conds);
 
-  EXPECT_EQ(qr_res.rows.size(), 3); 
+  EXPECT_EQ(qr_res.rows.size(), 3);
 }
 
 TEST_F(SourceTest, TransportUnit) {
-  using cyclus::QueryResult;
   using cyclus::Cond;
+  using cyclus::QueryResult;
 
   std::string config =
-    "<outcommod>commod</outcommod>"
-    "<outrecipe>recipe</outrecipe>"
-    "<package>testpackage</package>"
-    "<transport_unit>testtu</transport_unit>"
-    "<throughput>10</throughput>";
+      "<outcommod>commod</outcommod>"
+      "<outrecipe>recipe</outrecipe>"
+      "<package>testpackage</package>"
+      "<transport_unit>testtu</transport_unit>"
+      "<throughput>10</throughput>";
 
   int simdur = 2;
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Source"), config, simdur);
-  
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Source"), config, simdur);
+
   sim.context()->AddRecipe(recipe_name, recipe);
   sim.context()->AddPackage(package_name, 3, 4, "equal");
   package = sim.context()->GetPackage(package_name);
   sim.context()->AddTransportUnit(tu_name, 2, 2);
   tu = sim.context()->GetTransportUnit(tu_name);
-  
+
   sim.AddSink("commod").Finalize();
 
   EXPECT_NO_THROW(sim.Run());
 
   QueryResult qr_tr = sim.db().Query("Transactions", NULL);
   EXPECT_EQ(qr_tr.rows.size(), 4);
-  
+
   std::vector<Cond> conds;
   conds.push_back(Cond("PackageName", "==", package->name()));
   QueryResult qr_res = sim.db().Query("Resources", &conds);
@@ -225,23 +217,23 @@ TEST_F(SourceTest, TransportUnit) {
   QueryResult qr_allres = sim.db().Query("Resources", NULL);
 }
 
-boost::shared_ptr< cyclus::ExchangeContext<cyclus::Material> >
+boost::shared_ptr<cyclus::ExchangeContext<cyclus::Material>>
 SourceTest::GetContext(int nreqs, std::string commod) {
+  using cyclus::ExchangeContext;
   using cyclus::Material;
   using cyclus::Request;
-  using cyclus::ExchangeContext;
   using test_helpers::get_mat;
 
   double qty = 3;
-  boost::shared_ptr< ExchangeContext<Material> >
-      ec(new ExchangeContext<Material>());
+  boost::shared_ptr<ExchangeContext<Material>> ec(
+      new ExchangeContext<Material>());
   for (int i = 0; i < nreqs; i++) {
     ec->AddRequest(Request<Material>::Create(get_mat(), trader, commod));
   }
   return ec;
 }
 
-} // namespace cycamore
+}  // namespace cycamore
 
 cyclus::Agent* SourceConstructor(cyclus::Context* ctx) {
   return new cycamore::Source(ctx);
@@ -256,4 +248,3 @@ static int cyclus_agent_tests_connected = ConnectAgentTests();
 
 INSTANTIATE_TEST_SUITE_P(SourceFac, FacilityTests, Values(&SourceConstructor));
 INSTANTIATE_TEST_SUITE_P(SourceFac, AgentTests, Values(&SourceConstructor));
-

--- a/src/source_tests.cc
+++ b/src/source_tests.cc
@@ -41,12 +41,12 @@ void SourceTest::SetUpSource() {
 
 TEST_F(SourceTest, Clone) {
   cyclus::Context* ctx = tc.get();
-  cycamore::Source* cloned_fac =
-      dynamic_cast<cycamore::Source*>(src_facility->Clone());
+  cycamore::Source* cloned_fac = dynamic_cast<cycamore::Source*>
+                                         (src_facility->Clone());
 
-  EXPECT_EQ(outcommod(src_facility), outcommod(cloned_fac));
+  EXPECT_EQ(outcommod(src_facility),  outcommod(cloned_fac));
   EXPECT_EQ(throughput(src_facility), throughput(cloned_fac));
-  EXPECT_EQ(outrecipe(src_facility), outrecipe(cloned_fac));
+  EXPECT_EQ(outrecipe(src_facility),  outrecipe(cloned_fac));
 
   delete cloned_fac;
 }
@@ -64,7 +64,8 @@ TEST_F(SourceTest, AddBids) {
 
   int nreqs = 5;
 
-  boost::shared_ptr<ExchangeContext<Material>> ec = GetContext(nreqs, commod);
+  boost::shared_ptr< ExchangeContext<Material> >
+      ec = GetContext(nreqs, commod);
 
   src_facility->EnterNotify();
 
@@ -78,7 +79,7 @@ TEST_F(SourceTest, AddBids) {
   EXPECT_EQ(port->bidder(), src_facility);
   EXPECT_EQ(port->bids().size(), nreqs);
 
-  const std::set<CapacityConstraint<Material>>& constrs = port->constraints();
+  const std::set< CapacityConstraint<Material> >& constrs = port->constraints();
   ASSERT_TRUE(constrs.size() > 0);
   EXPECT_EQ(constrs.size(), 1);
   EXPECT_EQ(*constrs.begin(), CapacityConstraint<Material>(capacity));
@@ -91,8 +92,9 @@ TEST_F(SourceTest, Response) {
   using cyclus::Trade;
   using test_helpers::get_mat;
 
-  std::vector<Trade<Material>> trades;
-  std::vector<std::pair<Trade<Material>, Material::Ptr>> responses;
+  std::vector< Trade<Material> > trades;
+  std::vector<std::pair<Trade<Material>,
+                        Material::Ptr> > responses;
 
   // Null response
   EXPECT_NO_THROW(src_facility->GetMatlTrades(trades, responses));
@@ -101,7 +103,8 @@ TEST_F(SourceTest, Response) {
   double qty = capacity / 3;
   Request<Material>* request =
       Request<Material>::Create(get_mat(), trader, commod);
-  Bid<Material>* bid = Bid<Material>::Create(request, get_mat(), src_facility);
+  Bid<Material>* bid =
+      Bid<Material>::Create(request, get_mat(), src_facility);
 
   Trade<Material> trade(request, bid, qty);
   trades.push_back(trade);
@@ -126,88 +129,93 @@ TEST_F(SourceTest, Response) {
 }
 
 TEST_F(SourceTest, PositionInitialize) {
-  std::string config = "<outcommod>spent_fuel</outcommod>";
+  std::string config =
+    "<outcommod>spent_fuel</outcommod>"
+  ;
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Source"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Source"), config, simdur);
   int id = sim.Run();
 
   cyclus::QueryResult qr = sim.db().Query("AgentPosition", NULL);
   EXPECT_EQ(qr.GetVal<double>("Latitude"), 0.0);
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 0.0);
+
 }
 
 TEST_F(SourceTest, Longitude) {
   std::string config =
-      "<outcommod>spent_fuel</outcommod>"
-      "<latitude>-0.01</latitude>"
-      "<longitude>0.01</longitude>";
+    "<outcommod>spent_fuel</outcommod>"
+    "<latitude>-0.01</latitude>"
+    "<longitude>0.01</longitude>"
+  ;
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Source"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Source"), config, simdur);
   int id = sim.Run();
 
   cyclus::QueryResult qr = sim.db().Query("AgentPosition", NULL);
   EXPECT_EQ(qr.GetVal<double>("Latitude"), -0.01);
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 0.01);
+
 }
 
 TEST_F(SourceTest, Package) {
-  using cyclus::Cond;
   using cyclus::QueryResult;
+  using cyclus::Cond;
 
   std::string config =
-      "<outcommod>commod</outcommod>"
-      "<outrecipe>recipe</outrecipe>"
-      "<package>testpackage</package>"
-      "<throughput>5</throughput>";
+    "<outcommod>commod</outcommod>"
+    "<outrecipe>recipe</outrecipe>"
+    "<package>testpackage</package>"
+    "<throughput>5</throughput>";
 
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Source"), config, simdur);
-
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Source"), config, simdur);
+  
   sim.context()->AddRecipe(recipe_name, recipe);
   sim.context()->AddPackage(package_name, 3, 4, "first");
   package = sim.context()->GetPackage(package_name);
-
+  
   sim.AddSink("commod").Finalize();
 
   EXPECT_NO_THROW(sim.Run());
 
   QueryResult qr_tr = sim.db().Query("Transactions", NULL);
   EXPECT_EQ(qr_tr.rows.size(), 3);
-
+  
   std::vector<Cond> conds;
   conds.push_back(Cond("PackageName", "==", package->name()));
   QueryResult qr_res = sim.db().Query("Resources", &conds);
 
-  EXPECT_EQ(qr_res.rows.size(), 3);
+  EXPECT_EQ(qr_res.rows.size(), 3); 
 }
 
 TEST_F(SourceTest, TransportUnit) {
-  using cyclus::Cond;
   using cyclus::QueryResult;
+  using cyclus::Cond;
 
   std::string config =
-      "<outcommod>commod</outcommod>"
-      "<outrecipe>recipe</outrecipe>"
-      "<package>testpackage</package>"
-      "<transport_unit>testtu</transport_unit>"
-      "<throughput>10</throughput>";
+    "<outcommod>commod</outcommod>"
+    "<outrecipe>recipe</outrecipe>"
+    "<package>testpackage</package>"
+    "<transport_unit>testtu</transport_unit>"
+    "<throughput>10</throughput>";
 
   int simdur = 2;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Source"), config, simdur);
-
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Source"), config, simdur);
+  
   sim.context()->AddRecipe(recipe_name, recipe);
   sim.context()->AddPackage(package_name, 3, 4, "equal");
   package = sim.context()->GetPackage(package_name);
   sim.context()->AddTransportUnit(tu_name, 2, 2);
   tu = sim.context()->GetTransportUnit(tu_name);
-
+  
   sim.AddSink("commod").Finalize();
 
   EXPECT_NO_THROW(sim.Run());
 
   QueryResult qr_tr = sim.db().Query("Transactions", NULL);
   EXPECT_EQ(qr_tr.rows.size(), 4);
-
+  
   std::vector<Cond> conds;
   conds.push_back(Cond("PackageName", "==", package->name()));
   QueryResult qr_res = sim.db().Query("Resources", &conds);
@@ -217,23 +225,23 @@ TEST_F(SourceTest, TransportUnit) {
   QueryResult qr_allres = sim.db().Query("Resources", NULL);
 }
 
-boost::shared_ptr<cyclus::ExchangeContext<cyclus::Material>>
+boost::shared_ptr< cyclus::ExchangeContext<cyclus::Material> >
 SourceTest::GetContext(int nreqs, std::string commod) {
-  using cyclus::ExchangeContext;
   using cyclus::Material;
   using cyclus::Request;
+  using cyclus::ExchangeContext;
   using test_helpers::get_mat;
 
   double qty = 3;
-  boost::shared_ptr<ExchangeContext<Material>> ec(
-      new ExchangeContext<Material>());
+  boost::shared_ptr< ExchangeContext<Material> >
+      ec(new ExchangeContext<Material>());
   for (int i = 0; i < nreqs; i++) {
     ec->AddRequest(Request<Material>::Create(get_mat(), trader, commod));
   }
   return ec;
 }
 
-}  // namespace cycamore
+} // namespace cycamore
 
 cyclus::Agent* SourceConstructor(cyclus::Context* ctx) {
   return new cycamore::Source(ctx);
@@ -248,3 +256,4 @@ static int cyclus_agent_tests_connected = ConnectAgentTests();
 
 INSTANTIATE_TEST_SUITE_P(SourceFac, FacilityTests, Values(&SourceConstructor));
 INSTANTIATE_TEST_SUITE_P(SourceFac, AgentTests, Values(&SourceConstructor));
+

--- a/src/source_tests.h
+++ b/src/source_tests.h
@@ -1,7 +1,5 @@
 #ifndef CYCAMORE_SRC_SOURCE_TESTS_H_
 #define CYCAMORE_SRC_SOURCE_TESTS_H_
-#include "source.h"
-
 #include <gtest/gtest.h>
 
 #include <boost/shared_ptr.hpp>
@@ -11,6 +9,7 @@
 #include "exchange_context.h"
 #include "facility_tests.h"
 #include "material.h"
+#include "source.h"
 
 namespace cycamore {
 
@@ -42,10 +41,10 @@ class SourceTest : public ::testing::Test {
   }
   void throughput(cycamore::Source* s, double val) { s->throughput = val; }
 
-  boost::shared_ptr<cyclus::ExchangeContext<cyclus::Material> > GetContext(
+  boost::shared_ptr<cyclus::ExchangeContext<cyclus::Material>> GetContext(
       int nreqs, std::string commodity);
 };
 
-} // namespace cycamore
+}  // namespace cycamore
 
 #endif  // CYCAMORE_SRC_SOURCE_TESTS_H_

--- a/src/source_tests.h
+++ b/src/source_tests.h
@@ -1,5 +1,7 @@
 #ifndef CYCAMORE_SRC_SOURCE_TESTS_H_
 #define CYCAMORE_SRC_SOURCE_TESTS_H_
+#include "source.h"
+
 #include <gtest/gtest.h>
 
 #include <boost/shared_ptr.hpp>
@@ -9,7 +11,6 @@
 #include "exchange_context.h"
 #include "facility_tests.h"
 #include "material.h"
-#include "source.h"
 
 namespace cycamore {
 
@@ -41,10 +42,10 @@ class SourceTest : public ::testing::Test {
   }
   void throughput(cycamore::Source* s, double val) { s->throughput = val; }
 
-  boost::shared_ptr<cyclus::ExchangeContext<cyclus::Material>> GetContext(
+  boost::shared_ptr<cyclus::ExchangeContext<cyclus::Material> > GetContext(
       int nreqs, std::string commodity);
 };
 
-}  // namespace cycamore
+} // namespace cycamore
 
 #endif  // CYCAMORE_SRC_SOURCE_TESTS_H_

--- a/src/source_tests.h
+++ b/src/source_tests.h
@@ -42,10 +42,10 @@ class SourceTest : public ::testing::Test {
   }
   void throughput(cycamore::Source* s, double val) { s->throughput = val; }
 
-  boost::shared_ptr<cyclus::ExchangeContext<cyclus::Material> > GetContext(
+  boost::shared_ptr<cyclus::ExchangeContext<cyclus::Material>> GetContext(
       int nreqs, std::string commodity);
 };
 
-} // namespace cycamore
+}  // namespace cycamore
 
 #endif  // CYCAMORE_SRC_SOURCE_TESTS_H_

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -10,9 +10,11 @@ Storage::Storage(cyclus::Context* ctx)
       latitude(0.0),
       longitude(0.0),
       coordinates(latitude, longitude) {
-  inventory_tracker.Init({&inventory, &stocks, &ready, &processing}, cyclus::CY_LARGE_DOUBLE);
+  inventory_tracker.Init({&inventory, &stocks, &ready, &processing},
+                         cyclus::CY_LARGE_DOUBLE);
   cyclus::Warn<cyclus::EXPERIMENTAL_WARNING>(
-      "The Storage Facility is experimental.");};
+      "The Storage Facility is experimental.");
+};
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // pragmas
@@ -41,7 +43,8 @@ void Storage::InitFrom(Storage* m) {
 void Storage::InitFrom(cyclus::QueryableBackend* b) {
 #pragma cyclus impl initfromdb cycamore::Storage
 
-  cyclus::toolkit::Commodity commod = cyclus::toolkit::Commodity(out_commods.front());
+  cyclus::toolkit::Commodity commod =
+      cyclus::toolkit::Commodity(out_commods.front());
   cyclus::toolkit::CommodityProducer::Add(commod);
   cyclus::toolkit::CommodityProducer::SetCapacity(commod, throughput);
 }
@@ -54,28 +57,26 @@ void Storage::EnterNotify() {
   if (reorder_point < 0 && cumulative_cap <= 0) {
     InitBuyPolicyParameters();
     buy_policy.Init(this, &inventory, std::string("inventory"),
-                    &inventory_tracker, throughput, active_dist_,
-                    dormant_dist_, size_dist_);
-  }
-  else if (cumulative_cap > 0) {
+                    &inventory_tracker, throughput, active_dist_, dormant_dist_,
+                    size_dist_);
+  } else if (cumulative_cap > 0) {
     InitBuyPolicyParameters();
     buy_policy.Init(this, &inventory, std::string("inventory"),
                     &inventory_tracker, throughput, cumulative_cap,
                     dormant_dist_);
-  }
-  else if (reorder_quantity > 0) {
+  } else if (reorder_quantity > 0) {
     if (reorder_point + reorder_quantity > max_inv_size) {
       throw cyclus::ValueError(
-          "reorder_point + reorder_quantity must be less than or equal to max_inv_size");
+          "reorder_point + reorder_quantity must be less than or equal to "
+          "max_inv_size");
     }
     buy_policy.Init(this, &inventory, std::string("inventory"),
-                    &inventory_tracker, throughput, "RQ",
-                    reorder_quantity, reorder_point);
-  }
-  else {
+                    &inventory_tracker, throughput, "RQ", reorder_quantity,
+                    reorder_point);
+  } else {
     buy_policy.Init(this, &inventory, std::string("inventory"),
-                    &inventory_tracker, throughput, "sS",
-                    max_inv_size, reorder_point);
+                    &inventory_tracker, throughput, "sS", max_inv_size,
+                    reorder_point);
   }
 
   // dummy comp, use in_recipe if provided
@@ -101,13 +102,14 @@ void Storage::EnterNotify() {
   }
   buy_policy.Start();
 
-  std::string package_name_ =  context()->GetPackage(package)->name();
+  std::string package_name_ = context()->GetPackage(package)->name();
   std::string tu_name_ = context()->GetTransportUnit(transport_unit)->name();
   if (out_commods.size() == 1) {
-    sell_policy.Init(this, &stocks, std::string("stocks"), cyclus::CY_LARGE_DOUBLE, false,
-                     sell_quantity, package_name_, tu_name_)
-      .Set(out_commods.front())
-      .Start();
+    sell_policy
+        .Init(this, &stocks, std::string("stocks"), cyclus::CY_LARGE_DOUBLE,
+              false, sell_quantity, package_name_, tu_name_)
+        .Set(out_commods.front())
+        .Start();
 
   } else {
     std::stringstream ss;
@@ -133,25 +135,28 @@ std::string Storage::str() {
     ans = "no";
   }
   ss << cyclus::Facility::str();
-  ss << " has facility parameters {"
-     << "\n"
+  ss << " has facility parameters {" << "\n"
      << "     Output Commodity = " << out_str << ",\n"
      << "     Residence Time = " << residence_time << ",\n"
      << "     Throughput = " << throughput << ",\n"
-     << " commod producer members: "
-     << " produces " << out_str << "?:" << ans << "'}";
+     << " commod producer members: " << " produces " << out_str << "?:" << ans
+     << "'}";
   return ss.str();
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Storage::Tick() {
-
-
   LOG(cyclus::LEV_INFO3, "ComCnv") << prototype() << " is ticking {";
 
-  LOG(cyclus::LEV_INFO5, "ComCnv") << "Processing = " << processing.quantity() << ", ready = " << ready.quantity() << ", stocks = " << stocks.quantity() << " and max inventory = " << max_inv_size;
+  LOG(cyclus::LEV_INFO5, "ComCnv")
+      << "Processing = " << processing.quantity()
+      << ", ready = " << ready.quantity() << ", stocks = " << stocks.quantity()
+      << " and max inventory = " << max_inv_size;
 
-  LOG(cyclus::LEV_INFO4, "ComCnv") << "current capacity " << max_inv_size << " - " << processing.quantity() << " - " << ready.quantity() << " - " << stocks.quantity() << " = " << current_capacity();
+  LOG(cyclus::LEV_INFO4, "ComCnv")
+      << "current capacity " << max_inv_size << " - " << processing.quantity()
+      << " - " << ready.quantity() << " - " << stocks.quantity() << " = "
+      << current_capacity();
 
   if (current_capacity() > cyclus::eps_rsrc()) {
     LOG(cyclus::LEV_INFO4, "ComCnv")
@@ -166,17 +171,22 @@ void Storage::Tock() {
 
   BeginProcessing_();  // place unprocessed inventory into processing
 
-  LOG(cyclus::LEV_INFO4, "ComCnv") << "processing currently holds " << processing.quantity() << ". ready currently holds " << ready.quantity() << ".";
+  LOG(cyclus::LEV_INFO4, "ComCnv")
+      << "processing currently holds " << processing.quantity()
+      << ". ready currently holds " << ready.quantity() << ".";
 
   if (ready_time() >= 0 || residence_time == 0 && !inventory.empty()) {
     ReadyMatl_(ready_time());  // place processing into ready
   }
 
-  LOG(cyclus::LEV_INFO5, "ComCnv") << "Ready now holds " << ready.quantity() << " kg.";
+  LOG(cyclus::LEV_INFO5, "ComCnv")
+      << "Ready now holds " << ready.quantity() << " kg.";
 
   if (ready.quantity() > throughput) {
-    LOG(cyclus::LEV_INFO5, "ComCnv") << "Up to " << throughput << " kg will be placed in stocks based on throughput limits. ";
-    }
+    LOG(cyclus::LEV_INFO5, "ComCnv")
+        << "Up to " << throughput
+        << " kg will be placed in stocks based on throughput limits. ";
+  }
 
   ProcessMat_(throughput);  // place ready into stocks
 
@@ -186,15 +196,17 @@ void Storage::Tock() {
   double demand = 0;
   demand = current_capacity();
 
-  cyclus::toolkit::RecordTimeSeries<double>("demand"+in_commods[maxindx], this, demand);
+  cyclus::toolkit::RecordTimeSeries<double>("demand" + in_commods[maxindx],
+                                            this, demand);
 
   // Multiple commodity tracking is not supported, user can only
   // provide one value for out_commods, despite it being a vector of strings.
-  cyclus::toolkit::RecordTimeSeries<double>("supply"+out_commods[0], this,
+  cyclus::toolkit::RecordTimeSeries<double>("supply" + out_commods[0], this,
                                             stocks.quantity());
 
-  LOG(cyclus::LEV_INFO4, "ComCnv") << "process has "
-                                   << processing.quantity() << ". Ready has " << ready.quantity() << ". Stocks has " << stocks.quantity() << ".";
+  LOG(cyclus::LEV_INFO4, "ComCnv")
+      << "process has " << processing.quantity() << ". Ready has "
+      << ready.quantity() << ". Stocks has " << stocks.quantity() << ".";
   LOG(cyclus::LEV_INFO3, "ComCnv") << "}";
 }
 
@@ -253,10 +265,9 @@ void Storage::ProcessMat_(double cap) {
         stocks.Push(ready.Pop(max_pop, cyclus::eps_rsrc()));
       }
 
-      LOG(cyclus::LEV_INFO4, "ComCnv") << "Storage " << prototype()
-                                       << " moved resources"
-                                       << " from ready to stocks"
-                                       << " at t= " << context()->time();
+      LOG(cyclus::LEV_INFO4, "ComCnv")
+          << "Storage " << prototype() << " moved resources"
+          << " from ready to stocks" << " at t= " << context()->time();
     } catch (cyclus::Error& e) {
       e.msg(Agent::InformErrorMsg(e.msg()));
       throw e;
@@ -289,7 +300,6 @@ void Storage::RecordPosition() {
       ->AddVal("Longitude", longitude)
       ->Record();
 }
-
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 extern "C" cyclus::Agent* ConstructStorage(cyclus::Context* ctx) {

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -10,11 +10,9 @@ Storage::Storage(cyclus::Context* ctx)
       latitude(0.0),
       longitude(0.0),
       coordinates(latitude, longitude) {
-  inventory_tracker.Init({&inventory, &stocks, &ready, &processing},
-                         cyclus::CY_LARGE_DOUBLE);
+  inventory_tracker.Init({&inventory, &stocks, &ready, &processing}, cyclus::CY_LARGE_DOUBLE);
   cyclus::Warn<cyclus::EXPERIMENTAL_WARNING>(
-      "The Storage Facility is experimental.");
-};
+      "The Storage Facility is experimental.");};
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // pragmas
@@ -43,8 +41,7 @@ void Storage::InitFrom(Storage* m) {
 void Storage::InitFrom(cyclus::QueryableBackend* b) {
 #pragma cyclus impl initfromdb cycamore::Storage
 
-  cyclus::toolkit::Commodity commod =
-      cyclus::toolkit::Commodity(out_commods.front());
+  cyclus::toolkit::Commodity commod = cyclus::toolkit::Commodity(out_commods.front());
   cyclus::toolkit::CommodityProducer::Add(commod);
   cyclus::toolkit::CommodityProducer::SetCapacity(commod, throughput);
 }
@@ -57,26 +54,28 @@ void Storage::EnterNotify() {
   if (reorder_point < 0 && cumulative_cap <= 0) {
     InitBuyPolicyParameters();
     buy_policy.Init(this, &inventory, std::string("inventory"),
-                    &inventory_tracker, throughput, active_dist_, dormant_dist_,
-                    size_dist_);
-  } else if (cumulative_cap > 0) {
+                    &inventory_tracker, throughput, active_dist_,
+                    dormant_dist_, size_dist_);
+  }
+  else if (cumulative_cap > 0) {
     InitBuyPolicyParameters();
     buy_policy.Init(this, &inventory, std::string("inventory"),
                     &inventory_tracker, throughput, cumulative_cap,
                     dormant_dist_);
-  } else if (reorder_quantity > 0) {
+  }
+  else if (reorder_quantity > 0) {
     if (reorder_point + reorder_quantity > max_inv_size) {
       throw cyclus::ValueError(
-          "reorder_point + reorder_quantity must be less than or equal to "
-          "max_inv_size");
+          "reorder_point + reorder_quantity must be less than or equal to max_inv_size");
     }
     buy_policy.Init(this, &inventory, std::string("inventory"),
-                    &inventory_tracker, throughput, "RQ", reorder_quantity,
-                    reorder_point);
-  } else {
+                    &inventory_tracker, throughput, "RQ",
+                    reorder_quantity, reorder_point);
+  }
+  else {
     buy_policy.Init(this, &inventory, std::string("inventory"),
-                    &inventory_tracker, throughput, "sS", max_inv_size,
-                    reorder_point);
+                    &inventory_tracker, throughput, "sS",
+                    max_inv_size, reorder_point);
   }
 
   // dummy comp, use in_recipe if provided
@@ -102,14 +101,13 @@ void Storage::EnterNotify() {
   }
   buy_policy.Start();
 
-  std::string package_name_ = context()->GetPackage(package)->name();
+  std::string package_name_ =  context()->GetPackage(package)->name();
   std::string tu_name_ = context()->GetTransportUnit(transport_unit)->name();
   if (out_commods.size() == 1) {
-    sell_policy
-        .Init(this, &stocks, std::string("stocks"), cyclus::CY_LARGE_DOUBLE,
-              false, sell_quantity, package_name_, tu_name_)
-        .Set(out_commods.front())
-        .Start();
+    sell_policy.Init(this, &stocks, std::string("stocks"), cyclus::CY_LARGE_DOUBLE, false,
+                     sell_quantity, package_name_, tu_name_)
+      .Set(out_commods.front())
+      .Start();
 
   } else {
     std::stringstream ss;
@@ -135,28 +133,25 @@ std::string Storage::str() {
     ans = "no";
   }
   ss << cyclus::Facility::str();
-  ss << " has facility parameters {" << "\n"
+  ss << " has facility parameters {"
+     << "\n"
      << "     Output Commodity = " << out_str << ",\n"
      << "     Residence Time = " << residence_time << ",\n"
      << "     Throughput = " << throughput << ",\n"
-     << " commod producer members: " << " produces " << out_str << "?:" << ans
-     << "'}";
+     << " commod producer members: "
+     << " produces " << out_str << "?:" << ans << "'}";
   return ss.str();
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Storage::Tick() {
+
+
   LOG(cyclus::LEV_INFO3, "ComCnv") << prototype() << " is ticking {";
 
-  LOG(cyclus::LEV_INFO5, "ComCnv")
-      << "Processing = " << processing.quantity()
-      << ", ready = " << ready.quantity() << ", stocks = " << stocks.quantity()
-      << " and max inventory = " << max_inv_size;
+  LOG(cyclus::LEV_INFO5, "ComCnv") << "Processing = " << processing.quantity() << ", ready = " << ready.quantity() << ", stocks = " << stocks.quantity() << " and max inventory = " << max_inv_size;
 
-  LOG(cyclus::LEV_INFO4, "ComCnv")
-      << "current capacity " << max_inv_size << " - " << processing.quantity()
-      << " - " << ready.quantity() << " - " << stocks.quantity() << " = "
-      << current_capacity();
+  LOG(cyclus::LEV_INFO4, "ComCnv") << "current capacity " << max_inv_size << " - " << processing.quantity() << " - " << ready.quantity() << " - " << stocks.quantity() << " = " << current_capacity();
 
   if (current_capacity() > cyclus::eps_rsrc()) {
     LOG(cyclus::LEV_INFO4, "ComCnv")
@@ -171,22 +166,17 @@ void Storage::Tock() {
 
   BeginProcessing_();  // place unprocessed inventory into processing
 
-  LOG(cyclus::LEV_INFO4, "ComCnv")
-      << "processing currently holds " << processing.quantity()
-      << ". ready currently holds " << ready.quantity() << ".";
+  LOG(cyclus::LEV_INFO4, "ComCnv") << "processing currently holds " << processing.quantity() << ". ready currently holds " << ready.quantity() << ".";
 
   if (ready_time() >= 0 || residence_time == 0 && !inventory.empty()) {
     ReadyMatl_(ready_time());  // place processing into ready
   }
 
-  LOG(cyclus::LEV_INFO5, "ComCnv")
-      << "Ready now holds " << ready.quantity() << " kg.";
+  LOG(cyclus::LEV_INFO5, "ComCnv") << "Ready now holds " << ready.quantity() << " kg.";
 
   if (ready.quantity() > throughput) {
-    LOG(cyclus::LEV_INFO5, "ComCnv")
-        << "Up to " << throughput
-        << " kg will be placed in stocks based on throughput limits. ";
-  }
+    LOG(cyclus::LEV_INFO5, "ComCnv") << "Up to " << throughput << " kg will be placed in stocks based on throughput limits. ";
+    }
 
   ProcessMat_(throughput);  // place ready into stocks
 
@@ -196,17 +186,15 @@ void Storage::Tock() {
   double demand = 0;
   demand = current_capacity();
 
-  cyclus::toolkit::RecordTimeSeries<double>("demand" + in_commods[maxindx],
-                                            this, demand);
+  cyclus::toolkit::RecordTimeSeries<double>("demand"+in_commods[maxindx], this, demand);
 
   // Multiple commodity tracking is not supported, user can only
   // provide one value for out_commods, despite it being a vector of strings.
-  cyclus::toolkit::RecordTimeSeries<double>("supply" + out_commods[0], this,
+  cyclus::toolkit::RecordTimeSeries<double>("supply"+out_commods[0], this,
                                             stocks.quantity());
 
-  LOG(cyclus::LEV_INFO4, "ComCnv")
-      << "process has " << processing.quantity() << ". Ready has "
-      << ready.quantity() << ". Stocks has " << stocks.quantity() << ".";
+  LOG(cyclus::LEV_INFO4, "ComCnv") << "process has "
+                                   << processing.quantity() << ". Ready has " << ready.quantity() << ". Stocks has " << stocks.quantity() << ".";
   LOG(cyclus::LEV_INFO3, "ComCnv") << "}";
 }
 
@@ -265,9 +253,10 @@ void Storage::ProcessMat_(double cap) {
         stocks.Push(ready.Pop(max_pop, cyclus::eps_rsrc()));
       }
 
-      LOG(cyclus::LEV_INFO4, "ComCnv")
-          << "Storage " << prototype() << " moved resources"
-          << " from ready to stocks" << " at t= " << context()->time();
+      LOG(cyclus::LEV_INFO4, "ComCnv") << "Storage " << prototype()
+                                       << " moved resources"
+                                       << " from ready to stocks"
+                                       << " at t= " << context()->time();
     } catch (cyclus::Error& e) {
       e.msg(Agent::InformErrorMsg(e.msg()));
       throw e;
@@ -300,6 +289,7 @@ void Storage::RecordPosition() {
       ->AddVal("Longitude", longitude)
       ->Record();
 }
+
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 extern "C" cyclus::Agent* ConstructStorage(cyclus::Context* ctx) {

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -5,11 +5,12 @@
 namespace cycamore {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Storage::Storage(cyclus::Context* ctx)
-    : cyclus::Facility(ctx) {
-  inventory_tracker.Init({&inventory, &stocks, &ready, &processing}, cyclus::CY_LARGE_DOUBLE);
+Storage::Storage(cyclus::Context* ctx) : cyclus::Facility(ctx) {
+  inventory_tracker.Init({&inventory, &stocks, &ready, &processing},
+                         cyclus::CY_LARGE_DOUBLE);
   cyclus::Warn<cyclus::EXPERIMENTAL_WARNING>(
-      "The Storage Facility is experimental.");};
+      "The Storage Facility is experimental.");
+};
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // pragmas
@@ -38,7 +39,8 @@ void Storage::InitFrom(Storage* m) {
 void Storage::InitFrom(cyclus::QueryableBackend* b) {
 #pragma cyclus impl initfromdb cycamore::Storage
 
-  cyclus::toolkit::Commodity commod = cyclus::toolkit::Commodity(out_commods.front());
+  cyclus::toolkit::Commodity commod =
+      cyclus::toolkit::Commodity(out_commods.front());
   cyclus::toolkit::CommodityProducer::Add(commod);
   cyclus::toolkit::CommodityProducer::SetCapacity(commod, throughput);
 }
@@ -51,28 +53,26 @@ void Storage::EnterNotify() {
   if (reorder_point < 0 && cumulative_cap <= 0) {
     InitBuyPolicyParameters();
     buy_policy.Init(this, &inventory, std::string("inventory"),
-                    &inventory_tracker, throughput, active_dist_,
-                    dormant_dist_, size_dist_);
-  }
-  else if (cumulative_cap > 0) {
+                    &inventory_tracker, throughput, active_dist_, dormant_dist_,
+                    size_dist_);
+  } else if (cumulative_cap > 0) {
     InitBuyPolicyParameters();
     buy_policy.Init(this, &inventory, std::string("inventory"),
                     &inventory_tracker, throughput, cumulative_cap,
                     dormant_dist_);
-  }
-  else if (reorder_quantity > 0) {
+  } else if (reorder_quantity > 0) {
     if (reorder_point + reorder_quantity > max_inv_size) {
       throw cyclus::ValueError(
-          "reorder_point + reorder_quantity must be less than or equal to max_inv_size");
+          "reorder_point + reorder_quantity must be less than or equal to "
+          "max_inv_size");
     }
     buy_policy.Init(this, &inventory, std::string("inventory"),
-                    &inventory_tracker, throughput, "RQ",
-                    reorder_quantity, reorder_point);
-  }
-  else {
+                    &inventory_tracker, throughput, "RQ", reorder_quantity,
+                    reorder_point);
+  } else {
     buy_policy.Init(this, &inventory, std::string("inventory"),
-                    &inventory_tracker, throughput, "sS",
-                    max_inv_size, reorder_point);
+                    &inventory_tracker, throughput, "sS", max_inv_size,
+                    reorder_point);
   }
 
   // dummy comp, use in_recipe if provided
@@ -98,20 +98,21 @@ void Storage::EnterNotify() {
   }
   buy_policy.Start();
 
-  std::string package_name_ =  context()->GetPackage(package)->name();
+  std::string package_name_ = context()->GetPackage(package)->name();
   std::string tu_name_ = context()->GetTransportUnit(transport_unit)->name();
   if (out_commods.size() == 1) {
-    sell_policy.Init(this, &stocks, std::string("stocks"), cyclus::CY_LARGE_DOUBLE, false,
-                     sell_quantity, package_name_, tu_name_)
-      .Set(out_commods.front())
-      .Start();
+    sell_policy
+        .Init(this, &stocks, std::string("stocks"), cyclus::CY_LARGE_DOUBLE,
+              false, sell_quantity, package_name_, tu_name_)
+        .Set(out_commods.front())
+        .Start();
 
   } else {
     std::stringstream ss;
     ss << "out_commods has " << out_commods.size() << " values, expected 1.";
     throw cyclus::ValueError(ss.str());
   }
-  
+
   InitializePosition();
 }
 
@@ -131,25 +132,28 @@ std::string Storage::str() {
     ans = "no";
   }
   ss << cyclus::Facility::str();
-  ss << " has facility parameters {"
-     << "\n"
+  ss << " has facility parameters {" << "\n"
      << "     Output Commodity = " << out_str << ",\n"
      << "     Residence Time = " << residence_time << ",\n"
      << "     Throughput = " << throughput << ",\n"
-     << " commod producer members: "
-     << " produces " << out_str << "?:" << ans << "'}";
+     << " commod producer members: " << " produces " << out_str << "?:" << ans
+     << "'}";
   return ss.str();
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Storage::Tick() {
-
-
   LOG(cyclus::LEV_INFO3, "ComCnv") << prototype() << " is ticking {";
 
-  LOG(cyclus::LEV_INFO5, "ComCnv") << "Processing = " << processing.quantity() << ", ready = " << ready.quantity() << ", stocks = " << stocks.quantity() << " and max inventory = " << max_inv_size;
+  LOG(cyclus::LEV_INFO5, "ComCnv")
+      << "Processing = " << processing.quantity()
+      << ", ready = " << ready.quantity() << ", stocks = " << stocks.quantity()
+      << " and max inventory = " << max_inv_size;
 
-  LOG(cyclus::LEV_INFO4, "ComCnv") << "current capacity " << max_inv_size << " - " << processing.quantity() << " - " << ready.quantity() << " - " << stocks.quantity() << " = " << current_capacity();
+  LOG(cyclus::LEV_INFO4, "ComCnv")
+      << "current capacity " << max_inv_size << " - " << processing.quantity()
+      << " - " << ready.quantity() << " - " << stocks.quantity() << " = "
+      << current_capacity();
 
   if (current_capacity() > cyclus::eps_rsrc()) {
     LOG(cyclus::LEV_INFO4, "ComCnv")
@@ -164,17 +168,22 @@ void Storage::Tock() {
 
   BeginProcessing_();  // place unprocessed inventory into processing
 
-  LOG(cyclus::LEV_INFO4, "ComCnv") << "processing currently holds " << processing.quantity() << ". ready currently holds " << ready.quantity() << ".";
+  LOG(cyclus::LEV_INFO4, "ComCnv")
+      << "processing currently holds " << processing.quantity()
+      << ". ready currently holds " << ready.quantity() << ".";
 
   if (ready_time() >= 0 || residence_time == 0 && !inventory.empty()) {
     ReadyMatl_(ready_time());  // place processing into ready
   }
 
-  LOG(cyclus::LEV_INFO5, "ComCnv") << "Ready now holds " << ready.quantity() << " kg.";
+  LOG(cyclus::LEV_INFO5, "ComCnv")
+      << "Ready now holds " << ready.quantity() << " kg.";
 
   if (ready.quantity() > throughput) {
-    LOG(cyclus::LEV_INFO5, "ComCnv") << "Up to " << throughput << " kg will be placed in stocks based on throughput limits. ";
-    }
+    LOG(cyclus::LEV_INFO5, "ComCnv")
+        << "Up to " << throughput
+        << " kg will be placed in stocks based on throughput limits. ";
+  }
 
   ProcessMat_(throughput);  // place ready into stocks
 
@@ -184,15 +193,17 @@ void Storage::Tock() {
   double demand = 0;
   demand = current_capacity();
 
-  cyclus::toolkit::RecordTimeSeries<double>("demand"+in_commods[maxindx], this, demand);
+  cyclus::toolkit::RecordTimeSeries<double>("demand" + in_commods[maxindx],
+                                            this, demand);
 
   // Multiple commodity tracking is not supported, user can only
   // provide one value for out_commods, despite it being a vector of strings.
-  cyclus::toolkit::RecordTimeSeries<double>("supply"+out_commods[0], this,
+  cyclus::toolkit::RecordTimeSeries<double>("supply" + out_commods[0], this,
                                             stocks.quantity());
 
-  LOG(cyclus::LEV_INFO4, "ComCnv") << "process has "
-                                   << processing.quantity() << ". Ready has " << ready.quantity() << ". Stocks has " << stocks.quantity() << ".";
+  LOG(cyclus::LEV_INFO4, "ComCnv")
+      << "process has " << processing.quantity() << ". Ready has "
+      << ready.quantity() << ". Stocks has " << stocks.quantity() << ".";
   LOG(cyclus::LEV_INFO3, "ComCnv") << "}";
 }
 
@@ -251,10 +262,9 @@ void Storage::ProcessMat_(double cap) {
         stocks.Push(ready.Pop(max_pop, cyclus::eps_rsrc()));
       }
 
-      LOG(cyclus::LEV_INFO4, "ComCnv") << "Storage " << prototype()
-                                       << " moved resources"
-                                       << " from ready to stocks"
-                                       << " at t= " << context()->time();
+      LOG(cyclus::LEV_INFO4, "ComCnv")
+          << "Storage " << prototype() << " moved resources"
+          << " from ready to stocks" << " at t= " << context()->time();
     } catch (cyclus::Error& e) {
       e.msg(Agent::InformErrorMsg(e.msg()));
       throw e;

--- a/src/storage.h
+++ b/src/storage.h
@@ -1,13 +1,14 @@
 #ifndef CYCLUS_STORAGES_STORAGE_H_
 #define CYCLUS_STORAGES_STORAGE_H_
 
-#include <list>
 #include <string>
+#include <list>
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
-#include "cycamore_version.h"
 #include "cyclus.h"
+#include "cycamore_version.h"
+
+#include "boost/shared_ptr.hpp"
 
 // clang-format off
 #pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, \
@@ -31,15 +32,15 @@ namespace cycamore {
 ///
 /// @section agentparams Agent Parameters
 /// in_commods is a vector of strings naming the commodities that this facility
-/// receives
-/// out_commods is a string naming the commodity that in_commod is stocks into
+/// receives  
+/// out_commods is a string naming the commodity that in_commod is stocks into  
 /// residence_time is the minimum number of timesteps between receiving and
-/// offering
+/// offering  
 /// in_recipe (optional) describes the incoming resource by recipe
 ///
 /// @section optionalparams Optional Parameters
-/// max_inv_size is the maximum capacity of the inventory storage
-/// throughput is the maximum processing capacity per timestep
+/// max_inv_size is the maximum capacity of the inventory storage  
+/// throughput is the maximum processing capacity per timestep  
 /// package is the name of the package type to ship
 ///
 /// @section detailed Detailed Behavior
@@ -73,7 +74,7 @@ class Storage : public cyclus::Facility,
   /// @param ctx the cyclus context for access to simulation-wide parameters
   Storage(cyclus::Context* ctx);
 
-#pragma cyclus decl
+  #pragma cyclus decl
 
   // clang-format off
   #pragma cyclus note { \
@@ -132,13 +133,19 @@ class Storage : public cyclus::Facility,
   // --- Storage Members ---
 
   /// @brief current maximum amount that can be added to processing
-  inline double current_capacity() { return (inventory_tracker.space()); }
+  inline double current_capacity() {
+    return (inventory_tracker.space());
+  }
 
   /// @brief returns total capacity
-  inline double capacity() { return inventory_tracker.capacity(); }
+  inline double capacity() {
+    return inventory_tracker.capacity();
+  }
 
   /// @brief returns the time key for ready materials
-  inline int ready_time() { return context()->time() - residence_time; }
+  inline int ready_time() {
+    return context()->time() - residence_time;
+  }
 
   // clang-format off
   #pragma cyclus var { \
@@ -259,8 +266,9 @@ class Storage : public cyclus::Facility,
     "tooltip": "Buffer for material held for required residence_time" \
   }
   cyclus::toolkit::ResBuf<cyclus::Material> ready;
+  // clang-format on
 
-  // list of input times for materials entering the processing buffer
+  //// list of input times for materials entering the processing buffer
   #pragma cyclus var { \
     "default": [], \
     "internal": True \
@@ -292,7 +300,6 @@ class Storage : public cyclus::Facility,
            "should be expressed in degrees as a double." \
   }
   double longitude;
-  // clang-format on
 
   cyclus::toolkit::Position coordinates;
 
@@ -301,9 +308,9 @@ class Storage : public cyclus::Facility,
   friend class StorageTest;
 
  private:
-// Code Injection
-#include "toolkit/matl_buy_policy.cycpp.h"
-#include "toolkit/matl_sell_policy.cycpp.h"
+  // Code Injection
+  #include "toolkit/matl_buy_policy.cycpp.h"
+  #include "toolkit/matl_sell_policy.cycpp.h"
 };
 
 }  // namespace cycamore

--- a/src/storage.h
+++ b/src/storage.h
@@ -1,14 +1,13 @@
 #ifndef CYCLUS_STORAGES_STORAGE_H_
 #define CYCLUS_STORAGES_STORAGE_H_
 
-#include <string>
 #include <list>
+#include <string>
 #include <vector>
 
-#include "cyclus.h"
-#include "cycamore_version.h"
-
 #include "boost/shared_ptr.hpp"
+#include "cycamore_version.h"
+#include "cyclus.h"
 
 // clang-format off
 #pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, \
@@ -32,15 +31,15 @@ namespace cycamore {
 ///
 /// @section agentparams Agent Parameters
 /// in_commods is a vector of strings naming the commodities that this facility
-/// receives  
-/// out_commods is a string naming the commodity that in_commod is stocks into  
+/// receives
+/// out_commods is a string naming the commodity that in_commod is stocks into
 /// residence_time is the minimum number of timesteps between receiving and
-/// offering  
+/// offering
 /// in_recipe (optional) describes the incoming resource by recipe
 ///
 /// @section optionalparams Optional Parameters
-/// max_inv_size is the maximum capacity of the inventory storage  
-/// throughput is the maximum processing capacity per timestep  
+/// max_inv_size is the maximum capacity of the inventory storage
+/// throughput is the maximum processing capacity per timestep
 /// package is the name of the package type to ship
 ///
 /// @section detailed Detailed Behavior
@@ -74,7 +73,7 @@ class Storage : public cyclus::Facility,
   /// @param ctx the cyclus context for access to simulation-wide parameters
   Storage(cyclus::Context* ctx);
 
-  #pragma cyclus decl
+#pragma cyclus decl
 
   // clang-format off
   #pragma cyclus note { \
@@ -133,19 +132,13 @@ class Storage : public cyclus::Facility,
   // --- Storage Members ---
 
   /// @brief current maximum amount that can be added to processing
-  inline double current_capacity() {
-    return (inventory_tracker.space());
-  }
+  inline double current_capacity() { return (inventory_tracker.space()); }
 
   /// @brief returns total capacity
-  inline double capacity() {
-    return inventory_tracker.capacity();
-  }
+  inline double capacity() { return inventory_tracker.capacity(); }
 
   /// @brief returns the time key for ready materials
-  inline int ready_time() {
-    return context()->time() - residence_time;
-  }
+  inline int ready_time() { return context()->time() - residence_time; }
 
   // clang-format off
   #pragma cyclus var { \
@@ -266,9 +259,8 @@ class Storage : public cyclus::Facility,
     "tooltip": "Buffer for material held for required residence_time" \
   }
   cyclus::toolkit::ResBuf<cyclus::Material> ready;
-  // clang-format on
 
-  //// list of input times for materials entering the processing buffer
+  // list of input times for materials entering the processing buffer
   #pragma cyclus var { \
     "default": [], \
     "internal": True \
@@ -300,6 +292,7 @@ class Storage : public cyclus::Facility,
            "should be expressed in degrees as a double." \
   }
   double longitude;
+  // clang-format on
 
   cyclus::toolkit::Position coordinates;
 
@@ -308,9 +301,9 @@ class Storage : public cyclus::Facility,
   friend class StorageTest;
 
  private:
-  // Code Injection
-  #include "toolkit/matl_buy_policy.cycpp.h"
-  #include "toolkit/matl_sell_policy.cycpp.h"
+// Code Injection
+#include "toolkit/matl_buy_policy.cycpp.h"
+#include "toolkit/matl_sell_policy.cycpp.h"
 };
 
 }  // namespace cycamore

--- a/src/storage.h
+++ b/src/storage.h
@@ -10,7 +10,10 @@
 
 #include "boost/shared_ptr.hpp"
 
-#pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
+// clang-format off
+#pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, \
+    CY_NEAR_ZERO
+// clang-format on
 
 namespace cycamore {
 /// @class Storage
@@ -23,66 +26,75 @@ namespace cycamore {
 ///
 /// @section intro Introduction
 /// This Agent was initially developed to support the fco code-to-code
-/// comparison.
-/// It's very similar to the "NullFacility" of years
+/// comparison. It's very similar to the "NullFacility" of years
 /// past. Its purpose is to hold materials and release them only
 /// after some period of delay time.
 ///
 /// @section agentparams Agent Parameters
-/// in_commods is a vector of strings naming the commodities that this facility receives
-/// out_commods is a string naming the commodity that in_commod is stocks into
-/// residence_time is the minimum number of timesteps between receiving and offering
+/// in_commods is a vector of strings naming the commodities that this facility
+/// receives  
+/// out_commods is a string naming the commodity that in_commod is stocks into  
+/// residence_time is the minimum number of timesteps between receiving and
+/// offering  
 /// in_recipe (optional) describes the incoming resource by recipe
 ///
 /// @section optionalparams Optional Parameters
-/// max_inv_size is the maximum capacity of the inventory storage
-/// throughput is the maximum processing capacity per timestep
+/// max_inv_size is the maximum capacity of the inventory storage  
+/// throughput is the maximum processing capacity per timestep  
 /// package is the name of the package type to ship
 ///
 /// @section detailed Detailed Behavior
 ///
 /// Tick:
-/// Nothing really happens on the tick.
+///   Nothing really happens on the tick.
 ///
 /// Tock:
-/// On the tock, any material that has been waiting for long enough (delay
-/// time) is placed in the stocks buffer.
+///   On the tock, any material that has been waiting for long enough (delay
+///   time) is placed in the stocks buffer.
 ///
-/// Any brand new inventory that was received in this timestep is placed into
-/// the processing queue to begin waiting.
+///   Any brand new inventory that was received in this timestep is placed into
+///   the processing queue to begin waiting.
 ///
 /// Making Requests:
-/// This facility requests all of the in_commod that it can.
+///   This facility requests all of the in_commod that it can.
 ///
 /// Receiving Resources:
-/// Anything of the in_commod that is received by this facility goes into the
-/// inventory.
+///   Anything of the in_commod that is received by this facility goes into the
+///   inventory.
 ///
 /// Making Offers:
-/// Any stocks material in the stocks buffer is offered to the market.
+///   Any stocks material in the stocks buffer is offered to the market.
 ///
 /// Sending Resources:
-/// Matched resources are sent immediately.
-class Storage
-  : public cyclus::Facility,
-    public cyclus::toolkit::CommodityProducer,
-    public cyclus::toolkit::Position {
+///   Matched resources are sent immediately.
+class Storage : public cyclus::Facility,
+                public cyclus::toolkit::CommodityProducer,
+                public cyclus::toolkit::Position {
  public:
   /// @param ctx the cyclus context for access to simulation-wide parameters
   Storage(cyclus::Context* ctx);
 
   #pragma cyclus decl
 
-  #pragma cyclus note {"doc": "Storage is a simple facility which accepts any number of commodities " \
-                              "and holds them for a user specified amount of time. The commodities accepted "\
-                              "are chosen based on the specified preferences list. Once the desired amount of material "\
-                              "has entered the facility it is passed into a 'processing' buffer where it is held until "\
-                              "the residence time has passed. The material is then passed into a 'ready' buffer where it is "\
-                              "queued for removal. Currently, all input commodities are lumped into a single output commodity. "\
-                              "Storage also has the functionality to handle materials in discrete or continuous batches. Discrete "\
-                              "mode, which is the default, does not split or combine material batches. Continuous mode, however, "\
-                              "divides material batches if necessary in order to push materials through the facility as quickly "\
-                              "as possible."}
+  // clang-format off
+  #pragma cyclus note { \
+    "doc": "Storage is a simple facility which accepts any number of "\
+            "commodities and holds them for a user specified amount of "\
+            "time. The commodities accepted are chosen based on the "\
+            "specified preferences list. Once the desired amount of "\
+            "material has entered the facility it is passed into a "\
+            "'processing' buffer where it is held until the residence "\
+            "time has passed. The material is then passed into a 'ready' "\
+            "buffer where it is queued for removal. Currently, all input "\
+            "commodities are lumped into a single output commodity. "\
+            "Storage also has the functionality to handle materials in "\
+            "discrete or continuous batches. Discrete mode, which is the "\
+            "default, does not split or combine material batches. "\
+            "Continuous mode, however, divides material batches if "\
+            "necessary in order to push materials through the facility "\
+            "as quickly as possible." \
+  }
+  // clang-format on
 
   /// A verbose printer for the Storage Facility
   virtual std::string str();
@@ -101,15 +113,10 @@ class Storage
 
   virtual std::string version() { return CYCAMORE_VERSION; }
 
- private:
-  // Code Injection
-  #include "toolkit/matl_buy_policy.cycpp.h"
-  #include "toolkit/matl_sell_policy.cycpp.h"
-
  protected:
-  ///   @brief adds a material into the incoming commodity inventory
-  ///   @param mat the material to add to the incoming inventory.
-  ///   @throws if there is trouble with pushing to the inventory buffer.
+  /// @brief adds a material into the incoming commodity inventory
+  /// @param mat the material to add to the incoming inventory.
+  /// @throws if there is trouble with pushing to the inventory buffer.
   void AddMat_(cyclus::Material::Ptr mat);
 
   /// @brief Move all unprocessed inventory to processing
@@ -127,128 +134,170 @@ class Storage
 
   /// @brief current maximum amount that can be added to processing
   inline double current_capacity() {
-    return (inventory_tracker.space()); }
+    return (inventory_tracker.space());
+  }
 
   /// @brief returns total capacity
-  inline double capacity() { return inventory_tracker.capacity(); }
+  inline double capacity() {
+    return inventory_tracker.capacity();
+  }
 
   /// @brief returns the time key for ready materials
-  int ready_time(){ return context()->time() - residence_time; }
+  inline int ready_time() {
+    return context()->time() - residence_time;
+  }
 
-  // --- Module Members --- 
-
-  #pragma cyclus var {"tooltip":"input commodity",\
-                      "doc":"commodities accepted by this facility",\
-                      "uilabel":"Input Commodities",\
-                      "uitype":["oneormore","incommodity"]}
+  // clang-format off
+  #pragma cyclus var { \
+    "tooltip": "input commodity", \
+    "doc": "commodities accepted by this facility", \
+    "uilabel": "Input Commodities", \
+    "uitype": ["oneormore", "incommodity"] \
+  }
   std::vector<std::string> in_commods;
 
-  #pragma cyclus var {"default": [],\
-                      "doc":"preferences for each of the given commodities, in the same order."\
-                      "Defauts to 1 if unspecified",\
-                      "uilabel":"In Commody Preferences", \
-                      "range": [None, [CY_NEAR_ZERO, CY_LARGE_DOUBLE]], \
-                      "uitype":["oneormore", "range"]}
+  #pragma cyclus var { \
+    "default": [], \
+    "doc": "preferences for each of the given commodities, in the same order. "\
+           "Defaults to 1 if unspecified", \
+    "uilabel": "In Commodity Preferences", \
+    "range": [None, [CY_NEAR_ZERO, CY_LARGE_DOUBLE]], \
+    "uitype": ["oneormore", "range"] \
+  }
   std::vector<double> in_commod_prefs;
 
-  #pragma cyclus var {"tooltip":"output commodity",\
-                      "doc":"commodity produced by this facility. Multiple commodity tracking is"\
-                      " currently not supported, one output commodity catches all input commodities.",\
-                      "uilabel":"Output Commodities",\
-                      "uitype":["oneormore","outcommodity"]}
+  #pragma cyclus var { \
+    "tooltip": "output commodity", \
+    "doc": "commodity produced by this facility. Multiple commodity tracking "\
+           "is currently not supported, one output commodity catches all "\
+           "input commodities.", \
+    "uilabel": "Output Commodities", \
+    "uitype": ["oneormore", "outcommodity"] \
+  }
   std::vector<std::string> out_commods;
 
-  #pragma cyclus var {"default":"",\
-                      "tooltip":"input recipe",\
-                      "doc":"recipe accepted by this facility, if unspecified a dummy recipe is used",\
-                      "uilabel":"Input Recipe",\
-                      "uitype":"inrecipe"}
+  #pragma cyclus var { \
+    "default": "", \
+    "tooltip": "input recipe", \
+    "doc": "recipe accepted by this facility, if unspecified a dummy recipe "\
+           "is used", \
+    "uilabel": "Input Recipe", \
+    "uitype": "inrecipe" \
+  }
   std::string in_recipe;
 
-  #pragma cyclus var {"default": 0,\
-                      "tooltip":"residence time (timesteps)",\
-                      "doc":"the minimum holding time for a received commodity (timesteps).",\
-                      "units":"time steps",\
-                      "uilabel":"Residence Time", \
-                      "uitype": "range", \
-                      "range": [0, 12000]}
+  #pragma cyclus var { \
+    "default": 0, \
+    "tooltip": "residence time (timesteps)", \
+    "doc": "the minimum holding time for a received commodity "\
+           "(timesteps)", \
+    "units": "time steps", \
+    "uilabel": "Residence Time", \
+    "uitype": "range", \
+    "range": [0, 12000] \
+  }
   int residence_time;
 
-  #pragma cyclus var {"default": CY_LARGE_DOUBLE,\
-                     "tooltip":"throughput per timestep (kg)",\
-                     "doc":"the max amount that can be moved through the facility per timestep (kg)",\
-                     "uilabel":"Throughput",\
-                     "uitype": "range", \
-                     "range": [0.0, CY_LARGE_DOUBLE], \
-                     "units":"kg"}
+  #pragma cyclus var { \
+    "default": CY_LARGE_DOUBLE, \
+    "tooltip": "throughput per timestep (kg)", \
+    "doc": "the max amount that can be moved through the facility "\
+           "per timestep (kg)", \
+    "uilabel": "Throughput", \
+    "uitype": "range", \
+    "range": [0.0, CY_LARGE_DOUBLE], \
+    "units": "kg" \
+  }
   double throughput;
 
-  #pragma cyclus var {"default": CY_LARGE_DOUBLE,\
-                      "tooltip":"maximum inventory size (kg)",\
-                      "doc":"the maximum amount of material that can be in all storage buffer stages",\
-                      "uilabel":"Maximum Inventory Size",\
-                      "uitype": "range", \
-                      "range": [0.0, CY_LARGE_DOUBLE], \
-                      "units":"kg"}
+  #pragma cyclus var { \
+    "default": CY_LARGE_DOUBLE, \
+    "tooltip": "maximum inventory size (kg)", \
+    "doc": "the maximum amount of material that can be in all storage "\
+           "buffer stages", \
+    "uilabel": "Maximum Inventory Size", \
+    "uitype": "range", \
+    "range": [0.0, CY_LARGE_DOUBLE], \
+    "units": "kg" \
+  }
   double max_inv_size;
 
-  #pragma cyclus var {"default": False,\
-                      "tooltip":"Bool to determine how Storage handles batches",\
-                      "doc":"Determines if Storage will divide resource objects. Only controls material "\
-                            "handling within this facility, has no effect on DRE material handling. "\
-                            "If true, batches are handled as discrete quanta, neither split nor combined. "\
-                            "Otherwise, batches may be divided during processing. Default to false (continuous))",\
-                      "uilabel":"Batch Handling"}
+  #pragma cyclus var { \
+    "default": False, \
+    "tooltip": "Bool to determine how Storage handles batches", \
+    "doc": "Determines if Storage will divide resource objects. Only "\
+           "controls material handling within this facility. If true, "\
+           "batches are handled as discrete quanta. Otherwise, batches "\
+           "may be divided during processing. Default false (continuous).", \
+    "uilabel": "Batch Handling" \
+  }
   bool discrete_handling;
 
-  #pragma cyclus var {"default": "unpackaged", \
-                      "tooltip": "Output package", \
-                      "doc": "Outgoing material will be packaged when trading.", \
-                      "uitype": "package", \
-                      "uilabel": "Package"}
+  #pragma cyclus var { \
+    "default": "unpackaged", \
+    "tooltip": "Output package", \
+    "doc": "Outgoing material will be packaged when trading.", \
+    "uilabel": "Package", \
+    "uitype": "package" \
+  }
   std::string package;
 
-  #pragma cyclus var {"default": "unrestricted", \
-                      "tooltip": "Output transport unit", \
-                      "doc": "Outgoing material, after packaging, will be "\
-                      "further restricted by transport unit when trading.", \
-                      "uitype": "transportunit", \
-                      "uilabel": "Transport Unit"}
+  #pragma cyclus var { \
+    "default": "unrestricted", \
+    "tooltip": "Output transport unit", \
+    "doc": "Outgoing material, after packaging, will be restricted by "\
+           "transport unit when trading.", \
+    "uilabel": "Transport Unit", \
+    "uitype": "transportunit" \
+  }
   std::string transport_unit;
 
-  #pragma cyclus var {"tooltip":"Incoming material buffer"}
+  #pragma cyclus var { \
+    "tooltip": "Incoming material buffer" \
+  }
   cyclus::toolkit::ResBuf<cyclus::Material> inventory;
 
-  #pragma cyclus var {"tooltip":"Output material buffer"}
+  #pragma cyclus var { \
+    "tooltip": "Output material buffer" \
+  }
   cyclus::toolkit::ResBuf<cyclus::Material> stocks;
 
-  #pragma cyclus var {"tooltip":"Buffer for material held for required residence_time"}
+  #pragma cyclus var { \
+    "tooltip": "Buffer for material held for required residence_time" \
+  }
   cyclus::toolkit::ResBuf<cyclus::Material> ready;
+  // clang-format on
 
   //// list of input times for materials entering the processing buffer
-  #pragma cyclus var{"default": [],\
-                      "internal": True}
+  #pragma cyclus var { \
+    "default": [], \
+    "internal": True \
+  }
   std::list<int> entry_times;
 
-  #pragma cyclus var {"tooltip":"Buffer for material still waiting for required residence_time"}
+  #pragma cyclus var { \
+    "tooltip": "Buffer for material still waiting for required residence_time" \
+  }
   cyclus::toolkit::ResBuf<cyclus::Material> processing;
 
-  #pragma cyclus var {"tooltip": "Total Inventory Tracker to restrict maximum agent inventory"}
+  #pragma cyclus var { \
+    "tooltip": "Total Inventory Tracker to restrict maximum agent inventory" \
+  }
   cyclus::toolkit::TotalInvTracker inventory_tracker;
 
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical latitude in degrees as a double", \
-    "doc": "Latitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
+    "doc": "Latitude of the agent's geographical position. The value "\
+           "should be expressed in degrees as a double." \
   }
   double latitude;
 
   #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Geographical longitude in degrees as a double", \
-    "doc": "Longitude of the agent's geographical position. The value should " \
-           "be expressed in degrees as a double." \
+    "doc": "Longitude of the agent's geographical position. The value "\
+           "should be expressed in degrees as a double." \
   }
   double longitude;
 
@@ -257,6 +306,11 @@ class Storage
   void RecordPosition();
 
   friend class StorageTest;
+
+ private:
+  // Code Injection
+  #include "toolkit/matl_buy_policy.cycpp.h"
+  #include "toolkit/matl_sell_policy.cycpp.h"
 };
 
 }  // namespace cycamore

--- a/src/storage.h
+++ b/src/storage.h
@@ -32,15 +32,15 @@ namespace cycamore {
 ///
 /// @section agentparams Agent Parameters
 /// in_commods is a vector of strings naming the commodities that this facility
-/// receives  
-/// out_commods is a string naming the commodity that in_commod is stocks into  
+/// receives
+/// out_commods is a string naming the commodity that in_commod is stocks into
 /// residence_time is the minimum number of timesteps between receiving and
-/// offering  
+/// offering
 /// in_recipe (optional) describes the incoming resource by recipe
 ///
 /// @section optionalparams Optional Parameters
-/// max_inv_size is the maximum capacity of the inventory storage  
-/// throughput is the maximum processing capacity per timestep  
+/// max_inv_size is the maximum capacity of the inventory storage
+/// throughput is the maximum processing capacity per timestep
 /// package is the name of the package type to ship
 ///
 /// @section detailed Detailed Behavior
@@ -67,15 +67,13 @@ namespace cycamore {
 ///
 /// Sending Resources:
 /// Matched resources are sent immediately.
-class Storage
-  : public cyclus::Facility,
-    public cyclus::toolkit::CommodityProducer {
-      
- public:  
+class Storage : public cyclus::Facility,
+                public cyclus::toolkit::CommodityProducer {
+ public:
   /// @param ctx the cyclus context for access to simulation-wide parameters
   Storage(cyclus::Context* ctx);
 
-  #pragma cyclus decl
+#pragma cyclus decl
 
   // clang-format off
   #pragma cyclus note { \
@@ -131,19 +129,13 @@ class Storage
   // --- Storage Members ---
 
   /// @brief current maximum amount that can be added to processing
-  inline double current_capacity() {
-    return (inventory_tracker.space());
-  }
+  inline double current_capacity() { return (inventory_tracker.space()); }
 
   /// @brief returns total capacity
-  inline double capacity() {
-    return inventory_tracker.capacity();
-  }
+  inline double capacity() { return inventory_tracker.capacity(); }
 
   /// @brief returns the time key for ready materials
-  inline int ready_time() {
-    return context()->time() - residence_time;
-  }
+  inline int ready_time() { return context()->time() - residence_time; }
 
   // clang-format off
   #pragma cyclus var { \
@@ -264,34 +256,27 @@ class Storage
     "tooltip": "Buffer for material held for required residence_time" \
   }
   cyclus::toolkit::ResBuf<cyclus::Material> ready;
-  // clang-format on
 
   //// list of input times for materials entering the processing buffer
-  #pragma cyclus var { \
-    "default": [], \
-    "internal": True \
-  }
+  #pragma cyclus var {"default" : [], "internal" : True }
   std::list<int> entry_times;
 
   #pragma cyclus var { \
-    "tooltip": "Buffer for material still waiting for required residence_time" \
-  }
+    "tooltip" : "Buffer for material still waiting for required residence_time" }
   cyclus::toolkit::ResBuf<cyclus::Material> processing;
 
   #pragma cyclus var { \
-    "tooltip": "Total Inventory Tracker to restrict maximum agent inventory" \
-  }
+    "tooltip" : "Total Inventory Tracker to restrict maximum agent inventory" }
   cyclus::toolkit::TotalInvTracker inventory_tracker;
 
   // clang-format on
   friend class StorageTest;
 
  private:
-  // Code Injection
-  #include "toolkit/matl_buy_policy.cycpp.h"
-  #include "toolkit/matl_sell_policy.cycpp.h"
-  #include "toolkit/position.cycpp.h"
-
+// Code Injection
+#include "toolkit/matl_buy_policy.cycpp.h"
+#include "toolkit/matl_sell_policy.cycpp.h"
+#include "toolkit/position.cycpp.h"
 };
 
 }  // namespace cycamore

--- a/src/storage.h
+++ b/src/storage.h
@@ -283,6 +283,7 @@ class Storage
   }
   cyclus::toolkit::TotalInvTracker inventory_tracker;
 
+  // clang-format on
   friend class StorageTest;
 
  private:

--- a/src/storage_tests.cc
+++ b/src/storage_tests.cc
@@ -1,6 +1,6 @@
-#include "storage_tests.h"
-
 #include <gtest/gtest.h>
+
+#include "storage_tests.h"
 
 namespace cycamore {
 
@@ -15,7 +15,7 @@ void StorageTest::TearDown() {
   delete src_facility_;
 }
 
-void StorageTest::InitParameters() {
+void StorageTest::InitParameters(){
   in_r1 = "in_r1";
   in_c1.push_back("in_c1");
   out_c1.push_back("out_c1");
@@ -26,6 +26,7 @@ void StorageTest::InitParameters() {
   package = "foo";
   // Active period longer than any of the residence time related-tests needs
 
+
   cyclus::CompMap v;
   v[922350000] = 1;
   v[922380000] = 2;
@@ -33,7 +34,7 @@ void StorageTest::InitParameters() {
   tc_.get()->AddRecipe(in_r1, recipe);
 }
 
-void StorageTest::SetUpStorage() {
+void StorageTest::SetUpStorage(){
   src_facility_->in_recipe = in_r1;
   src_facility_->in_commods = in_c1;
   src_facility_->out_commods = out_c1;
@@ -45,7 +46,7 @@ void StorageTest::SetUpStorage() {
   src_facility_->package = package;
 }
 
-void StorageTest::TestInitState(Storage* fac) {
+void StorageTest::TestInitState(Storage* fac){
   EXPECT_EQ(residence_time, fac->residence_time);
   EXPECT_EQ(max_inv_size, fac->max_inv_size);
   EXPECT_EQ(throughput, fac->throughput);
@@ -53,7 +54,8 @@ void StorageTest::TestInitState(Storage* fac) {
   EXPECT_EQ(package, fac->package);
 }
 
-void StorageTest::TestAddMat(Storage* fac, cyclus::Material::Ptr mat) {
+void StorageTest::TestAddMat(Storage* fac,
+    cyclus::Material::Ptr mat){
   double amt = mat->quantity();
   double before = fac->inventory.quantity();
   fac->AddMat_(mat);
@@ -61,8 +63,8 @@ void StorageTest::TestAddMat(Storage* fac, cyclus::Material::Ptr mat) {
   EXPECT_EQ(amt, after - before);
 }
 
-void StorageTest::TestBuffers(Storage* fac, double inv, double proc,
-                              double ready, double stocks) {
+void StorageTest::TestBuffers(Storage* fac, double inv,
+    double proc, double ready, double stocks){
   double t = tc_.get()->time();
 
   EXPECT_EQ(inv, fac->inventory.quantity());
@@ -71,24 +73,29 @@ void StorageTest::TestBuffers(Storage* fac, double inv, double proc,
   EXPECT_EQ(ready, fac->ready.quantity());
 }
 
-void StorageTest::TestStocks(Storage* fac, cyclus::CompMap v) {
+void StorageTest::TestStocks(Storage* fac, cyclus::CompMap v){
+
   cyclus::toolkit::ResBuf<cyclus::Material>* buffer = &fac->stocks;
   Material::Ptr final_mat = cyclus::ResCast<Material>(buffer->PopBack());
   cyclus::CompMap final_comp = final_mat->comp()->atom();
-  EXPECT_EQ(final_comp, v);
+  EXPECT_EQ(final_comp,v);
+
 }
 
-void StorageTest::TestCurrentCap(Storage* fac, double inv) {
+void StorageTest::TestCurrentCap(Storage* fac, double inv){
+
   EXPECT_EQ(inv, fac->current_capacity());
 }
 
-void StorageTest::TestReadyTime(Storage* fac, int t) {
+void StorageTest::TestReadyTime(Storage* fac, int t){
+
   EXPECT_EQ(t, fac->ready_time());
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(StorageTest, clone) {
-  Storage* cloned_fac = dynamic_cast<Storage*>(src_facility_->Clone());
+  Storage* cloned_fac =
+      dynamic_cast<Storage*> (src_facility_->Clone());
   TestInitState(cloned_fac);
 }
 
@@ -99,8 +106,8 @@ TEST_F(StorageTest, InitialState) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(StorageTest, CurrentCapacity) {
-  TestCurrentCap(src_facility_, max_inv_size);
+TEST_F(StorageTest, CurrentCapacity){
+  TestCurrentCap(src_facility_,max_inv_size);
   max_inv_size = cyclus::CY_LARGE_DOUBLE;
   SetUpStorage();
   TestInitState(src_facility_);
@@ -115,12 +122,11 @@ TEST_F(StorageTest, Print) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(StorageTest, AddMats) {
   double cap = max_inv_size;
-  cyclus::Material::Ptr mat = cyclus::NewBlankMaterial(0.5 * cap);
+  cyclus::Material::Ptr mat = cyclus::NewBlankMaterial(0.5*cap);
   TestAddMat(src_facility_, mat);
 
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
-  cyclus::Material::Ptr recmat =
-      cyclus::Material::CreateUntracked(0.5 * cap, rec);
+  cyclus::Material::Ptr recmat = cyclus::Material::CreateUntracked(0.5*cap, rec);
   TestAddMat(src_facility_, recmat);
 }
 
@@ -132,8 +138,9 @@ TEST_F(StorageTest, Tick) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(StorageTest, Tock) {
+
   // initially, nothing in the buffers
-  TestBuffers(src_facility_, 0, 0, 0, 0);
+  TestBuffers(src_facility_,0,0,0,0);
 
   double cap = throughput;
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
@@ -141,30 +148,31 @@ TEST_F(StorageTest, Tock) {
   TestAddMat(src_facility_, mat);
 
   // affter add, the inventory has the material
-  TestBuffers(src_facility_, cap, 0, 0, 0);
+  TestBuffers(src_facility_,cap,0,0,0);
 
   EXPECT_NO_THROW(src_facility_->Tock());
 
   // after tock, the processing buffer has the material
-  TestBuffers(src_facility_, 0, cap, 0, 0);
+  TestBuffers(src_facility_,0,cap,0,0);
 
   EXPECT_EQ(0, tc_.get()->time());
-  for (int i = 1; i < residence_time - 1; ++i) {
+  for( int i = 1; i < residence_time-1; ++i){
     tc_.get()->time(i);
     EXPECT_NO_THROW(src_facility_->Tock());
-    TestBuffers(src_facility_, 0, cap, 0, 0);
+    TestBuffers(src_facility_,0,cap,0,0);
   }
 
   tc_.get()->time(residence_time);
   EXPECT_EQ(residence_time, tc_.get()->time());
-  TestReadyTime(src_facility_, 0);
+  TestReadyTime(src_facility_,0);
   src_facility_->Tock();
-  TestBuffers(src_facility_, 0, 0, 0, cap);
+  TestBuffers(src_facility_,0,0,0,cap);
 
-  tc_.get()->time(residence_time + 1);
-  TestReadyTime(src_facility_, 1);
+  tc_.get()->time(residence_time+1);
+  TestReadyTime(src_facility_,1);
   src_facility_->Tock();
-  TestBuffers(src_facility_, 0, 0, 0, cap);
+  TestBuffers(src_facility_,0,0,0,cap);
+
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -180,16 +188,16 @@ TEST_F(StorageTest, NoProcessTime) {
   TestAddMat(src_facility_, mat);
 
   // affter add, the inventory has the material
-  TestBuffers(src_facility_, cap, 0, 0, 0);
+  TestBuffers(src_facility_,cap,0,0,0);
 
   EXPECT_NO_THROW(src_facility_->Tock());
 
   // affter tock, the stocks have the material
-  TestBuffers(src_facility_, 0, 0, 0, cap);
+  TestBuffers(src_facility_,0,0,0,cap);
 }
 
 TEST_F(StorageTest, NoConvert) {
-  // Make sure no conversion occurs
+// Make sure no conversion occurs
   double cap = throughput;
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
   cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(cap, rec);
@@ -198,51 +206,51 @@ TEST_F(StorageTest, NoConvert) {
   EXPECT_NO_THROW(src_facility_->Tock());
 
   tc_.get()->time(residence_time);
-  TestReadyTime(src_facility_, 0);
+  TestReadyTime(src_facility_,0);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, 0, 0, cap);
+  TestBuffers(src_facility_,0,0,0,cap);
   cyclus::CompMap in_rec;
   in_rec[922350000] = 1;
   in_rec[922380000] = 2;
-  TestStocks(src_facility_, in_rec);
+  TestStocks(src_facility_,in_rec);
 }
 
 TEST_F(StorageTest, MultipleSmallBatches) {
   // Add first small batch
   double cap = throughput;
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
-  cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(0.2 * cap, rec);
+  cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(0.2*cap, rec);
   TestAddMat(src_facility_, mat);
 
   // After add, material is in inventory
-  TestBuffers(src_facility_, 0.2 * cap, 0, 0, 0);
+  TestBuffers(src_facility_,0.2*cap,0,0,0);
 
   // Move first batch into processing
   src_facility_->Tock();
-  TestBuffers(src_facility_, 0, 0.2 * cap, 0, 0);
+  TestBuffers(src_facility_,0,0.2*cap,0,0);
 
   // Add second small batch
   tc_.get()->time(2);
   src_facility_->Tock();
-  cyclus::Material::Ptr mat1 =
-      cyclus::Material::CreateUntracked(0.3 * cap, rec);
-  TestAddMat(src_facility_, mat1);
-  TestBuffers(src_facility_, 0.3 * cap, 0.2 * cap, 0, 0);
+  cyclus::Material::Ptr mat1 = cyclus::Material::CreateUntracked(0.3*cap, rec);
+  TestAddMat(src_facility_,mat1);
+  TestBuffers(src_facility_,0.3*cap,0.2*cap,0,0);
 
   // Move second batch into processing
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, 0.5 * cap, 0, 0);
+  TestBuffers(src_facility_,0,0.5*cap,0,0);
 
   // Move first batch to stocks
   tc_.get()->time(residence_time);
-  TestReadyTime(src_facility_, 0);
+  TestReadyTime(src_facility_,0);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, 0.3 * cap, 0, 0.2 * cap);
+  TestBuffers(src_facility_,0,0.3*cap,0,0.2*cap);
 
-  tc_.get()->time(residence_time + 2);
+  tc_.get()->time(residence_time+2);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, 0, 0, 0.5 * cap);
+  TestBuffers(src_facility_,0,0,0,0.5*cap);
 }
+
 
 TEST_F(StorageTest, ChangeCapacity) {
   // src_facility_->discrete_handling_(0);
@@ -255,123 +263,124 @@ TEST_F(StorageTest, ChangeCapacity) {
   cyclus::Material::Ptr mat1 = cyclus::Material::CreateUntracked(cap1, rec);
   TestAddMat(src_facility_, mat1);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, cap1, 0, 0);
+  TestBuffers(src_facility_,0,cap1,0,0);
 
   // Increase throughput, add second and third batches
   tc_.get()->time(2);
   throughput = 500;
   SetUpStorage();
   double cap2 = throughput;
-  cyclus::Material::Ptr mat2 = cyclus::Material::CreateUntracked(cap2, rec);
+  cyclus::Material::Ptr mat2 = cyclus::Material::CreateUntracked(cap2,rec);
   TestAddMat(src_facility_, mat2);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, cap2 + cap1, 0, 0);
+  TestBuffers(src_facility_,0,cap2+cap1,0,0);
   tc_.get()->time(3);
-  cyclus::Material::Ptr mat3 = cyclus::Material::CreateUntracked(cap2, rec);
+  cyclus::Material::Ptr mat3 = cyclus::Material::CreateUntracked(cap2,rec);
   TestAddMat(src_facility_, mat3);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, cap2 * 2 + cap1, 0, 0);
+  TestBuffers(src_facility_,0,cap2*2+cap1,0,0);
 
   // Move first batch to stocks
   tc_.get()->time(residence_time);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, 2 * cap2, 0, cap1);
+  TestBuffers(src_facility_,0,2*cap2,0,cap1);
 
   // Decrease throughput and move portion of second batch to stocks
   throughput = 400;
   SetUpStorage();
-  tc_.get()->time(residence_time + 2);
+  tc_.get()->time(residence_time+2);
   EXPECT_EQ(400, throughput);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, cap2, 100, cap1 + 400);
+  TestBuffers(src_facility_,0,cap2,100,cap1+400);
 
   // Continue to move second batch // and portion of third
-  tc_.get()->time(residence_time + 3);
+  tc_.get()->time(residence_time+3);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, 0, 200, cap1 + cap2 + 300);
+  TestBuffers(src_facility_,0,0,200,cap1+cap2+300);
 
   // Move remainder of third batch
-  tc_.get()->time(residence_time + 4);
+  tc_.get()->time(residence_time+4);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, 0, 0, cap1 + cap2 + cap2);
+  TestBuffers(src_facility_,0,0,0,cap1+cap2+cap2);
+
 }
 
 TEST_F(StorageTest, TwoBatchSameTime) {
   // Add first small batch
   double cap = throughput;
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
-  cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(0.2 * cap, rec);
+  cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(0.2*cap, rec);
   TestAddMat(src_facility_, mat);
 
   // After add, material is in inventory
-  TestBuffers(src_facility_, 0.2 * cap, 0, 0, 0);
-  cyclus::Material::Ptr mat1 =
-      cyclus::Material::CreateUntracked(0.2 * cap, rec);
+  TestBuffers(src_facility_,0.2*cap,0,0,0);
+  cyclus::Material::Ptr mat1 = cyclus::Material::CreateUntracked(0.2*cap, rec);
   TestAddMat(src_facility_, mat1);
-  TestBuffers(src_facility_, 0.4 * cap, 0, 0, 0);
+  TestBuffers(src_facility_,0.4*cap,0,0,0);
 
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, 0.4 * cap, 0, 0);
+  TestBuffers(src_facility_,0,0.4*cap,0,0);
 
   // Move material to stocks
   tc_.get()->time(residence_time);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, 0, 0, 0.4 * cap);
+  TestBuffers(src_facility_,0,0,0,0.4*cap);
 }
 
-TEST_F(StorageTest, ChangeProcessTime) {
+TEST_F(StorageTest,ChangeProcessTime){
   // Initialize process time variable and add first batch
   int proc_time1 = residence_time;
   double cap = throughput;
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
   cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(cap, rec);
   TestAddMat(src_facility_, mat);
-  TestBuffers(src_facility_, cap, 0, 0, 0);
+  TestBuffers(src_facility_,cap,0,0,0);
 
   // Move material to processing
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, cap, 0, 0);
+  TestBuffers(src_facility_,0,cap,0,0);
 
   // Add second batch
-  cyclus::Material::Ptr mat1 = cyclus::Material::CreateUntracked(cap, rec);
+  cyclus::Material::Ptr mat1 = cyclus::Material::CreateUntracked(cap,rec);
   tc_.get()->time(8);
-  TestAddMat(src_facility_, mat1);
-  TestBuffers(src_facility_, cap, cap, 0, 0);
+  TestAddMat(src_facility_,mat1);
+  TestBuffers(src_facility_,cap,cap,0,0);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, 2 * cap, 0, 0);
+  TestBuffers(src_facility_,0,2*cap,0,0);
 
   // Increase process time
-  residence_time = proc_time1 + 5;
+  residence_time = proc_time1+5;
   SetUpStorage();
   // src_facility_->residence_time = proc_time1+5;
-  EXPECT_EQ(residence_time, proc_time1 + 5);
-  EXPECT_EQ(residence_time, 15);
+  EXPECT_EQ(residence_time,proc_time1+5);
+  EXPECT_EQ(residence_time,15);
   int proc_time2 = residence_time;
 
   // Make sure material doesn't move before new process time
-  for (int i = proc_time1; i < proc_time2 - 1; ++i) {
-    tc_.get()->time(i);
-    EXPECT_NO_THROW(src_facility_->Tock());
-    TestBuffers(src_facility_, 0, 2 * cap, 0, 0);
+  for( int i=proc_time1; i < proc_time2 - 1; ++i){
+  tc_.get()->time(i);
+  EXPECT_NO_THROW(src_facility_->Tock());
+  TestBuffers(src_facility_,0,2*cap,0,0);
   }
 
   // Move first batch to stocks
   tc_.get()->time(proc_time2);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, cap, 0, cap);
+  TestBuffers(src_facility_,0,cap,0,cap);
 
   // Decrease process time
-  residence_time = proc_time2 - 3;
+  residence_time = proc_time2-3;
   SetUpStorage();
   int proc_time3 = residence_time;
 
   // Move second batch to stocks
-  tc_.get()->time(proc_time3 + 8);
+  tc_.get()->time(proc_time3 +8);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, 0, 0, 2 * cap);
+  TestBuffers(src_facility_,0,0,0,2*cap);
+
 }
 
-TEST_F(StorageTest, DifferentRecipe) {
+TEST_F(StorageTest,DifferentRecipe){
   // Initialize material with different recipe than in_recipe
   double cap = throughput;
   cyclus::CompMap v;
@@ -382,26 +391,26 @@ TEST_F(StorageTest, DifferentRecipe) {
 
   // Move material through the facility
   TestAddMat(src_facility_, mat);
-  TestBuffers(src_facility_, cap, 0, 0, 0);
+  TestBuffers(src_facility_,cap,0,0,0);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, cap, 0, 0);
+  TestBuffers(src_facility_,0,cap,0,0);
   tc_.get()->time(residence_time);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_, 0, 0, 0, cap);
+  TestBuffers(src_facility_,0,0,0,cap);
 }
 
-TEST_F(StorageTest, BehaviorTest) {
+TEST_F(StorageTest, BehaviorTest){
   // Verify Storage behavior
 
   std::string config =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <residence_time>1</residence_time>"
-      "   <max_inv_size>10</max_inv_size>";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <residence_time>1</residence_time>"
+    "   <max_inv_size>10</max_inv_size>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -414,22 +423,23 @@ TEST_F(StorageTest, BehaviorTest) {
   cyclus::QueryResult qr = sim.db().Query("Transactions", &conds);
   int n_trans = qr.rows.size();
   EXPECT_EQ(1, n_trans) << "expected 1 transactions, got " << n_trans;
+
 }
 
-TEST_F(StorageTest, MultipleCommods) {
+TEST_F(StorageTest, MultipleCommods){
   // Verify Storage accepting Multiple Commods
 
   std::string config =
-      "   <in_commods> <val>spent_fuel</val>"
-      "                <val>spent_fuel2</val> </in_commods>"
-      "   <in_commod_prefs> <val>1</val>"
-      "                     <val>1</val> </in_commod_prefs>"
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <max_inv_size>10</max_inv_size>";
+    "   <in_commods> <val>spent_fuel</val>"
+    "                <val>spent_fuel2</val> </in_commods>"
+    "   <in_commod_prefs> <val>1</val>"
+    "                     <val>1</val> </in_commod_prefs>"
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <max_inv_size>10</max_inv_size>";
 
   int simdur = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSource("spent_fuel2").capacity(5).Finalize();
@@ -451,19 +461,20 @@ TEST_F(StorageTest, MultipleCommods) {
   EXPECT_EQ(1, n_trans2) << "expected 1 transactions, got " << n_trans;
 }
 
+
 // Should get one transaction in a 2 step simulation when agent is active for
 // one step and dormant for one step
-TEST_F(StorageTest, ActiveDormant) {
+TEST_F(StorageTest, ActiveDormant){
   std::string config =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <throughput>1</throughput>"
-      "   <active_buying_val>1</active_buying_val>"
-      "   <dormant_buying_val>1</dormant_buying_val>";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <throughput>1</throughput>"
+    "   <active_buying_val>1</active_buying_val>"
+    "   <dormant_buying_val>1</dormant_buying_val>";
 
   int simdur = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -476,23 +487,23 @@ TEST_F(StorageTest, ActiveDormant) {
   cyclus::QueryResult qr = sim.db().Query("Transactions", &conds);
   int n_trans = qr.rows.size();
   EXPECT_EQ(1, n_trans) << "expected 1 transactions, got " << n_trans;
-}
+ }
 
-// Should get two transactions in a 2 step simulation when there is no
-// dormant period, i.e. agent is always active
-TEST_F(StorageTest, NoDormant) {
+  // Should get two transactions in a 2 step simulation when there is no 
+  // dormant period, i.e. agent is always active
+TEST_F(StorageTest, NoDormant){
   std::string config =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <throughput>1</throughput>"
-      "   <active_buying_frequency_type>Fixed</active_buying_frequency_type>"
-      "   <active_buying_val>1</active_buying_val>"
-      "   <dormant_buying_frequency_type>Fixed</dormant_buying_frequency_type>"
-      "   <dormant_buying_val>-1</dormant_buying_val>";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <throughput>1</throughput>"
+    "   <active_buying_frequency_type>Fixed</active_buying_frequency_type>"
+    "   <active_buying_val>1</active_buying_val>"
+    "   <dormant_buying_frequency_type>Fixed</dormant_buying_frequency_type>"
+    "   <dormant_buying_val>-1</dormant_buying_val>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -504,23 +515,23 @@ TEST_F(StorageTest, NoDormant) {
   cyclus::QueryResult qr = sim.db().Query("Transactions", &conds);
   int n_trans = qr.rows.size();
   EXPECT_EQ(3, n_trans) << "expected 3 transactions, got " << n_trans;
-}
+ }
 
-TEST_F(StorageTest, UniformActiveNormalDormant) {
+TEST_F(StorageTest, UniformActiveNormalDormant){
   std::string config =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <throughput>1</throughput>"
-      "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>"
-      "   <active_buying_min>2</active_buying_min>"
-      "   <active_buying_max>3</active_buying_max>"
-      "   <dormant_buying_frequency_type>Normal</dormant_buying_frequency_type>"
-      "   <dormant_buying_mean>5</dormant_buying_mean>"
-      "   <dormant_buying_stddev>1</dormant_buying_stddev>";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <throughput>1</throughput>"
+    "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>"
+    "   <active_buying_min>2</active_buying_min>"
+    "   <active_buying_max>3</active_buying_max>"
+    "   <dormant_buying_frequency_type>Normal</dormant_buying_frequency_type>"
+    "   <dormant_buying_mean>5</dormant_buying_mean>"
+    "   <dormant_buying_stddev>1</dormant_buying_stddev>";
 
   int simdur = 20;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -542,18 +553,17 @@ TEST_F(StorageTest, UniformActiveNormalDormant) {
 
 TEST_F(StorageTest, BinomialActiveDormant) {
   std::string config =
-      "   <in_commods> <val>commod</val> </in_commods> "
-      "   <out_commods> <val>commod1</val> </out_commods> "
-      "   <throughput>1</throughput>"
-      "   <active_buying_frequency_type>Binomial</active_buying_frequency_type>"
-      "   <active_buying_end_probability>0.2</active_buying_end_probability>"
-      "   "
-      "<dormant_buying_frequency_type>Binomial</dormant_buying_frequency_type>"
-      "   <dormant_buying_end_probability>0.3</dormant_buying_end_probability>";
+  "   <in_commods> <val>commod</val> </in_commods> "
+  "   <out_commods> <val>commod1</val> </out_commods> "
+  "   <throughput>1</throughput>"
+  "   <active_buying_frequency_type>Binomial</active_buying_frequency_type>"
+  "   <active_buying_end_probability>0.2</active_buying_end_probability>"
+  "   <dormant_buying_frequency_type>Binomial</dormant_buying_frequency_type>"
+  "   <dormant_buying_end_probability>0.3</dormant_buying_end_probability>";
 
   int simdur = 30;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
   sim.AddSource("commod").capacity(5).Finalize();
 
   int id = sim.Run();
@@ -573,29 +583,21 @@ TEST_F(StorageTest, BinomialActiveDormant) {
 
 TEST_F(StorageTest, DisruptionActiveDormant) {
   std::string config =
-      "    <in_commods><val>commod</val></in_commods>"
-      "    <out_commods><val>commod1</val></out_commods>"
-      "    <throughput>1</throughput>"
-      "    "
-      "<active_buying_frequency_type>FixedWithDisruption</"
-      "active_buying_frequency_type>"
-      "    "
-      "<active_buying_disruption_probability>0.4</"
-      "active_buying_disruption_probability>"
-      "    <active_buying_val>2</active_buying_val>"
-      "    <active_buying_disruption>5</active_buying_disruption>"
-      "    "
-      "<dormant_buying_frequency_type>FixedWithDisruption</"
-      "dormant_buying_frequency_type>"
-      "    "
-      "<dormant_buying_disruption_probability>0.5</"
-      "dormant_buying_disruption_probability>"
-      "    <dormant_buying_val>1</dormant_buying_val>"
-      "    <dormant_buying_disruption>10</dormant_buying_disruption>";
+  "    <in_commods><val>commod</val></in_commods>"
+  "    <out_commods><val>commod1</val></out_commods>"
+  "    <throughput>1</throughput>"
+  "    <active_buying_frequency_type>FixedWithDisruption</active_buying_frequency_type>"
+  "    <active_buying_disruption_probability>0.4</active_buying_disruption_probability>"
+  "    <active_buying_val>2</active_buying_val>"
+  "    <active_buying_disruption>5</active_buying_disruption>"
+  "    <dormant_buying_frequency_type>FixedWithDisruption</dormant_buying_frequency_type>"
+  "    <dormant_buying_disruption_probability>0.5</dormant_buying_disruption_probability>"
+  "    <dormant_buying_val>1</dormant_buying_val>"
+  "    <dormant_buying_disruption>10</dormant_buying_disruption>";
 
   int simdur = 50;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
   sim.AddSource("commod").capacity(5).Finalize();
   int id = sim.Run();
 
@@ -603,29 +605,29 @@ TEST_F(StorageTest, DisruptionActiveDormant) {
   // confirm that transactions are only occurring during active periods
   // first active length = 5 (disrupted)
   EXPECT_EQ(0, qr.GetVal<int>("Time", 0));
-  EXPECT_EQ(1, qr.GetVal<int>("Time", 1));  // ... end of active
-
+  EXPECT_EQ(1, qr.GetVal<int>("Time", 1)); // ... end of active
+  
   // first dormant length = 1 (not disrupted)
   // second active length = 2 (not disrupted)
-  EXPECT_EQ(3, qr.GetVal<int>("Time", 2));  // ... end of dormant
+  EXPECT_EQ(3, qr.GetVal<int>("Time", 2)); // ... end of dormant
   EXPECT_EQ(4, qr.GetVal<int>("Time", 3));
-
+  
   // second dormant length = 10 (disrupted)
   // third active length = 2 (not disrupted)
-  EXPECT_EQ(15, qr.GetVal<int>("Time", 4));  // ... end of second active
+  EXPECT_EQ(15, qr.GetVal<int>("Time", 4)); // ... end of second active
 }
 
-TEST_F(StorageTest, FixedBuyingSize) {
+TEST_F(StorageTest, FixedBuyingSize){
   std::string config =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <throughput>1</throughput>"
-      "   <buying_size_type>Fixed</buying_size_type>"
-      "   <buying_size_val>0.5</buying_size_val>";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <throughput>1</throughput>"
+    "   <buying_size_type>Fixed</buying_size_type>"
+    "   <buying_size_val>0.5</buying_size_val>";
 
   int simdur = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
   int id = sim.Run();
@@ -635,18 +637,18 @@ TEST_F(StorageTest, FixedBuyingSize) {
   EXPECT_NEAR(0.5, qr.GetVal<double>("Quantity", 1), 0.00001);
 }
 
-TEST_F(StorageTest, UniformBuyingSize) {
+TEST_F(StorageTest, UniformBuyingSize){
   std::string config =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <throughput>1</throughput>"
-      "   <buying_size_type>Uniform</buying_size_type>"
-      "   <buying_size_min>0.5</buying_size_min>"
-      "   <buying_size_max>0.7</buying_size_max>";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <throughput>1</throughput>"
+    "   <buying_size_type>Uniform</buying_size_type>"
+    "   <buying_size_min>0.5</buying_size_min>"
+    "   <buying_size_max>0.7</buying_size_max>";
 
   int simdur = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
   int id = sim.Run();
@@ -656,18 +658,18 @@ TEST_F(StorageTest, UniformBuyingSize) {
   EXPECT_NEAR(0.68825, qr.GetVal<double>("Quantity", 1), 0.00001);
 }
 
-TEST_F(StorageTest, NormalBuyingSize) {
+TEST_F(StorageTest, NormalBuyingSize){
   std::string config =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <throughput>1</throughput>"
-      "   <buying_size_type>Normal</buying_size_type>"
-      "   <buying_size_mean>0.5</buying_size_mean>"
-      "   <buying_size_stddev>0.1</buying_size_stddev>";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <throughput>1</throughput>"
+    "   <buying_size_type>Normal</buying_size_type>"
+    "   <buying_size_mean>0.5</buying_size_mean>"
+    "   <buying_size_stddev>0.1</buying_size_stddev>";
 
   int simdur = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
 
@@ -678,24 +680,24 @@ TEST_F(StorageTest, NormalBuyingSize) {
   EXPECT_NEAR(0.32648, qr.GetVal<double>("Quantity", 1), 0.00001);
 }
 
-TEST_F(StorageTest, NormalActiveDormantBuyingSize) {
-  std::string config =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <throughput>1</throughput>"
-      "   <active_buying_frequency_type>Normal</active_buying_frequency_type>"
-      "   <active_buying_mean>3</active_buying_mean>"
-      "   <active_buying_stddev>1</active_buying_stddev>"
-      "   <dormant_buying_frequency_type>Normal</dormant_buying_frequency_type>"
-      "   <dormant_buying_mean>2</dormant_buying_mean>"
-      "   <dormant_buying_stddev>1</dormant_buying_stddev>"
-      "   <buying_size_type>Normal</buying_size_type>"
-      "   <buying_size_mean>0.5</buying_size_mean>"
-      "   <buying_size_stddev>0.1</buying_size_stddev>";
+TEST_F(StorageTest, NormalActiveDormantBuyingSize){
+    std::string config =
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <throughput>1</throughput>"
+    "   <active_buying_frequency_type>Normal</active_buying_frequency_type>"
+    "   <active_buying_mean>3</active_buying_mean>"
+    "   <active_buying_stddev>1</active_buying_stddev>"
+    "   <dormant_buying_frequency_type>Normal</dormant_buying_frequency_type>"
+    "   <dormant_buying_mean>2</dormant_buying_mean>"
+    "   <dormant_buying_stddev>1</dormant_buying_stddev>"
+    "   <buying_size_type>Normal</buying_size_type>"
+    "   <buying_size_mean>0.5</buying_size_mean>"
+    "   <buying_size_stddev>0.1</buying_size_stddev>";
 
   int simdur = 15;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -730,61 +732,61 @@ TEST_F(StorageTest, NormalActiveDormantBuyingSize) {
 TEST_F(StorageTest, IncorrectBuyPolSetupUniform) {
   // uniform missing min and max
   std::string config_uniform =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <throughput>1</throughput>"
-      "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <throughput>1</throughput>"
+    "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>";
 
   int simdur = 15;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config_uniform,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config_uniform,
+                                         simdur);
   EXPECT_THROW(sim.Run(), cyclus::ValueError);
 }
 
 TEST_F(StorageTest, IncorrectBuyPolSetupNormal) {
   // normal missing mean and std dev
   std::string config_normal =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <throughput>1</throughput>"
-      "   <active_buying_frequency_type>Normal</active_buying_frequency_type>";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <throughput>1</throughput>"
+    "   <active_buying_frequency_type>Normal</active_buying_frequency_type>";
   int simdur = 15;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config_normal,
-                      simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config_normal,
+                                         simdur);
   EXPECT_THROW(sim.Run(), cyclus::ValueError);
 }
 
 TEST_F(StorageTest, IncorrectBuyPolSetupMinMax) {
   // tries to set min > max
   std::string config_uniform_min_bigger_max =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <throughput>1</throughput>"
-      "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>"
-      "   <active_buying_min>3</active_buying_min>"
-      "   <active_buying_max>2</active_buying_max>";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <throughput>1</throughput>"
+    "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>"
+    "   <active_buying_min>3</active_buying_min>"
+    "   <active_buying_max>2</active_buying_max>";
 
   int simdur = 15;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"),
-                      config_uniform_min_bigger_max, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), 
+                                         config_uniform_min_bigger_max, simdur);
   EXPECT_THROW(sim.Run(), cyclus::ValueError);
 }
 
-TEST_F(StorageTest, PositionInitialize) {
+TEST_F(StorageTest, PositionInitialize){
   // Verify Storage behavior
 
   std::string config =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <residence_time>1</residence_time>"
-      "   <max_inv_size>10</max_inv_size>";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <residence_time>1</residence_time>"
+    "   <max_inv_size>10</max_inv_size>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -796,20 +798,20 @@ TEST_F(StorageTest, PositionInitialize) {
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 0.0);
 }
 
-TEST_F(StorageTest, Longitude) {
+TEST_F(StorageTest, Longitude){
   // Verify Storage behavior
 
   std::string config =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <residence_time>1</residence_time>"
-      "   <max_inv_size>10</max_inv_size>"
-      "   <latitude>50.0</latitude> "
-      "   <longitude>35.0</longitude> ";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <residence_time>1</residence_time>"
+    "   <max_inv_size>10</max_inv_size>"
+    "   <latitude>50.0</latitude> "
+    "   <longitude>35.0</longitude> ";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -823,14 +825,14 @@ TEST_F(StorageTest, Longitude) {
 
 TEST_F(StorageTest, RQ_Inventory_Invalid) {
   std::string config =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <max_inv_size>5</max_inv_size>"
-      "   <reorder_point>2</reorder_point>"
-      "   <reorder_quantity>10</reorder_quantity>";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <max_inv_size>5</max_inv_size>"
+    "   <reorder_point>2</reorder_point>"
+    "   <reorder_quantity>10</reorder_quantity>";
 
   int simdur = 2;
-
+ 
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   EXPECT_THROW(int id = sim.Run(), cyclus::ValueError);
@@ -838,15 +840,15 @@ TEST_F(StorageTest, RQ_Inventory_Invalid) {
 
 TEST_F(StorageTest, RQ_Inventory) {
   std::string config =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <max_inv_size>5</max_inv_size>"
-      "   <reorder_point>2</reorder_point>"
-      "   <reorder_quantity>3</reorder_quantity>";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <max_inv_size>5</max_inv_size>"
+    "   <reorder_point>2</reorder_point>"
+    "   <reorder_quantity>3</reorder_quantity>";
 
   int simdur = 5;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -871,14 +873,14 @@ TEST_F(StorageTest, RQ_Inventory) {
 
 TEST_F(StorageTest, sS_Inventory) {
   std::string config =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <max_inv_size>5</max_inv_size>"
-      "   <reorder_point>2</reorder_point>";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <max_inv_size>5</max_inv_size>"
+    "   <reorder_point>2</reorder_point>";
 
   int simdur = 5;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -902,16 +904,16 @@ TEST_F(StorageTest, sS_Inventory) {
 
 TEST_F(StorageTest, CCap_Inventory) {
   std::string config =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <throughput>1</throughput> "
-      "   <cumulative_cap>2</cumulative_cap> "
-      "   <dormant_buying_frequency_type>Fixed</dormant_buying_frequency_type> "
-      "   <dormant_buying_val>2</dormant_buying_val> ";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <throughput>1</throughput> "
+    "   <cumulative_cap>2</cumulative_cap> "
+    "   <dormant_buying_frequency_type>Fixed</dormant_buying_frequency_type> "
+    "   <dormant_buying_val>2</dormant_buying_val> ";
 
   int simdur = 9;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -939,13 +941,13 @@ TEST_F(StorageTest, CCap_Inventory) {
 TEST_F(StorageTest, PackageExactly) {
   // resource can be packaged without splitting or merging
   std::string config =
-      "   <in_commods> <val>spent_fuel</val> </in_commods> "
-      "   <out_commods> <val>dry_spent</val> </out_commods> "
-      "   <package>foo</package>";
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <package>foo</package>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
   sim.context()->AddPackage("foo", 1, 2, "first");
   cyclus::Package::Ptr p = sim.context()->GetPackage("foo");
 
@@ -975,13 +977,13 @@ TEST_F(StorageTest, PackageExactly) {
 TEST_F(StorageTest, PackageSplitEqual) {
   // Resources must be split into two to package. Packaging strategy equal
   std::string config =
-      "   <in_commods> <val>commodity</val> </in_commods> "
-      "   <out_commods> <val>commodity1</val> </out_commods> "
-      "   <package>foo</package>";
+    "   <in_commods> <val>commodity</val> </in_commods> "
+    "   <out_commods> <val>commodity1</val> </out_commods> "
+    "   <package>foo</package>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
   sim.context()->AddPackage("foo", 1, 2, "equal");
   cyclus::Package::Ptr p = sim.context()->GetPackage("foo");
 
@@ -991,10 +993,9 @@ TEST_F(StorageTest, PackageSplitEqual) {
   int id = sim.Run();
 
   std::vector<cyclus::Cond> tr_conds;
-  tr_conds.push_back(
-      cyclus::Cond("Commodity", "==", std::string("commodity1")));
+  tr_conds.push_back(cyclus::Cond("Commodity", "==", std::string("commodity1")));
   cyclus::QueryResult qr_trans = sim.db().Query("Transactions", &tr_conds);
-  // four transactions out of storage. Each resource is split, so two
+  // four transactions out of storage. Each resource is split, so two 
   // transactions at time 1, two at time 2
   EXPECT_EQ(4, qr_trans.rows.size());
 
@@ -1017,13 +1018,13 @@ TEST_F(StorageTest, PackageSplitEqual) {
 TEST_F(StorageTest, PackageSplitFirst) {
   // Resources must be split into two to package. Packaging strategy first
   std::string config =
-      "   <in_commods> <val>commodity</val> </in_commods> "
-      "   <out_commods> <val>commodity1</val> </out_commods> "
-      "   <package>foo</package>";
+    "   <in_commods> <val>commodity</val> </in_commods> "
+    "   <out_commods> <val>commodity1</val> </out_commods> "
+    "   <package>foo</package>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
   sim.context()->AddPackage("foo", 1, 2, "first");
   cyclus::Package::Ptr p = sim.context()->GetPackage("foo");
 
@@ -1033,10 +1034,9 @@ TEST_F(StorageTest, PackageSplitFirst) {
   int id = sim.Run();
 
   std::vector<cyclus::Cond> tr_conds;
-  tr_conds.push_back(
-      cyclus::Cond("Commodity", "==", std::string("commodity1")));
+  tr_conds.push_back(cyclus::Cond("Commodity", "==", std::string("commodity1")));
   cyclus::QueryResult qr_trans = sim.db().Query("Transactions", &tr_conds);
-  // four transactions out of storage. Each resource is split, so two
+  // four transactions out of storage. Each resource is split, so two 
   // transactions at time 1, two at time 2
   EXPECT_EQ(4, qr_trans.rows.size());
 
@@ -1051,17 +1051,17 @@ TEST_F(StorageTest, PackageSplitFirst) {
   // because package does split-first, resources are size 2 and 1
   EXPECT_EQ(qr_res.rows.size(), 4);
 
-  // order of trade execution is not guaranteed. Therefore, create vector,
+  // order of trade execution is not guaranteed. Therefore, create vector, 
   // sort by size, and then check values
   std::vector<double> pkgd_t0 = {qr_res.GetVal<double>("Quantity", 0),
-                                 qr_res.GetVal<double>("Quantity", 1)};
+                                    qr_res.GetVal<double>("Quantity", 1)};
   std::sort(pkgd_t0.begin(), pkgd_t0.end(), std::greater<double>());
   std::vector<double> exp_t0 = {2, 1};
 
   EXPECT_EQ(exp_t0, pkgd_t0);
 
   std::vector<double> pkgd_t1 = {qr_res.GetVal<double>("Quantity", 2),
-                                 qr_res.GetVal<double>("Quantity", 3)};
+                                    qr_res.GetVal<double>("Quantity", 3)};
   std::sort(pkgd_t1.begin(), pkgd_t1.end(), std::greater<double>());
   std::vector<double> exp_t1 = {2, 1};
 
@@ -1070,14 +1070,14 @@ TEST_F(StorageTest, PackageSplitFirst) {
 
 TEST_F(StorageTest, PackageMerge) {
   std::string config =
-      "   <in_commods> <val>commodity</val> </in_commods> "
-      "   <out_commods> <val>commodity1</val> </out_commods> "
-      "   <throughput>1</throughput> "
-      "   <package>foo</package>";
+    "   <in_commods> <val>commodity</val> </in_commods> "
+    "   <out_commods> <val>commodity1</val> </out_commods> "
+    "   <throughput>1</throughput> "
+    "   <package>foo</package>";
 
   int simdur = 5;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
   sim.context()->AddPackage("foo", 1, 2, "first");
   cyclus::Package::Ptr p = sim.context()->GetPackage("foo");
 
@@ -1087,8 +1087,7 @@ TEST_F(StorageTest, PackageMerge) {
   int id = sim.Run();
 
   std::vector<cyclus::Cond> tr_conds;
-  tr_conds.push_back(
-      cyclus::Cond("Commodity", "==", std::string("commodity1")));
+  tr_conds.push_back(cyclus::Cond("Commodity", "==", std::string("commodity1")));
 
   cyclus::QueryResult qr_trans = sim.db().Query("Transactions", &tr_conds);
   // two transactions out of storage. Because the source only provides 0.5 each
@@ -1109,16 +1108,16 @@ TEST_F(StorageTest, PackageMerge) {
 }
 
 TEST_F(StorageTest, TransportUnit) {
-  std::string config =
-      "   <in_commods> <val>commodity</val> </in_commods> "
-      "   <out_commods> <val>commodity1</val> </out_commods> "
-      "   <throughput>3</throughput> "
-      "   <package>foo</package>"
-      "   <transport_unit>bar</transport_unit>";
+    std::string config =
+    "   <in_commods> <val>commodity</val> </in_commods> "
+    "   <out_commods> <val>commodity1</val> </out_commods> "
+    "   <throughput>3</throughput> "
+    "   <package>foo</package>"
+    "   <transport_unit>bar</transport_unit>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
   sim.context()->AddPackage("foo", 1, 1, "first");
   cyclus::Package::Ptr p = sim.context()->GetPackage("foo");
   sim.context()->AddTransportUnit("bar", 2, 2, "first");
@@ -1129,8 +1128,7 @@ TEST_F(StorageTest, TransportUnit) {
   int id = sim.Run();
 
   std::vector<cyclus::Cond> tr_conds;
-  tr_conds.push_back(
-      cyclus::Cond("Commodity", "==", std::string("commodity1")));
+  tr_conds.push_back(cyclus::Cond("Commodity", "==", std::string("commodity1")));
 
   cyclus::QueryResult qr_trans = sim.db().Query("Transactions", &tr_conds);
   // 6 transactions. While all three units could be packaged in one time step,
@@ -1158,7 +1156,7 @@ TEST_F(StorageTest, TransportUnit) {
   EXPECT_EQ(1, qr_res.GetVal<double>("Quantity", 5));
 }
 
-}  // namespace cycamore
+} // namespace cycamore
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 cyclus::Agent* StorageConstructor(cyclus::Context* ctx) {
@@ -1170,11 +1168,11 @@ cyclus::Agent* StorageConstructor(cyclus::Context* ctx) {
 int ConnectAgentTests();
 static int cyclus_agent_tests_connected = ConnectAgentTests();
 #define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif  // CYCLUS_AGENT_TESTS_CONNECTED
+#endif // CYCLUS_AGENT_TESTS_CONNECTED
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_SUITE_P(StorageFac, FacilityTests,
-                         ::testing::Values(&StorageConstructor));
+                        ::testing::Values(&StorageConstructor));
 
 INSTANTIATE_TEST_SUITE_P(StorageFac, AgentTests,
-                         ::testing::Values(&StorageConstructor));
+                        ::testing::Values(&StorageConstructor));

--- a/src/storage_tests.cc
+++ b/src/storage_tests.cc
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include "storage_tests.h"
+
+#include <gtest/gtest.h>
 
 namespace cycamore {
 
@@ -15,7 +15,7 @@ void StorageTest::TearDown() {
   delete src_facility_;
 }
 
-void StorageTest::InitParameters(){
+void StorageTest::InitParameters() {
   in_r1 = "in_r1";
   in_c1.push_back("in_c1");
   out_c1.push_back("out_c1");
@@ -26,7 +26,6 @@ void StorageTest::InitParameters(){
   package = "foo";
   // Active period longer than any of the residence time related-tests needs
 
-
   cyclus::CompMap v;
   v[922350000] = 1;
   v[922380000] = 2;
@@ -34,7 +33,7 @@ void StorageTest::InitParameters(){
   tc_.get()->AddRecipe(in_r1, recipe);
 }
 
-void StorageTest::SetUpStorage(){
+void StorageTest::SetUpStorage() {
   src_facility_->in_recipe = in_r1;
   src_facility_->in_commods = in_c1;
   src_facility_->out_commods = out_c1;
@@ -46,7 +45,7 @@ void StorageTest::SetUpStorage(){
   src_facility_->package = package;
 }
 
-void StorageTest::TestInitState(Storage* fac){
+void StorageTest::TestInitState(Storage* fac) {
   EXPECT_EQ(residence_time, fac->residence_time);
   EXPECT_EQ(max_inv_size, fac->max_inv_size);
   EXPECT_EQ(throughput, fac->throughput);
@@ -54,8 +53,7 @@ void StorageTest::TestInitState(Storage* fac){
   EXPECT_EQ(package, fac->package);
 }
 
-void StorageTest::TestAddMat(Storage* fac,
-    cyclus::Material::Ptr mat){
+void StorageTest::TestAddMat(Storage* fac, cyclus::Material::Ptr mat) {
   double amt = mat->quantity();
   double before = fac->inventory.quantity();
   fac->AddMat_(mat);
@@ -63,8 +61,8 @@ void StorageTest::TestAddMat(Storage* fac,
   EXPECT_EQ(amt, after - before);
 }
 
-void StorageTest::TestBuffers(Storage* fac, double inv,
-    double proc, double ready, double stocks){
+void StorageTest::TestBuffers(Storage* fac, double inv, double proc,
+                              double ready, double stocks) {
   double t = tc_.get()->time();
 
   EXPECT_EQ(inv, fac->inventory.quantity());
@@ -73,29 +71,24 @@ void StorageTest::TestBuffers(Storage* fac, double inv,
   EXPECT_EQ(ready, fac->ready.quantity());
 }
 
-void StorageTest::TestStocks(Storage* fac, cyclus::CompMap v){
-
+void StorageTest::TestStocks(Storage* fac, cyclus::CompMap v) {
   cyclus::toolkit::ResBuf<cyclus::Material>* buffer = &fac->stocks;
   Material::Ptr final_mat = cyclus::ResCast<Material>(buffer->PopBack());
   cyclus::CompMap final_comp = final_mat->comp()->atom();
-  EXPECT_EQ(final_comp,v);
-
+  EXPECT_EQ(final_comp, v);
 }
 
-void StorageTest::TestCurrentCap(Storage* fac, double inv){
-
+void StorageTest::TestCurrentCap(Storage* fac, double inv) {
   EXPECT_EQ(inv, fac->current_capacity());
 }
 
-void StorageTest::TestReadyTime(Storage* fac, int t){
-
+void StorageTest::TestReadyTime(Storage* fac, int t) {
   EXPECT_EQ(t, fac->ready_time());
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(StorageTest, clone) {
-  Storage* cloned_fac =
-      dynamic_cast<Storage*> (src_facility_->Clone());
+  Storage* cloned_fac = dynamic_cast<Storage*>(src_facility_->Clone());
   TestInitState(cloned_fac);
 }
 
@@ -106,8 +99,8 @@ TEST_F(StorageTest, InitialState) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(StorageTest, CurrentCapacity){
-  TestCurrentCap(src_facility_,max_inv_size);
+TEST_F(StorageTest, CurrentCapacity) {
+  TestCurrentCap(src_facility_, max_inv_size);
   max_inv_size = cyclus::CY_LARGE_DOUBLE;
   SetUpStorage();
   TestInitState(src_facility_);
@@ -122,11 +115,12 @@ TEST_F(StorageTest, Print) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(StorageTest, AddMats) {
   double cap = max_inv_size;
-  cyclus::Material::Ptr mat = cyclus::NewBlankMaterial(0.5*cap);
+  cyclus::Material::Ptr mat = cyclus::NewBlankMaterial(0.5 * cap);
   TestAddMat(src_facility_, mat);
 
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
-  cyclus::Material::Ptr recmat = cyclus::Material::CreateUntracked(0.5*cap, rec);
+  cyclus::Material::Ptr recmat =
+      cyclus::Material::CreateUntracked(0.5 * cap, rec);
   TestAddMat(src_facility_, recmat);
 }
 
@@ -138,9 +132,8 @@ TEST_F(StorageTest, Tick) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(StorageTest, Tock) {
-
   // initially, nothing in the buffers
-  TestBuffers(src_facility_,0,0,0,0);
+  TestBuffers(src_facility_, 0, 0, 0, 0);
 
   double cap = throughput;
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
@@ -148,31 +141,30 @@ TEST_F(StorageTest, Tock) {
   TestAddMat(src_facility_, mat);
 
   // affter add, the inventory has the material
-  TestBuffers(src_facility_,cap,0,0,0);
+  TestBuffers(src_facility_, cap, 0, 0, 0);
 
   EXPECT_NO_THROW(src_facility_->Tock());
 
   // after tock, the processing buffer has the material
-  TestBuffers(src_facility_,0,cap,0,0);
+  TestBuffers(src_facility_, 0, cap, 0, 0);
 
   EXPECT_EQ(0, tc_.get()->time());
-  for( int i = 1; i < residence_time-1; ++i){
+  for (int i = 1; i < residence_time - 1; ++i) {
     tc_.get()->time(i);
     EXPECT_NO_THROW(src_facility_->Tock());
-    TestBuffers(src_facility_,0,cap,0,0);
+    TestBuffers(src_facility_, 0, cap, 0, 0);
   }
 
   tc_.get()->time(residence_time);
   EXPECT_EQ(residence_time, tc_.get()->time());
-  TestReadyTime(src_facility_,0);
+  TestReadyTime(src_facility_, 0);
   src_facility_->Tock();
-  TestBuffers(src_facility_,0,0,0,cap);
+  TestBuffers(src_facility_, 0, 0, 0, cap);
 
-  tc_.get()->time(residence_time+1);
-  TestReadyTime(src_facility_,1);
+  tc_.get()->time(residence_time + 1);
+  TestReadyTime(src_facility_, 1);
   src_facility_->Tock();
-  TestBuffers(src_facility_,0,0,0,cap);
-
+  TestBuffers(src_facility_, 0, 0, 0, cap);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -188,16 +180,16 @@ TEST_F(StorageTest, NoProcessTime) {
   TestAddMat(src_facility_, mat);
 
   // affter add, the inventory has the material
-  TestBuffers(src_facility_,cap,0,0,0);
+  TestBuffers(src_facility_, cap, 0, 0, 0);
 
   EXPECT_NO_THROW(src_facility_->Tock());
 
   // affter tock, the stocks have the material
-  TestBuffers(src_facility_,0,0,0,cap);
+  TestBuffers(src_facility_, 0, 0, 0, cap);
 }
 
 TEST_F(StorageTest, NoConvert) {
-// Make sure no conversion occurs
+  // Make sure no conversion occurs
   double cap = throughput;
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
   cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(cap, rec);
@@ -206,51 +198,51 @@ TEST_F(StorageTest, NoConvert) {
   EXPECT_NO_THROW(src_facility_->Tock());
 
   tc_.get()->time(residence_time);
-  TestReadyTime(src_facility_,0);
+  TestReadyTime(src_facility_, 0);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0,0,cap);
+  TestBuffers(src_facility_, 0, 0, 0, cap);
   cyclus::CompMap in_rec;
   in_rec[922350000] = 1;
   in_rec[922380000] = 2;
-  TestStocks(src_facility_,in_rec);
+  TestStocks(src_facility_, in_rec);
 }
 
 TEST_F(StorageTest, MultipleSmallBatches) {
   // Add first small batch
   double cap = throughput;
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
-  cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(0.2*cap, rec);
+  cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(0.2 * cap, rec);
   TestAddMat(src_facility_, mat);
 
   // After add, material is in inventory
-  TestBuffers(src_facility_,0.2*cap,0,0,0);
+  TestBuffers(src_facility_, 0.2 * cap, 0, 0, 0);
 
   // Move first batch into processing
   src_facility_->Tock();
-  TestBuffers(src_facility_,0,0.2*cap,0,0);
+  TestBuffers(src_facility_, 0, 0.2 * cap, 0, 0);
 
   // Add second small batch
   tc_.get()->time(2);
   src_facility_->Tock();
-  cyclus::Material::Ptr mat1 = cyclus::Material::CreateUntracked(0.3*cap, rec);
-  TestAddMat(src_facility_,mat1);
-  TestBuffers(src_facility_,0.3*cap,0.2*cap,0,0);
+  cyclus::Material::Ptr mat1 =
+      cyclus::Material::CreateUntracked(0.3 * cap, rec);
+  TestAddMat(src_facility_, mat1);
+  TestBuffers(src_facility_, 0.3 * cap, 0.2 * cap, 0, 0);
 
   // Move second batch into processing
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0.5*cap,0,0);
+  TestBuffers(src_facility_, 0, 0.5 * cap, 0, 0);
 
   // Move first batch to stocks
   tc_.get()->time(residence_time);
-  TestReadyTime(src_facility_,0);
+  TestReadyTime(src_facility_, 0);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0.3*cap,0,0.2*cap);
+  TestBuffers(src_facility_, 0, 0.3 * cap, 0, 0.2 * cap);
 
-  tc_.get()->time(residence_time+2);
+  tc_.get()->time(residence_time + 2);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0,0,0.5*cap);
+  TestBuffers(src_facility_, 0, 0, 0, 0.5 * cap);
 }
-
 
 TEST_F(StorageTest, ChangeCapacity) {
   // src_facility_->discrete_handling_(0);
@@ -263,124 +255,123 @@ TEST_F(StorageTest, ChangeCapacity) {
   cyclus::Material::Ptr mat1 = cyclus::Material::CreateUntracked(cap1, rec);
   TestAddMat(src_facility_, mat1);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,cap1,0,0);
+  TestBuffers(src_facility_, 0, cap1, 0, 0);
 
   // Increase throughput, add second and third batches
   tc_.get()->time(2);
   throughput = 500;
   SetUpStorage();
   double cap2 = throughput;
-  cyclus::Material::Ptr mat2 = cyclus::Material::CreateUntracked(cap2,rec);
+  cyclus::Material::Ptr mat2 = cyclus::Material::CreateUntracked(cap2, rec);
   TestAddMat(src_facility_, mat2);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,cap2+cap1,0,0);
+  TestBuffers(src_facility_, 0, cap2 + cap1, 0, 0);
   tc_.get()->time(3);
-  cyclus::Material::Ptr mat3 = cyclus::Material::CreateUntracked(cap2,rec);
+  cyclus::Material::Ptr mat3 = cyclus::Material::CreateUntracked(cap2, rec);
   TestAddMat(src_facility_, mat3);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,cap2*2+cap1,0,0);
+  TestBuffers(src_facility_, 0, cap2 * 2 + cap1, 0, 0);
 
   // Move first batch to stocks
   tc_.get()->time(residence_time);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,2*cap2,0,cap1);
+  TestBuffers(src_facility_, 0, 2 * cap2, 0, cap1);
 
   // Decrease throughput and move portion of second batch to stocks
   throughput = 400;
   SetUpStorage();
-  tc_.get()->time(residence_time+2);
+  tc_.get()->time(residence_time + 2);
   EXPECT_EQ(400, throughput);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,cap2,100,cap1+400);
+  TestBuffers(src_facility_, 0, cap2, 100, cap1 + 400);
 
   // Continue to move second batch // and portion of third
-  tc_.get()->time(residence_time+3);
+  tc_.get()->time(residence_time + 3);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0,200,cap1+cap2+300);
+  TestBuffers(src_facility_, 0, 0, 200, cap1 + cap2 + 300);
 
   // Move remainder of third batch
-  tc_.get()->time(residence_time+4);
+  tc_.get()->time(residence_time + 4);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0,0,cap1+cap2+cap2);
-
+  TestBuffers(src_facility_, 0, 0, 0, cap1 + cap2 + cap2);
 }
 
 TEST_F(StorageTest, TwoBatchSameTime) {
   // Add first small batch
   double cap = throughput;
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
-  cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(0.2*cap, rec);
+  cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(0.2 * cap, rec);
   TestAddMat(src_facility_, mat);
 
   // After add, material is in inventory
-  TestBuffers(src_facility_,0.2*cap,0,0,0);
-  cyclus::Material::Ptr mat1 = cyclus::Material::CreateUntracked(0.2*cap, rec);
+  TestBuffers(src_facility_, 0.2 * cap, 0, 0, 0);
+  cyclus::Material::Ptr mat1 =
+      cyclus::Material::CreateUntracked(0.2 * cap, rec);
   TestAddMat(src_facility_, mat1);
-  TestBuffers(src_facility_,0.4*cap,0,0,0);
+  TestBuffers(src_facility_, 0.4 * cap, 0, 0, 0);
 
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0.4*cap,0,0);
+  TestBuffers(src_facility_, 0, 0.4 * cap, 0, 0);
 
   // Move material to stocks
   tc_.get()->time(residence_time);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0,0,0.4*cap);
+  TestBuffers(src_facility_, 0, 0, 0, 0.4 * cap);
 }
 
-TEST_F(StorageTest,ChangeProcessTime){
+TEST_F(StorageTest, ChangeProcessTime) {
   // Initialize process time variable and add first batch
   int proc_time1 = residence_time;
   double cap = throughput;
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
   cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(cap, rec);
   TestAddMat(src_facility_, mat);
-  TestBuffers(src_facility_,cap,0,0,0);
+  TestBuffers(src_facility_, cap, 0, 0, 0);
 
   // Move material to processing
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,cap,0,0);
+  TestBuffers(src_facility_, 0, cap, 0, 0);
 
   // Add second batch
-  cyclus::Material::Ptr mat1 = cyclus::Material::CreateUntracked(cap,rec);
+  cyclus::Material::Ptr mat1 = cyclus::Material::CreateUntracked(cap, rec);
   tc_.get()->time(8);
-  TestAddMat(src_facility_,mat1);
-  TestBuffers(src_facility_,cap,cap,0,0);
+  TestAddMat(src_facility_, mat1);
+  TestBuffers(src_facility_, cap, cap, 0, 0);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,2*cap,0,0);
+  TestBuffers(src_facility_, 0, 2 * cap, 0, 0);
 
   // Increase process time
-  residence_time = proc_time1+5;
+  residence_time = proc_time1 + 5;
   SetUpStorage();
   // src_facility_->residence_time = proc_time1+5;
-  EXPECT_EQ(residence_time,proc_time1+5);
-  EXPECT_EQ(residence_time,15);
+  EXPECT_EQ(residence_time, proc_time1 + 5);
+  EXPECT_EQ(residence_time, 15);
   int proc_time2 = residence_time;
 
   // Make sure material doesn't move before new process time
-  for( int i=proc_time1; i < proc_time2 - 1; ++i){
-  tc_.get()->time(i);
-  EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,2*cap,0,0);
+  for (int i = proc_time1; i < proc_time2 - 1; ++i) {
+    tc_.get()->time(i);
+    EXPECT_NO_THROW(src_facility_->Tock());
+    TestBuffers(src_facility_, 0, 2 * cap, 0, 0);
   }
 
   // Move first batch to stocks
   tc_.get()->time(proc_time2);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,cap,0,cap);
+  TestBuffers(src_facility_, 0, cap, 0, cap);
 
   // Decrease process time
-  residence_time = proc_time2-3;
+  residence_time = proc_time2 - 3;
   SetUpStorage();
   int proc_time3 = residence_time;
 
   // Move second batch to stocks
-  tc_.get()->time(proc_time3 +8);
+  tc_.get()->time(proc_time3 + 8);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0,0,2*cap);
-
+  TestBuffers(src_facility_, 0, 0, 0, 2 * cap);
 }
 
-TEST_F(StorageTest,DifferentRecipe){
+TEST_F(StorageTest, DifferentRecipe) {
   // Initialize material with different recipe than in_recipe
   double cap = throughput;
   cyclus::CompMap v;
@@ -391,26 +382,26 @@ TEST_F(StorageTest,DifferentRecipe){
 
   // Move material through the facility
   TestAddMat(src_facility_, mat);
-  TestBuffers(src_facility_,cap,0,0,0);
+  TestBuffers(src_facility_, cap, 0, 0, 0);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,cap,0,0);
+  TestBuffers(src_facility_, 0, cap, 0, 0);
   tc_.get()->time(residence_time);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0,0,cap);
+  TestBuffers(src_facility_, 0, 0, 0, cap);
 }
 
-TEST_F(StorageTest, BehaviorTest){
+TEST_F(StorageTest, BehaviorTest) {
   // Verify Storage behavior
 
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <residence_time>1</residence_time>"
-    "   <max_inv_size>10</max_inv_size>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <residence_time>1</residence_time>"
+      "   <max_inv_size>10</max_inv_size>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -423,23 +414,22 @@ TEST_F(StorageTest, BehaviorTest){
   cyclus::QueryResult qr = sim.db().Query("Transactions", &conds);
   int n_trans = qr.rows.size();
   EXPECT_EQ(1, n_trans) << "expected 1 transactions, got " << n_trans;
-
 }
 
-TEST_F(StorageTest, MultipleCommods){
+TEST_F(StorageTest, MultipleCommods) {
   // Verify Storage accepting Multiple Commods
 
   std::string config =
-    "   <in_commods> <val>spent_fuel</val>"
-    "                <val>spent_fuel2</val> </in_commods>"
-    "   <in_commod_prefs> <val>1</val>"
-    "                     <val>1</val> </in_commod_prefs>"
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <max_inv_size>10</max_inv_size>";
+      "   <in_commods> <val>spent_fuel</val>"
+      "                <val>spent_fuel2</val> </in_commods>"
+      "   <in_commod_prefs> <val>1</val>"
+      "                     <val>1</val> </in_commod_prefs>"
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <max_inv_size>10</max_inv_size>";
 
   int simdur = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSource("spent_fuel2").capacity(5).Finalize();
@@ -461,20 +451,19 @@ TEST_F(StorageTest, MultipleCommods){
   EXPECT_EQ(1, n_trans2) << "expected 1 transactions, got " << n_trans;
 }
 
-
 // Should get one transaction in a 2 step simulation when agent is active for
 // one step and dormant for one step
-TEST_F(StorageTest, ActiveDormant){
+TEST_F(StorageTest, ActiveDormant) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <active_buying_val>1</active_buying_val>"
-    "   <dormant_buying_val>1</dormant_buying_val>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <active_buying_val>1</active_buying_val>"
+      "   <dormant_buying_val>1</dormant_buying_val>";
 
   int simdur = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -487,23 +476,23 @@ TEST_F(StorageTest, ActiveDormant){
   cyclus::QueryResult qr = sim.db().Query("Transactions", &conds);
   int n_trans = qr.rows.size();
   EXPECT_EQ(1, n_trans) << "expected 1 transactions, got " << n_trans;
- }
+}
 
-  // Should get two transactions in a 2 step simulation when there is no 
-  // dormant period, i.e. agent is always active
-TEST_F(StorageTest, NoDormant){
+// Should get two transactions in a 2 step simulation when there is no
+// dormant period, i.e. agent is always active
+TEST_F(StorageTest, NoDormant) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <active_buying_frequency_type>Fixed</active_buying_frequency_type>"
-    "   <active_buying_val>1</active_buying_val>"
-    "   <dormant_buying_frequency_type>Fixed</dormant_buying_frequency_type>"
-    "   <dormant_buying_val>-1</dormant_buying_val>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <active_buying_frequency_type>Fixed</active_buying_frequency_type>"
+      "   <active_buying_val>1</active_buying_val>"
+      "   <dormant_buying_frequency_type>Fixed</dormant_buying_frequency_type>"
+      "   <dormant_buying_val>-1</dormant_buying_val>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -515,23 +504,23 @@ TEST_F(StorageTest, NoDormant){
   cyclus::QueryResult qr = sim.db().Query("Transactions", &conds);
   int n_trans = qr.rows.size();
   EXPECT_EQ(3, n_trans) << "expected 3 transactions, got " << n_trans;
- }
+}
 
-TEST_F(StorageTest, UniformActiveNormalDormant){
+TEST_F(StorageTest, UniformActiveNormalDormant) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>"
-    "   <active_buying_min>2</active_buying_min>"
-    "   <active_buying_max>3</active_buying_max>"
-    "   <dormant_buying_frequency_type>Normal</dormant_buying_frequency_type>"
-    "   <dormant_buying_mean>5</dormant_buying_mean>"
-    "   <dormant_buying_stddev>1</dormant_buying_stddev>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>"
+      "   <active_buying_min>2</active_buying_min>"
+      "   <active_buying_max>3</active_buying_max>"
+      "   <dormant_buying_frequency_type>Normal</dormant_buying_frequency_type>"
+      "   <dormant_buying_mean>5</dormant_buying_mean>"
+      "   <dormant_buying_stddev>1</dormant_buying_stddev>";
 
   int simdur = 20;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -553,17 +542,18 @@ TEST_F(StorageTest, UniformActiveNormalDormant){
 
 TEST_F(StorageTest, BinomialActiveDormant) {
   std::string config =
-  "   <in_commods> <val>commod</val> </in_commods> "
-  "   <out_commods> <val>commod1</val> </out_commods> "
-  "   <throughput>1</throughput>"
-  "   <active_buying_frequency_type>Binomial</active_buying_frequency_type>"
-  "   <active_buying_end_probability>0.2</active_buying_end_probability>"
-  "   <dormant_buying_frequency_type>Binomial</dormant_buying_frequency_type>"
-  "   <dormant_buying_end_probability>0.3</dormant_buying_end_probability>";
+      "   <in_commods> <val>commod</val> </in_commods> "
+      "   <out_commods> <val>commod1</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <active_buying_frequency_type>Binomial</active_buying_frequency_type>"
+      "   <active_buying_end_probability>0.2</active_buying_end_probability>"
+      "   "
+      "<dormant_buying_frequency_type>Binomial</dormant_buying_frequency_type>"
+      "   <dormant_buying_end_probability>0.3</dormant_buying_end_probability>";
 
   int simdur = 30;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
   sim.AddSource("commod").capacity(5).Finalize();
 
   int id = sim.Run();
@@ -583,21 +573,29 @@ TEST_F(StorageTest, BinomialActiveDormant) {
 
 TEST_F(StorageTest, DisruptionActiveDormant) {
   std::string config =
-  "    <in_commods><val>commod</val></in_commods>"
-  "    <out_commods><val>commod1</val></out_commods>"
-  "    <throughput>1</throughput>"
-  "    <active_buying_frequency_type>FixedWithDisruption</active_buying_frequency_type>"
-  "    <active_buying_disruption_probability>0.4</active_buying_disruption_probability>"
-  "    <active_buying_val>2</active_buying_val>"
-  "    <active_buying_disruption>5</active_buying_disruption>"
-  "    <dormant_buying_frequency_type>FixedWithDisruption</dormant_buying_frequency_type>"
-  "    <dormant_buying_disruption_probability>0.5</dormant_buying_disruption_probability>"
-  "    <dormant_buying_val>1</dormant_buying_val>"
-  "    <dormant_buying_disruption>10</dormant_buying_disruption>";
+      "    <in_commods><val>commod</val></in_commods>"
+      "    <out_commods><val>commod1</val></out_commods>"
+      "    <throughput>1</throughput>"
+      "    "
+      "<active_buying_frequency_type>FixedWithDisruption</"
+      "active_buying_frequency_type>"
+      "    "
+      "<active_buying_disruption_probability>0.4</"
+      "active_buying_disruption_probability>"
+      "    <active_buying_val>2</active_buying_val>"
+      "    <active_buying_disruption>5</active_buying_disruption>"
+      "    "
+      "<dormant_buying_frequency_type>FixedWithDisruption</"
+      "dormant_buying_frequency_type>"
+      "    "
+      "<dormant_buying_disruption_probability>0.5</"
+      "dormant_buying_disruption_probability>"
+      "    <dormant_buying_val>1</dormant_buying_val>"
+      "    <dormant_buying_disruption>10</dormant_buying_disruption>";
 
   int simdur = 50;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
   sim.AddSource("commod").capacity(5).Finalize();
   int id = sim.Run();
 
@@ -605,29 +603,29 @@ TEST_F(StorageTest, DisruptionActiveDormant) {
   // confirm that transactions are only occurring during active periods
   // first active length = 5 (disrupted)
   EXPECT_EQ(0, qr.GetVal<int>("Time", 0));
-  EXPECT_EQ(1, qr.GetVal<int>("Time", 1)); // ... end of active
-  
+  EXPECT_EQ(1, qr.GetVal<int>("Time", 1));  // ... end of active
+
   // first dormant length = 1 (not disrupted)
   // second active length = 2 (not disrupted)
-  EXPECT_EQ(3, qr.GetVal<int>("Time", 2)); // ... end of dormant
+  EXPECT_EQ(3, qr.GetVal<int>("Time", 2));  // ... end of dormant
   EXPECT_EQ(4, qr.GetVal<int>("Time", 3));
-  
+
   // second dormant length = 10 (disrupted)
   // third active length = 2 (not disrupted)
-  EXPECT_EQ(15, qr.GetVal<int>("Time", 4)); // ... end of second active
+  EXPECT_EQ(15, qr.GetVal<int>("Time", 4));  // ... end of second active
 }
 
-TEST_F(StorageTest, FixedBuyingSize){
+TEST_F(StorageTest, FixedBuyingSize) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <buying_size_type>Fixed</buying_size_type>"
-    "   <buying_size_val>0.5</buying_size_val>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <buying_size_type>Fixed</buying_size_type>"
+      "   <buying_size_val>0.5</buying_size_val>";
 
   int simdur = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
   int id = sim.Run();
@@ -637,18 +635,18 @@ TEST_F(StorageTest, FixedBuyingSize){
   EXPECT_NEAR(0.5, qr.GetVal<double>("Quantity", 1), 0.00001);
 }
 
-TEST_F(StorageTest, UniformBuyingSize){
+TEST_F(StorageTest, UniformBuyingSize) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <buying_size_type>Uniform</buying_size_type>"
-    "   <buying_size_min>0.5</buying_size_min>"
-    "   <buying_size_max>0.7</buying_size_max>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <buying_size_type>Uniform</buying_size_type>"
+      "   <buying_size_min>0.5</buying_size_min>"
+      "   <buying_size_max>0.7</buying_size_max>";
 
   int simdur = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
   int id = sim.Run();
@@ -658,18 +656,18 @@ TEST_F(StorageTest, UniformBuyingSize){
   EXPECT_NEAR(0.68825, qr.GetVal<double>("Quantity", 1), 0.00001);
 }
 
-TEST_F(StorageTest, NormalBuyingSize){
+TEST_F(StorageTest, NormalBuyingSize) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <buying_size_type>Normal</buying_size_type>"
-    "   <buying_size_mean>0.5</buying_size_mean>"
-    "   <buying_size_stddev>0.1</buying_size_stddev>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <buying_size_type>Normal</buying_size_type>"
+      "   <buying_size_mean>0.5</buying_size_mean>"
+      "   <buying_size_stddev>0.1</buying_size_stddev>";
 
   int simdur = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
 
@@ -680,24 +678,24 @@ TEST_F(StorageTest, NormalBuyingSize){
   EXPECT_NEAR(0.32648, qr.GetVal<double>("Quantity", 1), 0.00001);
 }
 
-TEST_F(StorageTest, NormalActiveDormantBuyingSize){
-    std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <active_buying_frequency_type>Normal</active_buying_frequency_type>"
-    "   <active_buying_mean>3</active_buying_mean>"
-    "   <active_buying_stddev>1</active_buying_stddev>"
-    "   <dormant_buying_frequency_type>Normal</dormant_buying_frequency_type>"
-    "   <dormant_buying_mean>2</dormant_buying_mean>"
-    "   <dormant_buying_stddev>1</dormant_buying_stddev>"
-    "   <buying_size_type>Normal</buying_size_type>"
-    "   <buying_size_mean>0.5</buying_size_mean>"
-    "   <buying_size_stddev>0.1</buying_size_stddev>";
+TEST_F(StorageTest, NormalActiveDormantBuyingSize) {
+  std::string config =
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <active_buying_frequency_type>Normal</active_buying_frequency_type>"
+      "   <active_buying_mean>3</active_buying_mean>"
+      "   <active_buying_stddev>1</active_buying_stddev>"
+      "   <dormant_buying_frequency_type>Normal</dormant_buying_frequency_type>"
+      "   <dormant_buying_mean>2</dormant_buying_mean>"
+      "   <dormant_buying_stddev>1</dormant_buying_stddev>"
+      "   <buying_size_type>Normal</buying_size_type>"
+      "   <buying_size_mean>0.5</buying_size_mean>"
+      "   <buying_size_stddev>0.1</buying_size_stddev>";
 
   int simdur = 15;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -732,61 +730,61 @@ TEST_F(StorageTest, NormalActiveDormantBuyingSize){
 TEST_F(StorageTest, IncorrectBuyPolSetupUniform) {
   // uniform missing min and max
   std::string config_uniform =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>";
 
   int simdur = 15;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config_uniform,
-                                         simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config_uniform,
+                      simdur);
   EXPECT_THROW(sim.Run(), cyclus::ValueError);
 }
 
 TEST_F(StorageTest, IncorrectBuyPolSetupNormal) {
   // normal missing mean and std dev
   std::string config_normal =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <active_buying_frequency_type>Normal</active_buying_frequency_type>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <active_buying_frequency_type>Normal</active_buying_frequency_type>";
   int simdur = 15;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config_normal,
-                                         simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config_normal,
+                      simdur);
   EXPECT_THROW(sim.Run(), cyclus::ValueError);
 }
 
 TEST_F(StorageTest, IncorrectBuyPolSetupMinMax) {
   // tries to set min > max
   std::string config_uniform_min_bigger_max =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>"
-    "   <active_buying_min>3</active_buying_min>"
-    "   <active_buying_max>2</active_buying_max>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>"
+      "   <active_buying_min>3</active_buying_min>"
+      "   <active_buying_max>2</active_buying_max>";
 
   int simdur = 15;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), 
-                                         config_uniform_min_bigger_max, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"),
+                      config_uniform_min_bigger_max, simdur);
   EXPECT_THROW(sim.Run(), cyclus::ValueError);
 }
 
-TEST_F(StorageTest, PositionInitialize){
+TEST_F(StorageTest, PositionInitialize) {
   // Verify Storage behavior
 
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <residence_time>1</residence_time>"
-    "   <max_inv_size>10</max_inv_size>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <residence_time>1</residence_time>"
+      "   <max_inv_size>10</max_inv_size>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -798,20 +796,20 @@ TEST_F(StorageTest, PositionInitialize){
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 0.0);
 }
 
-TEST_F(StorageTest, Longitude){
+TEST_F(StorageTest, Longitude) {
   // Verify Storage behavior
 
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <residence_time>1</residence_time>"
-    "   <max_inv_size>10</max_inv_size>"
-    "   <latitude>50.0</latitude> "
-    "   <longitude>35.0</longitude> ";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <residence_time>1</residence_time>"
+      "   <max_inv_size>10</max_inv_size>"
+      "   <latitude>50.0</latitude> "
+      "   <longitude>35.0</longitude> ";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -825,14 +823,14 @@ TEST_F(StorageTest, Longitude){
 
 TEST_F(StorageTest, RQ_Inventory_Invalid) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <max_inv_size>5</max_inv_size>"
-    "   <reorder_point>2</reorder_point>"
-    "   <reorder_quantity>10</reorder_quantity>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <max_inv_size>5</max_inv_size>"
+      "   <reorder_point>2</reorder_point>"
+      "   <reorder_quantity>10</reorder_quantity>";
 
   int simdur = 2;
- 
+
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   EXPECT_THROW(int id = sim.Run(), cyclus::ValueError);
@@ -840,15 +838,15 @@ TEST_F(StorageTest, RQ_Inventory_Invalid) {
 
 TEST_F(StorageTest, RQ_Inventory) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <max_inv_size>5</max_inv_size>"
-    "   <reorder_point>2</reorder_point>"
-    "   <reorder_quantity>3</reorder_quantity>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <max_inv_size>5</max_inv_size>"
+      "   <reorder_point>2</reorder_point>"
+      "   <reorder_quantity>3</reorder_quantity>";
 
   int simdur = 5;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -873,14 +871,14 @@ TEST_F(StorageTest, RQ_Inventory) {
 
 TEST_F(StorageTest, sS_Inventory) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <max_inv_size>5</max_inv_size>"
-    "   <reorder_point>2</reorder_point>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <max_inv_size>5</max_inv_size>"
+      "   <reorder_point>2</reorder_point>";
 
   int simdur = 5;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -904,16 +902,16 @@ TEST_F(StorageTest, sS_Inventory) {
 
 TEST_F(StorageTest, CCap_Inventory) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput> "
-    "   <cumulative_cap>2</cumulative_cap> "
-    "   <dormant_buying_frequency_type>Fixed</dormant_buying_frequency_type> "
-    "   <dormant_buying_val>2</dormant_buying_val> ";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput> "
+      "   <cumulative_cap>2</cumulative_cap> "
+      "   <dormant_buying_frequency_type>Fixed</dormant_buying_frequency_type> "
+      "   <dormant_buying_val>2</dormant_buying_val> ";
 
   int simdur = 9;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -941,13 +939,13 @@ TEST_F(StorageTest, CCap_Inventory) {
 TEST_F(StorageTest, PackageExactly) {
   // resource can be packaged without splitting or merging
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <package>foo</package>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <package>foo</package>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
   sim.context()->AddPackage("foo", 1, 2, "first");
   cyclus::Package::Ptr p = sim.context()->GetPackage("foo");
 
@@ -977,13 +975,13 @@ TEST_F(StorageTest, PackageExactly) {
 TEST_F(StorageTest, PackageSplitEqual) {
   // Resources must be split into two to package. Packaging strategy equal
   std::string config =
-    "   <in_commods> <val>commodity</val> </in_commods> "
-    "   <out_commods> <val>commodity1</val> </out_commods> "
-    "   <package>foo</package>";
+      "   <in_commods> <val>commodity</val> </in_commods> "
+      "   <out_commods> <val>commodity1</val> </out_commods> "
+      "   <package>foo</package>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
   sim.context()->AddPackage("foo", 1, 2, "equal");
   cyclus::Package::Ptr p = sim.context()->GetPackage("foo");
 
@@ -993,9 +991,10 @@ TEST_F(StorageTest, PackageSplitEqual) {
   int id = sim.Run();
 
   std::vector<cyclus::Cond> tr_conds;
-  tr_conds.push_back(cyclus::Cond("Commodity", "==", std::string("commodity1")));
+  tr_conds.push_back(
+      cyclus::Cond("Commodity", "==", std::string("commodity1")));
   cyclus::QueryResult qr_trans = sim.db().Query("Transactions", &tr_conds);
-  // four transactions out of storage. Each resource is split, so two 
+  // four transactions out of storage. Each resource is split, so two
   // transactions at time 1, two at time 2
   EXPECT_EQ(4, qr_trans.rows.size());
 
@@ -1018,13 +1017,13 @@ TEST_F(StorageTest, PackageSplitEqual) {
 TEST_F(StorageTest, PackageSplitFirst) {
   // Resources must be split into two to package. Packaging strategy first
   std::string config =
-    "   <in_commods> <val>commodity</val> </in_commods> "
-    "   <out_commods> <val>commodity1</val> </out_commods> "
-    "   <package>foo</package>";
+      "   <in_commods> <val>commodity</val> </in_commods> "
+      "   <out_commods> <val>commodity1</val> </out_commods> "
+      "   <package>foo</package>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
   sim.context()->AddPackage("foo", 1, 2, "first");
   cyclus::Package::Ptr p = sim.context()->GetPackage("foo");
 
@@ -1034,9 +1033,10 @@ TEST_F(StorageTest, PackageSplitFirst) {
   int id = sim.Run();
 
   std::vector<cyclus::Cond> tr_conds;
-  tr_conds.push_back(cyclus::Cond("Commodity", "==", std::string("commodity1")));
+  tr_conds.push_back(
+      cyclus::Cond("Commodity", "==", std::string("commodity1")));
   cyclus::QueryResult qr_trans = sim.db().Query("Transactions", &tr_conds);
-  // four transactions out of storage. Each resource is split, so two 
+  // four transactions out of storage. Each resource is split, so two
   // transactions at time 1, two at time 2
   EXPECT_EQ(4, qr_trans.rows.size());
 
@@ -1051,17 +1051,17 @@ TEST_F(StorageTest, PackageSplitFirst) {
   // because package does split-first, resources are size 2 and 1
   EXPECT_EQ(qr_res.rows.size(), 4);
 
-  // order of trade execution is not guaranteed. Therefore, create vector, 
+  // order of trade execution is not guaranteed. Therefore, create vector,
   // sort by size, and then check values
   std::vector<double> pkgd_t0 = {qr_res.GetVal<double>("Quantity", 0),
-                                    qr_res.GetVal<double>("Quantity", 1)};
+                                 qr_res.GetVal<double>("Quantity", 1)};
   std::sort(pkgd_t0.begin(), pkgd_t0.end(), std::greater<double>());
   std::vector<double> exp_t0 = {2, 1};
 
   EXPECT_EQ(exp_t0, pkgd_t0);
 
   std::vector<double> pkgd_t1 = {qr_res.GetVal<double>("Quantity", 2),
-                                    qr_res.GetVal<double>("Quantity", 3)};
+                                 qr_res.GetVal<double>("Quantity", 3)};
   std::sort(pkgd_t1.begin(), pkgd_t1.end(), std::greater<double>());
   std::vector<double> exp_t1 = {2, 1};
 
@@ -1070,14 +1070,14 @@ TEST_F(StorageTest, PackageSplitFirst) {
 
 TEST_F(StorageTest, PackageMerge) {
   std::string config =
-    "   <in_commods> <val>commodity</val> </in_commods> "
-    "   <out_commods> <val>commodity1</val> </out_commods> "
-    "   <throughput>1</throughput> "
-    "   <package>foo</package>";
+      "   <in_commods> <val>commodity</val> </in_commods> "
+      "   <out_commods> <val>commodity1</val> </out_commods> "
+      "   <throughput>1</throughput> "
+      "   <package>foo</package>";
 
   int simdur = 5;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
   sim.context()->AddPackage("foo", 1, 2, "first");
   cyclus::Package::Ptr p = sim.context()->GetPackage("foo");
 
@@ -1087,7 +1087,8 @@ TEST_F(StorageTest, PackageMerge) {
   int id = sim.Run();
 
   std::vector<cyclus::Cond> tr_conds;
-  tr_conds.push_back(cyclus::Cond("Commodity", "==", std::string("commodity1")));
+  tr_conds.push_back(
+      cyclus::Cond("Commodity", "==", std::string("commodity1")));
 
   cyclus::QueryResult qr_trans = sim.db().Query("Transactions", &tr_conds);
   // two transactions out of storage. Because the source only provides 0.5 each
@@ -1108,16 +1109,16 @@ TEST_F(StorageTest, PackageMerge) {
 }
 
 TEST_F(StorageTest, TransportUnit) {
-    std::string config =
-    "   <in_commods> <val>commodity</val> </in_commods> "
-    "   <out_commods> <val>commodity1</val> </out_commods> "
-    "   <throughput>3</throughput> "
-    "   <package>foo</package>"
-    "   <transport_unit>bar</transport_unit>";
+  std::string config =
+      "   <in_commods> <val>commodity</val> </in_commods> "
+      "   <out_commods> <val>commodity1</val> </out_commods> "
+      "   <throughput>3</throughput> "
+      "   <package>foo</package>"
+      "   <transport_unit>bar</transport_unit>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
   sim.context()->AddPackage("foo", 1, 1, "first");
   cyclus::Package::Ptr p = sim.context()->GetPackage("foo");
   sim.context()->AddTransportUnit("bar", 2, 2, "first");
@@ -1128,7 +1129,8 @@ TEST_F(StorageTest, TransportUnit) {
   int id = sim.Run();
 
   std::vector<cyclus::Cond> tr_conds;
-  tr_conds.push_back(cyclus::Cond("Commodity", "==", std::string("commodity1")));
+  tr_conds.push_back(
+      cyclus::Cond("Commodity", "==", std::string("commodity1")));
 
   cyclus::QueryResult qr_trans = sim.db().Query("Transactions", &tr_conds);
   // 6 transactions. While all three units could be packaged in one time step,
@@ -1156,7 +1158,7 @@ TEST_F(StorageTest, TransportUnit) {
   EXPECT_EQ(1, qr_res.GetVal<double>("Quantity", 5));
 }
 
-} // namespace cycamore
+}  // namespace cycamore
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 cyclus::Agent* StorageConstructor(cyclus::Context* ctx) {
@@ -1168,11 +1170,11 @@ cyclus::Agent* StorageConstructor(cyclus::Context* ctx) {
 int ConnectAgentTests();
 static int cyclus_agent_tests_connected = ConnectAgentTests();
 #define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED
+#endif  // CYCLUS_AGENT_TESTS_CONNECTED
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_SUITE_P(StorageFac, FacilityTests,
-                        ::testing::Values(&StorageConstructor));
+                         ::testing::Values(&StorageConstructor));
 
 INSTANTIATE_TEST_SUITE_P(StorageFac, AgentTests,
-                        ::testing::Values(&StorageConstructor));
+                         ::testing::Values(&StorageConstructor));

--- a/src/storage_tests.cc
+++ b/src/storage_tests.cc
@@ -15,7 +15,7 @@ void StorageTest::TearDown() {
   delete src_facility_;
 }
 
-void StorageTest::InitParameters(){
+void StorageTest::InitParameters() {
   in_r1 = "in_r1";
   in_c1.push_back("in_c1");
   out_c1.push_back("out_c1");
@@ -26,7 +26,6 @@ void StorageTest::InitParameters(){
   package = "foo";
   // Active period longer than any of the residence time related-tests needs
 
-
   cyclus::CompMap v;
   v[922350000] = 1;
   v[922380000] = 2;
@@ -34,7 +33,7 @@ void StorageTest::InitParameters(){
   tc_.get()->AddRecipe(in_r1, recipe);
 }
 
-void StorageTest::SetUpStorage(){
+void StorageTest::SetUpStorage() {
   src_facility_->in_recipe = in_r1;
   src_facility_->in_commods = in_c1;
   src_facility_->out_commods = out_c1;
@@ -46,7 +45,7 @@ void StorageTest::SetUpStorage(){
   src_facility_->package = package;
 }
 
-void StorageTest::TestInitState(Storage* fac){
+void StorageTest::TestInitState(Storage* fac) {
   EXPECT_EQ(residence_time, fac->residence_time);
   EXPECT_EQ(max_inv_size, fac->max_inv_size);
   EXPECT_EQ(throughput, fac->throughput);
@@ -54,8 +53,7 @@ void StorageTest::TestInitState(Storage* fac){
   EXPECT_EQ(package, fac->package);
 }
 
-void StorageTest::TestAddMat(Storage* fac,
-    cyclus::Material::Ptr mat){
+void StorageTest::TestAddMat(Storage* fac, cyclus::Material::Ptr mat) {
   double amt = mat->quantity();
   double before = fac->inventory.quantity();
   fac->AddMat_(mat);
@@ -63,8 +61,8 @@ void StorageTest::TestAddMat(Storage* fac,
   EXPECT_EQ(amt, after - before);
 }
 
-void StorageTest::TestBuffers(Storage* fac, double inv,
-    double proc, double ready, double stocks){
+void StorageTest::TestBuffers(Storage* fac, double inv, double proc,
+                              double ready, double stocks) {
   double t = tc_.get()->time();
 
   EXPECT_EQ(inv, fac->inventory.quantity());
@@ -73,29 +71,24 @@ void StorageTest::TestBuffers(Storage* fac, double inv,
   EXPECT_EQ(ready, fac->ready.quantity());
 }
 
-void StorageTest::TestStocks(Storage* fac, cyclus::CompMap v){
-
+void StorageTest::TestStocks(Storage* fac, cyclus::CompMap v) {
   cyclus::toolkit::ResBuf<cyclus::Material>* buffer = &fac->stocks;
   Material::Ptr final_mat = cyclus::ResCast<Material>(buffer->PopBack());
   cyclus::CompMap final_comp = final_mat->comp()->atom();
-  EXPECT_EQ(final_comp,v);
-
+  EXPECT_EQ(final_comp, v);
 }
 
-void StorageTest::TestCurrentCap(Storage* fac, double inv){
-
+void StorageTest::TestCurrentCap(Storage* fac, double inv) {
   EXPECT_EQ(inv, fac->current_capacity());
 }
 
-void StorageTest::TestReadyTime(Storage* fac, int t){
-
+void StorageTest::TestReadyTime(Storage* fac, int t) {
   EXPECT_EQ(t, fac->ready_time());
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(StorageTest, clone) {
-  Storage* cloned_fac =
-      dynamic_cast<Storage*> (src_facility_->Clone());
+  Storage* cloned_fac = dynamic_cast<Storage*>(src_facility_->Clone());
   TestInitState(cloned_fac);
 }
 
@@ -106,8 +99,8 @@ TEST_F(StorageTest, InitialState) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(StorageTest, CurrentCapacity){
-  TestCurrentCap(src_facility_,max_inv_size);
+TEST_F(StorageTest, CurrentCapacity) {
+  TestCurrentCap(src_facility_, max_inv_size);
   max_inv_size = cyclus::CY_LARGE_DOUBLE;
   SetUpStorage();
   TestInitState(src_facility_);
@@ -122,11 +115,12 @@ TEST_F(StorageTest, Print) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(StorageTest, AddMats) {
   double cap = max_inv_size;
-  cyclus::Material::Ptr mat = cyclus::NewBlankMaterial(0.5*cap);
+  cyclus::Material::Ptr mat = cyclus::NewBlankMaterial(0.5 * cap);
   TestAddMat(src_facility_, mat);
 
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
-  cyclus::Material::Ptr recmat = cyclus::Material::CreateUntracked(0.5*cap, rec);
+  cyclus::Material::Ptr recmat =
+      cyclus::Material::CreateUntracked(0.5 * cap, rec);
   TestAddMat(src_facility_, recmat);
 }
 
@@ -138,9 +132,8 @@ TEST_F(StorageTest, Tick) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(StorageTest, Tock) {
-
   // initially, nothing in the buffers
-  TestBuffers(src_facility_,0,0,0,0);
+  TestBuffers(src_facility_, 0, 0, 0, 0);
 
   double cap = throughput;
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
@@ -148,31 +141,30 @@ TEST_F(StorageTest, Tock) {
   TestAddMat(src_facility_, mat);
 
   // affter add, the inventory has the material
-  TestBuffers(src_facility_,cap,0,0,0);
+  TestBuffers(src_facility_, cap, 0, 0, 0);
 
   EXPECT_NO_THROW(src_facility_->Tock());
 
   // after tock, the processing buffer has the material
-  TestBuffers(src_facility_,0,cap,0,0);
+  TestBuffers(src_facility_, 0, cap, 0, 0);
 
   EXPECT_EQ(0, tc_.get()->time());
-  for( int i = 1; i < residence_time-1; ++i){
+  for (int i = 1; i < residence_time - 1; ++i) {
     tc_.get()->time(i);
     EXPECT_NO_THROW(src_facility_->Tock());
-    TestBuffers(src_facility_,0,cap,0,0);
+    TestBuffers(src_facility_, 0, cap, 0, 0);
   }
 
   tc_.get()->time(residence_time);
   EXPECT_EQ(residence_time, tc_.get()->time());
-  TestReadyTime(src_facility_,0);
+  TestReadyTime(src_facility_, 0);
   src_facility_->Tock();
-  TestBuffers(src_facility_,0,0,0,cap);
+  TestBuffers(src_facility_, 0, 0, 0, cap);
 
-  tc_.get()->time(residence_time+1);
-  TestReadyTime(src_facility_,1);
+  tc_.get()->time(residence_time + 1);
+  TestReadyTime(src_facility_, 1);
   src_facility_->Tock();
-  TestBuffers(src_facility_,0,0,0,cap);
-
+  TestBuffers(src_facility_, 0, 0, 0, cap);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -188,16 +180,16 @@ TEST_F(StorageTest, NoProcessTime) {
   TestAddMat(src_facility_, mat);
 
   // affter add, the inventory has the material
-  TestBuffers(src_facility_,cap,0,0,0);
+  TestBuffers(src_facility_, cap, 0, 0, 0);
 
   EXPECT_NO_THROW(src_facility_->Tock());
 
   // affter tock, the stocks have the material
-  TestBuffers(src_facility_,0,0,0,cap);
+  TestBuffers(src_facility_, 0, 0, 0, cap);
 }
 
 TEST_F(StorageTest, NoConvert) {
-// Make sure no conversion occurs
+  // Make sure no conversion occurs
   double cap = throughput;
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
   cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(cap, rec);
@@ -206,51 +198,51 @@ TEST_F(StorageTest, NoConvert) {
   EXPECT_NO_THROW(src_facility_->Tock());
 
   tc_.get()->time(residence_time);
-  TestReadyTime(src_facility_,0);
+  TestReadyTime(src_facility_, 0);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0,0,cap);
+  TestBuffers(src_facility_, 0, 0, 0, cap);
   cyclus::CompMap in_rec;
   in_rec[922350000] = 1;
   in_rec[922380000] = 2;
-  TestStocks(src_facility_,in_rec);
+  TestStocks(src_facility_, in_rec);
 }
 
 TEST_F(StorageTest, MultipleSmallBatches) {
   // Add first small batch
   double cap = throughput;
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
-  cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(0.2*cap, rec);
+  cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(0.2 * cap, rec);
   TestAddMat(src_facility_, mat);
 
   // After add, material is in inventory
-  TestBuffers(src_facility_,0.2*cap,0,0,0);
+  TestBuffers(src_facility_, 0.2 * cap, 0, 0, 0);
 
   // Move first batch into processing
   src_facility_->Tock();
-  TestBuffers(src_facility_,0,0.2*cap,0,0);
+  TestBuffers(src_facility_, 0, 0.2 * cap, 0, 0);
 
   // Add second small batch
   tc_.get()->time(2);
   src_facility_->Tock();
-  cyclus::Material::Ptr mat1 = cyclus::Material::CreateUntracked(0.3*cap, rec);
-  TestAddMat(src_facility_,mat1);
-  TestBuffers(src_facility_,0.3*cap,0.2*cap,0,0);
+  cyclus::Material::Ptr mat1 =
+      cyclus::Material::CreateUntracked(0.3 * cap, rec);
+  TestAddMat(src_facility_, mat1);
+  TestBuffers(src_facility_, 0.3 * cap, 0.2 * cap, 0, 0);
 
   // Move second batch into processing
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0.5*cap,0,0);
+  TestBuffers(src_facility_, 0, 0.5 * cap, 0, 0);
 
   // Move first batch to stocks
   tc_.get()->time(residence_time);
-  TestReadyTime(src_facility_,0);
+  TestReadyTime(src_facility_, 0);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0.3*cap,0,0.2*cap);
+  TestBuffers(src_facility_, 0, 0.3 * cap, 0, 0.2 * cap);
 
-  tc_.get()->time(residence_time+2);
+  tc_.get()->time(residence_time + 2);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0,0,0.5*cap);
+  TestBuffers(src_facility_, 0, 0, 0, 0.5 * cap);
 }
-
 
 TEST_F(StorageTest, ChangeCapacity) {
   // src_facility_->discrete_handling_(0);
@@ -263,124 +255,123 @@ TEST_F(StorageTest, ChangeCapacity) {
   cyclus::Material::Ptr mat1 = cyclus::Material::CreateUntracked(cap1, rec);
   TestAddMat(src_facility_, mat1);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,cap1,0,0);
+  TestBuffers(src_facility_, 0, cap1, 0, 0);
 
   // Increase throughput, add second and third batches
   tc_.get()->time(2);
   throughput = 500;
   SetUpStorage();
   double cap2 = throughput;
-  cyclus::Material::Ptr mat2 = cyclus::Material::CreateUntracked(cap2,rec);
+  cyclus::Material::Ptr mat2 = cyclus::Material::CreateUntracked(cap2, rec);
   TestAddMat(src_facility_, mat2);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,cap2+cap1,0,0);
+  TestBuffers(src_facility_, 0, cap2 + cap1, 0, 0);
   tc_.get()->time(3);
-  cyclus::Material::Ptr mat3 = cyclus::Material::CreateUntracked(cap2,rec);
+  cyclus::Material::Ptr mat3 = cyclus::Material::CreateUntracked(cap2, rec);
   TestAddMat(src_facility_, mat3);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,cap2*2+cap1,0,0);
+  TestBuffers(src_facility_, 0, cap2 * 2 + cap1, 0, 0);
 
   // Move first batch to stocks
   tc_.get()->time(residence_time);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,2*cap2,0,cap1);
+  TestBuffers(src_facility_, 0, 2 * cap2, 0, cap1);
 
   // Decrease throughput and move portion of second batch to stocks
   throughput = 400;
   SetUpStorage();
-  tc_.get()->time(residence_time+2);
+  tc_.get()->time(residence_time + 2);
   EXPECT_EQ(400, throughput);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,cap2,100,cap1+400);
+  TestBuffers(src_facility_, 0, cap2, 100, cap1 + 400);
 
   // Continue to move second batch // and portion of third
-  tc_.get()->time(residence_time+3);
+  tc_.get()->time(residence_time + 3);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0,200,cap1+cap2+300);
+  TestBuffers(src_facility_, 0, 0, 200, cap1 + cap2 + 300);
 
   // Move remainder of third batch
-  tc_.get()->time(residence_time+4);
+  tc_.get()->time(residence_time + 4);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0,0,cap1+cap2+cap2);
-
+  TestBuffers(src_facility_, 0, 0, 0, cap1 + cap2 + cap2);
 }
 
 TEST_F(StorageTest, TwoBatchSameTime) {
   // Add first small batch
   double cap = throughput;
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
-  cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(0.2*cap, rec);
+  cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(0.2 * cap, rec);
   TestAddMat(src_facility_, mat);
 
   // After add, material is in inventory
-  TestBuffers(src_facility_,0.2*cap,0,0,0);
-  cyclus::Material::Ptr mat1 = cyclus::Material::CreateUntracked(0.2*cap, rec);
+  TestBuffers(src_facility_, 0.2 * cap, 0, 0, 0);
+  cyclus::Material::Ptr mat1 =
+      cyclus::Material::CreateUntracked(0.2 * cap, rec);
   TestAddMat(src_facility_, mat1);
-  TestBuffers(src_facility_,0.4*cap,0,0,0);
+  TestBuffers(src_facility_, 0.4 * cap, 0, 0, 0);
 
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0.4*cap,0,0);
+  TestBuffers(src_facility_, 0, 0.4 * cap, 0, 0);
 
   // Move material to stocks
   tc_.get()->time(residence_time);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0,0,0.4*cap);
+  TestBuffers(src_facility_, 0, 0, 0, 0.4 * cap);
 }
 
-TEST_F(StorageTest,ChangeProcessTime){
+TEST_F(StorageTest, ChangeProcessTime) {
   // Initialize process time variable and add first batch
   int proc_time1 = residence_time;
   double cap = throughput;
   cyclus::Composition::Ptr rec = tc_.get()->GetRecipe(in_r1);
   cyclus::Material::Ptr mat = cyclus::Material::CreateUntracked(cap, rec);
   TestAddMat(src_facility_, mat);
-  TestBuffers(src_facility_,cap,0,0,0);
+  TestBuffers(src_facility_, cap, 0, 0, 0);
 
   // Move material to processing
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,cap,0,0);
+  TestBuffers(src_facility_, 0, cap, 0, 0);
 
   // Add second batch
-  cyclus::Material::Ptr mat1 = cyclus::Material::CreateUntracked(cap,rec);
+  cyclus::Material::Ptr mat1 = cyclus::Material::CreateUntracked(cap, rec);
   tc_.get()->time(8);
-  TestAddMat(src_facility_,mat1);
-  TestBuffers(src_facility_,cap,cap,0,0);
+  TestAddMat(src_facility_, mat1);
+  TestBuffers(src_facility_, cap, cap, 0, 0);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,2*cap,0,0);
+  TestBuffers(src_facility_, 0, 2 * cap, 0, 0);
 
   // Increase process time
-  residence_time = proc_time1+5;
+  residence_time = proc_time1 + 5;
   SetUpStorage();
   // src_facility_->residence_time = proc_time1+5;
-  EXPECT_EQ(residence_time,proc_time1+5);
-  EXPECT_EQ(residence_time,15);
+  EXPECT_EQ(residence_time, proc_time1 + 5);
+  EXPECT_EQ(residence_time, 15);
   int proc_time2 = residence_time;
 
   // Make sure material doesn't move before new process time
-  for( int i=proc_time1; i < proc_time2 - 1; ++i){
-  tc_.get()->time(i);
-  EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,2*cap,0,0);
+  for (int i = proc_time1; i < proc_time2 - 1; ++i) {
+    tc_.get()->time(i);
+    EXPECT_NO_THROW(src_facility_->Tock());
+    TestBuffers(src_facility_, 0, 2 * cap, 0, 0);
   }
 
   // Move first batch to stocks
   tc_.get()->time(proc_time2);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,cap,0,cap);
+  TestBuffers(src_facility_, 0, cap, 0, cap);
 
   // Decrease process time
-  residence_time = proc_time2-3;
+  residence_time = proc_time2 - 3;
   SetUpStorage();
   int proc_time3 = residence_time;
 
   // Move second batch to stocks
-  tc_.get()->time(proc_time3 +8);
+  tc_.get()->time(proc_time3 + 8);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0,0,2*cap);
-
+  TestBuffers(src_facility_, 0, 0, 0, 2 * cap);
 }
 
-TEST_F(StorageTest,DifferentRecipe){
+TEST_F(StorageTest, DifferentRecipe) {
   // Initialize material with different recipe than in_recipe
   double cap = throughput;
   cyclus::CompMap v;
@@ -391,26 +382,26 @@ TEST_F(StorageTest,DifferentRecipe){
 
   // Move material through the facility
   TestAddMat(src_facility_, mat);
-  TestBuffers(src_facility_,cap,0,0,0);
+  TestBuffers(src_facility_, cap, 0, 0, 0);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,cap,0,0);
+  TestBuffers(src_facility_, 0, cap, 0, 0);
   tc_.get()->time(residence_time);
   EXPECT_NO_THROW(src_facility_->Tock());
-  TestBuffers(src_facility_,0,0,0,cap);
+  TestBuffers(src_facility_, 0, 0, 0, cap);
 }
 
-TEST_F(StorageTest, BehaviorTest){
+TEST_F(StorageTest, BehaviorTest) {
   // Verify Storage behavior
 
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <residence_time>1</residence_time>"
-    "   <max_inv_size>10</max_inv_size>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <residence_time>1</residence_time>"
+      "   <max_inv_size>10</max_inv_size>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -423,23 +414,22 @@ TEST_F(StorageTest, BehaviorTest){
   cyclus::QueryResult qr = sim.db().Query("Transactions", &conds);
   int n_trans = qr.rows.size();
   EXPECT_EQ(1, n_trans) << "expected 1 transactions, got " << n_trans;
-
 }
 
-TEST_F(StorageTest, MultipleCommods){
+TEST_F(StorageTest, MultipleCommods) {
   // Verify Storage accepting Multiple Commods
 
   std::string config =
-    "   <in_commods> <val>spent_fuel</val>"
-    "                <val>spent_fuel2</val> </in_commods>"
-    "   <in_commod_prefs> <val>1</val>"
-    "                     <val>1</val> </in_commod_prefs>"
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <max_inv_size>10</max_inv_size>";
+      "   <in_commods> <val>spent_fuel</val>"
+      "                <val>spent_fuel2</val> </in_commods>"
+      "   <in_commod_prefs> <val>1</val>"
+      "                     <val>1</val> </in_commod_prefs>"
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <max_inv_size>10</max_inv_size>";
 
   int simdur = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSource("spent_fuel2").capacity(5).Finalize();
@@ -461,20 +451,19 @@ TEST_F(StorageTest, MultipleCommods){
   EXPECT_EQ(1, n_trans2) << "expected 1 transactions, got " << n_trans;
 }
 
-
 // Should get one transaction in a 2 step simulation when agent is active for
 // one step and dormant for one step
-TEST_F(StorageTest, ActiveDormant){
+TEST_F(StorageTest, ActiveDormant) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <active_buying_val>1</active_buying_val>"
-    "   <dormant_buying_val>1</dormant_buying_val>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <active_buying_val>1</active_buying_val>"
+      "   <dormant_buying_val>1</dormant_buying_val>";
 
   int simdur = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -487,23 +476,23 @@ TEST_F(StorageTest, ActiveDormant){
   cyclus::QueryResult qr = sim.db().Query("Transactions", &conds);
   int n_trans = qr.rows.size();
   EXPECT_EQ(1, n_trans) << "expected 1 transactions, got " << n_trans;
- }
+}
 
-  // Should get two transactions in a 2 step simulation when there is no 
-  // dormant period, i.e. agent is always active
-TEST_F(StorageTest, NoDormant){
+// Should get two transactions in a 2 step simulation when there is no
+// dormant period, i.e. agent is always active
+TEST_F(StorageTest, NoDormant) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <active_buying_frequency_type>Fixed</active_buying_frequency_type>"
-    "   <active_buying_val>1</active_buying_val>"
-    "   <dormant_buying_frequency_type>Fixed</dormant_buying_frequency_type>"
-    "   <dormant_buying_val>-1</dormant_buying_val>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <active_buying_frequency_type>Fixed</active_buying_frequency_type>"
+      "   <active_buying_val>1</active_buying_val>"
+      "   <dormant_buying_frequency_type>Fixed</dormant_buying_frequency_type>"
+      "   <dormant_buying_val>-1</dormant_buying_val>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -515,23 +504,23 @@ TEST_F(StorageTest, NoDormant){
   cyclus::QueryResult qr = sim.db().Query("Transactions", &conds);
   int n_trans = qr.rows.size();
   EXPECT_EQ(3, n_trans) << "expected 3 transactions, got " << n_trans;
- }
+}
 
-TEST_F(StorageTest, UniformActiveNormalDormant){
+TEST_F(StorageTest, UniformActiveNormalDormant) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>"
-    "   <active_buying_min>2</active_buying_min>"
-    "   <active_buying_max>3</active_buying_max>"
-    "   <dormant_buying_frequency_type>Normal</dormant_buying_frequency_type>"
-    "   <dormant_buying_mean>5</dormant_buying_mean>"
-    "   <dormant_buying_stddev>1</dormant_buying_stddev>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>"
+      "   <active_buying_min>2</active_buying_min>"
+      "   <active_buying_max>3</active_buying_max>"
+      "   <dormant_buying_frequency_type>Normal</dormant_buying_frequency_type>"
+      "   <dormant_buying_mean>5</dormant_buying_mean>"
+      "   <dormant_buying_stddev>1</dormant_buying_stddev>";
 
   int simdur = 20;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -553,17 +542,18 @@ TEST_F(StorageTest, UniformActiveNormalDormant){
 
 TEST_F(StorageTest, BinomialActiveDormant) {
   std::string config =
-  "   <in_commods> <val>commod</val> </in_commods> "
-  "   <out_commods> <val>commod1</val> </out_commods> "
-  "   <throughput>1</throughput>"
-  "   <active_buying_frequency_type>Binomial</active_buying_frequency_type>"
-  "   <active_buying_end_probability>0.2</active_buying_end_probability>"
-  "   <dormant_buying_frequency_type>Binomial</dormant_buying_frequency_type>"
-  "   <dormant_buying_end_probability>0.3</dormant_buying_end_probability>";
+      "   <in_commods> <val>commod</val> </in_commods> "
+      "   <out_commods> <val>commod1</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <active_buying_frequency_type>Binomial</active_buying_frequency_type>"
+      "   <active_buying_end_probability>0.2</active_buying_end_probability>"
+      "   "
+      "<dormant_buying_frequency_type>Binomial</dormant_buying_frequency_type>"
+      "   <dormant_buying_end_probability>0.3</dormant_buying_end_probability>";
 
   int simdur = 30;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
   sim.AddSource("commod").capacity(5).Finalize();
 
   int id = sim.Run();
@@ -583,21 +573,29 @@ TEST_F(StorageTest, BinomialActiveDormant) {
 
 TEST_F(StorageTest, DisruptionActiveDormant) {
   std::string config =
-  "    <in_commods><val>commod</val></in_commods>"
-  "    <out_commods><val>commod1</val></out_commods>"
-  "    <throughput>1</throughput>"
-  "    <active_buying_frequency_type>FixedWithDisruption</active_buying_frequency_type>"
-  "    <active_buying_disruption_probability>0.4</active_buying_disruption_probability>"
-  "    <active_buying_val>2</active_buying_val>"
-  "    <active_buying_disruption>5</active_buying_disruption>"
-  "    <dormant_buying_frequency_type>FixedWithDisruption</dormant_buying_frequency_type>"
-  "    <dormant_buying_disruption_probability>0.5</dormant_buying_disruption_probability>"
-  "    <dormant_buying_val>1</dormant_buying_val>"
-  "    <dormant_buying_disruption>10</dormant_buying_disruption>";
+      "    <in_commods><val>commod</val></in_commods>"
+      "    <out_commods><val>commod1</val></out_commods>"
+      "    <throughput>1</throughput>"
+      "    "
+      "<active_buying_frequency_type>FixedWithDisruption</"
+      "active_buying_frequency_type>"
+      "    "
+      "<active_buying_disruption_probability>0.4</"
+      "active_buying_disruption_probability>"
+      "    <active_buying_val>2</active_buying_val>"
+      "    <active_buying_disruption>5</active_buying_disruption>"
+      "    "
+      "<dormant_buying_frequency_type>FixedWithDisruption</"
+      "dormant_buying_frequency_type>"
+      "    "
+      "<dormant_buying_disruption_probability>0.5</"
+      "dormant_buying_disruption_probability>"
+      "    <dormant_buying_val>1</dormant_buying_val>"
+      "    <dormant_buying_disruption>10</dormant_buying_disruption>";
 
   int simdur = 50;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
   sim.AddSource("commod").capacity(5).Finalize();
   int id = sim.Run();
 
@@ -605,29 +603,29 @@ TEST_F(StorageTest, DisruptionActiveDormant) {
   // confirm that transactions are only occurring during active periods
   // first active length = 5 (disrupted)
   EXPECT_EQ(0, qr.GetVal<int>("Time", 0));
-  EXPECT_EQ(1, qr.GetVal<int>("Time", 1)); // ... end of active
-  
+  EXPECT_EQ(1, qr.GetVal<int>("Time", 1));  // ... end of active
+
   // first dormant length = 1 (not disrupted)
   // second active length = 2 (not disrupted)
-  EXPECT_EQ(3, qr.GetVal<int>("Time", 2)); // ... end of dormant
+  EXPECT_EQ(3, qr.GetVal<int>("Time", 2));  // ... end of dormant
   EXPECT_EQ(4, qr.GetVal<int>("Time", 3));
-  
+
   // second dormant length = 10 (disrupted)
   // third active length = 2 (not disrupted)
-  EXPECT_EQ(15, qr.GetVal<int>("Time", 4)); // ... end of second active
+  EXPECT_EQ(15, qr.GetVal<int>("Time", 4));  // ... end of second active
 }
 
-TEST_F(StorageTest, FixedBuyingSize){
+TEST_F(StorageTest, FixedBuyingSize) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <buying_size_type>Fixed</buying_size_type>"
-    "   <buying_size_val>0.5</buying_size_val>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <buying_size_type>Fixed</buying_size_type>"
+      "   <buying_size_val>0.5</buying_size_val>";
 
   int simdur = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
   int id = sim.Run();
@@ -637,18 +635,18 @@ TEST_F(StorageTest, FixedBuyingSize){
   EXPECT_NEAR(0.5, qr.GetVal<double>("Quantity", 1), 0.00001);
 }
 
-TEST_F(StorageTest, UniformBuyingSize){
+TEST_F(StorageTest, UniformBuyingSize) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <buying_size_type>Uniform</buying_size_type>"
-    "   <buying_size_min>0.5</buying_size_min>"
-    "   <buying_size_max>0.7</buying_size_max>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <buying_size_type>Uniform</buying_size_type>"
+      "   <buying_size_min>0.5</buying_size_min>"
+      "   <buying_size_max>0.7</buying_size_max>";
 
   int simdur = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
   int id = sim.Run();
@@ -658,18 +656,18 @@ TEST_F(StorageTest, UniformBuyingSize){
   EXPECT_NEAR(0.68825, qr.GetVal<double>("Quantity", 1), 0.00001);
 }
 
-TEST_F(StorageTest, NormalBuyingSize){
+TEST_F(StorageTest, NormalBuyingSize) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <buying_size_type>Normal</buying_size_type>"
-    "   <buying_size_mean>0.5</buying_size_mean>"
-    "   <buying_size_stddev>0.1</buying_size_stddev>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <buying_size_type>Normal</buying_size_type>"
+      "   <buying_size_mean>0.5</buying_size_mean>"
+      "   <buying_size_stddev>0.1</buying_size_stddev>";
 
   int simdur = 2;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
 
@@ -680,24 +678,24 @@ TEST_F(StorageTest, NormalBuyingSize){
   EXPECT_NEAR(0.32648, qr.GetVal<double>("Quantity", 1), 0.00001);
 }
 
-TEST_F(StorageTest, NormalActiveDormantBuyingSize){
-    std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <active_buying_frequency_type>Normal</active_buying_frequency_type>"
-    "   <active_buying_mean>3</active_buying_mean>"
-    "   <active_buying_stddev>1</active_buying_stddev>"
-    "   <dormant_buying_frequency_type>Normal</dormant_buying_frequency_type>"
-    "   <dormant_buying_mean>2</dormant_buying_mean>"
-    "   <dormant_buying_stddev>1</dormant_buying_stddev>"
-    "   <buying_size_type>Normal</buying_size_type>"
-    "   <buying_size_mean>0.5</buying_size_mean>"
-    "   <buying_size_stddev>0.1</buying_size_stddev>";
+TEST_F(StorageTest, NormalActiveDormantBuyingSize) {
+  std::string config =
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <active_buying_frequency_type>Normal</active_buying_frequency_type>"
+      "   <active_buying_mean>3</active_buying_mean>"
+      "   <active_buying_stddev>1</active_buying_stddev>"
+      "   <dormant_buying_frequency_type>Normal</dormant_buying_frequency_type>"
+      "   <dormant_buying_mean>2</dormant_buying_mean>"
+      "   <dormant_buying_stddev>1</dormant_buying_stddev>"
+      "   <buying_size_type>Normal</buying_size_type>"
+      "   <buying_size_mean>0.5</buying_size_mean>"
+      "   <buying_size_stddev>0.1</buying_size_stddev>";
 
   int simdur = 15;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -732,61 +730,61 @@ TEST_F(StorageTest, NormalActiveDormantBuyingSize){
 TEST_F(StorageTest, IncorrectBuyPolSetupUniform) {
   // uniform missing min and max
   std::string config_uniform =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>";
 
   int simdur = 15;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config_uniform,
-                                         simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config_uniform,
+                      simdur);
   EXPECT_THROW(sim.Run(), cyclus::ValueError);
 }
 
 TEST_F(StorageTest, IncorrectBuyPolSetupNormal) {
   // normal missing mean and std dev
   std::string config_normal =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <active_buying_frequency_type>Normal</active_buying_frequency_type>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <active_buying_frequency_type>Normal</active_buying_frequency_type>";
   int simdur = 15;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config_normal,
-                                         simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config_normal,
+                      simdur);
   EXPECT_THROW(sim.Run(), cyclus::ValueError);
 }
 
 TEST_F(StorageTest, IncorrectBuyPolSetupMinMax) {
   // tries to set min > max
   std::string config_uniform_min_bigger_max =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput>"
-    "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>"
-    "   <active_buying_min>3</active_buying_min>"
-    "   <active_buying_max>2</active_buying_max>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput>"
+      "   <active_buying_frequency_type>Uniform</active_buying_frequency_type>"
+      "   <active_buying_min>3</active_buying_min>"
+      "   <active_buying_max>2</active_buying_max>";
 
   int simdur = 15;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), 
-                                         config_uniform_min_bigger_max, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"),
+                      config_uniform_min_bigger_max, simdur);
   EXPECT_THROW(sim.Run(), cyclus::ValueError);
 }
 
-TEST_F(StorageTest, PositionInitialize){
+TEST_F(StorageTest, PositionInitialize) {
   // Verify Storage behavior
 
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <residence_time>1</residence_time>"
-    "   <max_inv_size>10</max_inv_size>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <residence_time>1</residence_time>"
+      "   <max_inv_size>10</max_inv_size>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -798,20 +796,20 @@ TEST_F(StorageTest, PositionInitialize){
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 0.0);
 }
 
-TEST_F(StorageTest, Longitude){
+TEST_F(StorageTest, Longitude) {
   // Verify Storage behavior
 
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <residence_time>1</residence_time>"
-    "   <max_inv_size>10</max_inv_size>"
-    "   <latitude>50.0</latitude> "
-    "   <longitude>35.0</longitude> ";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <residence_time>1</residence_time>"
+      "   <max_inv_size>10</max_inv_size>"
+      "   <latitude>50.0</latitude> "
+      "   <longitude>35.0</longitude> ";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -825,14 +823,14 @@ TEST_F(StorageTest, Longitude){
 
 TEST_F(StorageTest, RQ_Inventory_Invalid) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <max_inv_size>5</max_inv_size>"
-    "   <reorder_point>2</reorder_point>"
-    "   <reorder_quantity>10</reorder_quantity>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <max_inv_size>5</max_inv_size>"
+      "   <reorder_point>2</reorder_point>"
+      "   <reorder_quantity>10</reorder_quantity>";
 
   int simdur = 2;
- 
+
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   EXPECT_THROW(int id = sim.Run(), cyclus::ValueError);
@@ -840,15 +838,15 @@ TEST_F(StorageTest, RQ_Inventory_Invalid) {
 
 TEST_F(StorageTest, RQ_Inventory) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <max_inv_size>5</max_inv_size>"
-    "   <reorder_point>2</reorder_point>"
-    "   <reorder_quantity>3</reorder_quantity>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <max_inv_size>5</max_inv_size>"
+      "   <reorder_point>2</reorder_point>"
+      "   <reorder_quantity>3</reorder_quantity>";
 
   int simdur = 5;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -873,14 +871,14 @@ TEST_F(StorageTest, RQ_Inventory) {
 
 TEST_F(StorageTest, sS_Inventory) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <max_inv_size>5</max_inv_size>"
-    "   <reorder_point>2</reorder_point>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <max_inv_size>5</max_inv_size>"
+      "   <reorder_point>2</reorder_point>";
 
   int simdur = 5;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -904,16 +902,16 @@ TEST_F(StorageTest, sS_Inventory) {
 
 TEST_F(StorageTest, CCap_Inventory) {
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <throughput>1</throughput> "
-    "   <cumulative_cap>2</cumulative_cap> "
-    "   <dormant_buying_frequency_type>Fixed</dormant_buying_frequency_type> "
-    "   <dormant_buying_val>2</dormant_buying_val> ";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <throughput>1</throughput> "
+      "   <cumulative_cap>2</cumulative_cap> "
+      "   <dormant_buying_frequency_type>Fixed</dormant_buying_frequency_type> "
+      "   <dormant_buying_val>2</dormant_buying_val> ";
 
   int simdur = 9;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
 
   sim.AddSource("spent_fuel").capacity(5).Finalize();
   sim.AddSink("dry_spent").Finalize();
@@ -941,13 +939,13 @@ TEST_F(StorageTest, CCap_Inventory) {
 TEST_F(StorageTest, PackageExactly) {
   // resource can be packaged without splitting or merging
   std::string config =
-    "   <in_commods> <val>spent_fuel</val> </in_commods> "
-    "   <out_commods> <val>dry_spent</val> </out_commods> "
-    "   <package>foo</package>";
+      "   <in_commods> <val>spent_fuel</val> </in_commods> "
+      "   <out_commods> <val>dry_spent</val> </out_commods> "
+      "   <package>foo</package>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
   sim.context()->AddPackage("foo", 1, 2, "first");
   cyclus::Package::Ptr p = sim.context()->GetPackage("foo");
 
@@ -977,13 +975,13 @@ TEST_F(StorageTest, PackageExactly) {
 TEST_F(StorageTest, PackageSplitEqual) {
   // Resources must be split into two to package. Packaging strategy equal
   std::string config =
-    "   <in_commods> <val>commodity</val> </in_commods> "
-    "   <out_commods> <val>commodity1</val> </out_commods> "
-    "   <package>foo</package>";
+      "   <in_commods> <val>commodity</val> </in_commods> "
+      "   <out_commods> <val>commodity1</val> </out_commods> "
+      "   <package>foo</package>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
   sim.context()->AddPackage("foo", 1, 2, "equal");
   cyclus::Package::Ptr p = sim.context()->GetPackage("foo");
 
@@ -993,9 +991,10 @@ TEST_F(StorageTest, PackageSplitEqual) {
   int id = sim.Run();
 
   std::vector<cyclus::Cond> tr_conds;
-  tr_conds.push_back(cyclus::Cond("Commodity", "==", std::string("commodity1")));
+  tr_conds.push_back(
+      cyclus::Cond("Commodity", "==", std::string("commodity1")));
   cyclus::QueryResult qr_trans = sim.db().Query("Transactions", &tr_conds);
-  // four transactions out of storage. Each resource is split, so two 
+  // four transactions out of storage. Each resource is split, so two
   // transactions at time 1, two at time 2
   EXPECT_EQ(4, qr_trans.rows.size());
 
@@ -1018,13 +1017,13 @@ TEST_F(StorageTest, PackageSplitEqual) {
 TEST_F(StorageTest, PackageSplitFirst) {
   // Resources must be split into two to package. Packaging strategy first
   std::string config =
-    "   <in_commods> <val>commodity</val> </in_commods> "
-    "   <out_commods> <val>commodity1</val> </out_commods> "
-    "   <package>foo</package>";
+      "   <in_commods> <val>commodity</val> </in_commods> "
+      "   <out_commods> <val>commodity1</val> </out_commods> "
+      "   <package>foo</package>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
   sim.context()->AddPackage("foo", 1, 2, "first");
   cyclus::Package::Ptr p = sim.context()->GetPackage("foo");
 
@@ -1034,9 +1033,10 @@ TEST_F(StorageTest, PackageSplitFirst) {
   int id = sim.Run();
 
   std::vector<cyclus::Cond> tr_conds;
-  tr_conds.push_back(cyclus::Cond("Commodity", "==", std::string("commodity1")));
+  tr_conds.push_back(
+      cyclus::Cond("Commodity", "==", std::string("commodity1")));
   cyclus::QueryResult qr_trans = sim.db().Query("Transactions", &tr_conds);
-  // four transactions out of storage. Each resource is split, so two 
+  // four transactions out of storage. Each resource is split, so two
   // transactions at time 1, two at time 2
   EXPECT_EQ(4, qr_trans.rows.size());
 
@@ -1051,17 +1051,17 @@ TEST_F(StorageTest, PackageSplitFirst) {
   // because package does split-first, resources are size 2 and 1
   EXPECT_EQ(qr_res.rows.size(), 4);
 
-  // order of trade execution is not guaranteed. Therefore, create vector, 
+  // order of trade execution is not guaranteed. Therefore, create vector,
   // sort by size, and then check values
   std::vector<double> pkgd_t0 = {qr_res.GetVal<double>("Quantity", 0),
-                                    qr_res.GetVal<double>("Quantity", 1)};
+                                 qr_res.GetVal<double>("Quantity", 1)};
   std::sort(pkgd_t0.begin(), pkgd_t0.end(), std::greater<double>());
   std::vector<double> exp_t0 = {2, 1};
 
   EXPECT_EQ(exp_t0, pkgd_t0);
 
   std::vector<double> pkgd_t1 = {qr_res.GetVal<double>("Quantity", 2),
-                                    qr_res.GetVal<double>("Quantity", 3)};
+                                 qr_res.GetVal<double>("Quantity", 3)};
   std::sort(pkgd_t1.begin(), pkgd_t1.end(), std::greater<double>());
   std::vector<double> exp_t1 = {2, 1};
 
@@ -1070,14 +1070,14 @@ TEST_F(StorageTest, PackageSplitFirst) {
 
 TEST_F(StorageTest, PackageMerge) {
   std::string config =
-    "   <in_commods> <val>commodity</val> </in_commods> "
-    "   <out_commods> <val>commodity1</val> </out_commods> "
-    "   <throughput>1</throughput> "
-    "   <package>foo</package>";
+      "   <in_commods> <val>commodity</val> </in_commods> "
+      "   <out_commods> <val>commodity1</val> </out_commods> "
+      "   <throughput>1</throughput> "
+      "   <package>foo</package>";
 
   int simdur = 5;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
   sim.context()->AddPackage("foo", 1, 2, "first");
   cyclus::Package::Ptr p = sim.context()->GetPackage("foo");
 
@@ -1087,7 +1087,8 @@ TEST_F(StorageTest, PackageMerge) {
   int id = sim.Run();
 
   std::vector<cyclus::Cond> tr_conds;
-  tr_conds.push_back(cyclus::Cond("Commodity", "==", std::string("commodity1")));
+  tr_conds.push_back(
+      cyclus::Cond("Commodity", "==", std::string("commodity1")));
 
   cyclus::QueryResult qr_trans = sim.db().Query("Transactions", &tr_conds);
   // two transactions out of storage. Because the source only provides 0.5 each
@@ -1108,16 +1109,16 @@ TEST_F(StorageTest, PackageMerge) {
 }
 
 TEST_F(StorageTest, TransportUnit) {
-    std::string config =
-    "   <in_commods> <val>commodity</val> </in_commods> "
-    "   <out_commods> <val>commodity1</val> </out_commods> "
-    "   <throughput>3</throughput> "
-    "   <package>foo</package>"
-    "   <transport_unit>bar</transport_unit>";
+  std::string config =
+      "   <in_commods> <val>commodity</val> </in_commods> "
+      "   <out_commods> <val>commodity1</val> </out_commods> "
+      "   <throughput>3</throughput> "
+      "   <package>foo</package>"
+      "   <transport_unit>bar</transport_unit>";
 
   int simdur = 3;
 
-  cyclus::MockSim sim(cyclus::AgentSpec (":cycamore:Storage"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"), config, simdur);
   sim.context()->AddPackage("foo", 1, 1, "first");
   cyclus::Package::Ptr p = sim.context()->GetPackage("foo");
   sim.context()->AddTransportUnit("bar", 2, 2, "first");
@@ -1128,7 +1129,8 @@ TEST_F(StorageTest, TransportUnit) {
   int id = sim.Run();
 
   std::vector<cyclus::Cond> tr_conds;
-  tr_conds.push_back(cyclus::Cond("Commodity", "==", std::string("commodity1")));
+  tr_conds.push_back(
+      cyclus::Cond("Commodity", "==", std::string("commodity1")));
 
   cyclus::QueryResult qr_trans = sim.db().Query("Transactions", &tr_conds);
   // 6 transactions. While all three units could be packaged in one time step,
@@ -1156,7 +1158,7 @@ TEST_F(StorageTest, TransportUnit) {
   EXPECT_EQ(1, qr_res.GetVal<double>("Quantity", 5));
 }
 
-} // namespace cycamore
+}  // namespace cycamore
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 cyclus::Agent* StorageConstructor(cyclus::Context* ctx) {
@@ -1168,11 +1170,11 @@ cyclus::Agent* StorageConstructor(cyclus::Context* ctx) {
 int ConnectAgentTests();
 static int cyclus_agent_tests_connected = ConnectAgentTests();
 #define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED
+#endif  // CYCLUS_AGENT_TESTS_CONNECTED
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_SUITE_P(StorageFac, FacilityTests,
-                        ::testing::Values(&StorageConstructor));
+                         ::testing::Values(&StorageConstructor));
 
 INSTANTIATE_TEST_SUITE_P(StorageFac, AgentTests,
-                        ::testing::Values(&StorageConstructor));
+                         ::testing::Values(&StorageConstructor));

--- a/src/storage_tests.h
+++ b/src/storage_tests.h
@@ -3,11 +3,10 @@
 
 #include <gtest/gtest.h>
 
-#include "storage.h"
-
+#include "agent_tests.h"
 #include "context.h"
 #include "facility_tests.h"
-#include "agent_tests.h"
+#include "storage.h"
 
 namespace cycamore {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -21,11 +20,12 @@ class StorageTest : public ::testing::Test {
   void InitParameters();
   void SetUpStorage();
   void TestInitState(cycamore::Storage* fac);
-  void TestAddMat(cycamore::Storage* fac, 
-      cyclus::Material::Ptr mat);
-  void TestBuffers(cycamore::Storage* fac, double inv, double 
+  void TestAddMat(cycamore::Storage* fac, cyclus::Material::Ptr mat);
+  void TestBuffers(cycamore::Storage* fac, double inv,
+                   double
 
-      proc, double ready, double stocks);
+                       proc,
+                   double ready, double stocks);
   void TestStocks(cycamore::Storage* fac, cyclus::CompMap v);
   void TestReadyTime(cycamore::Storage* fac, int t);
   void TestCurrentCap(cycamore::Storage* fac, double inv);
@@ -38,6 +38,5 @@ class StorageTest : public ::testing::Test {
   bool discrete_handling;
   std::string package;
 };
-} // namespace cycamore
-#endif // STORAGE_TESTS_H_
-
+}  // namespace cycamore
+#endif  // STORAGE_TESTS_H_

--- a/src/storage_tests.h
+++ b/src/storage_tests.h
@@ -3,10 +3,11 @@
 
 #include <gtest/gtest.h>
 
-#include "agent_tests.h"
+#include "storage.h"
+
 #include "context.h"
 #include "facility_tests.h"
-#include "storage.h"
+#include "agent_tests.h"
 
 namespace cycamore {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -20,12 +21,11 @@ class StorageTest : public ::testing::Test {
   void InitParameters();
   void SetUpStorage();
   void TestInitState(cycamore::Storage* fac);
-  void TestAddMat(cycamore::Storage* fac, cyclus::Material::Ptr mat);
-  void TestBuffers(cycamore::Storage* fac, double inv,
-                   double
+  void TestAddMat(cycamore::Storage* fac, 
+      cyclus::Material::Ptr mat);
+  void TestBuffers(cycamore::Storage* fac, double inv, double 
 
-                       proc,
-                   double ready, double stocks);
+      proc, double ready, double stocks);
   void TestStocks(cycamore::Storage* fac, cyclus::CompMap v);
   void TestReadyTime(cycamore::Storage* fac, int t);
   void TestCurrentCap(cycamore::Storage* fac, double inv);
@@ -38,5 +38,6 @@ class StorageTest : public ::testing::Test {
   bool discrete_handling;
   std::string package;
 };
-}  // namespace cycamore
-#endif  // STORAGE_TESTS_H_
+} // namespace cycamore
+#endif // STORAGE_TESTS_H_
+

--- a/src/storage_tests.h
+++ b/src/storage_tests.h
@@ -21,11 +21,12 @@ class StorageTest : public ::testing::Test {
   void InitParameters();
   void SetUpStorage();
   void TestInitState(cycamore::Storage* fac);
-  void TestAddMat(cycamore::Storage* fac, 
-      cyclus::Material::Ptr mat);
-  void TestBuffers(cycamore::Storage* fac, double inv, double 
+  void TestAddMat(cycamore::Storage* fac, cyclus::Material::Ptr mat);
+  void TestBuffers(cycamore::Storage* fac, double inv,
+                   double
 
-      proc, double ready, double stocks);
+                       proc,
+                   double ready, double stocks);
   void TestStocks(cycamore::Storage* fac, cyclus::CompMap v);
   void TestReadyTime(cycamore::Storage* fac, int t);
   void TestCurrentCap(cycamore::Storage* fac, double inv);
@@ -38,6 +39,5 @@ class StorageTest : public ::testing::Test {
   bool discrete_handling;
   std::string package;
 };
-} // namespace cycamore
-#endif // STORAGE_TESTS_H_
-
+}  // namespace cycamore
+#endif  // STORAGE_TESTS_H_


### PR DESCRIPTION
# Summary of Changes

This (massive, sorry) PR does three things: adds `//clang-format off` and `//clang-format on` protection to all `#pragma` blocks in cycamore/src, cleans up some of the `#pragma` blocks/checks spelling and grammar in comments, and then runs `clang-format` on all the files in cycamore/src.

# Related CEPs and Issues

This PR is related to:

- cyclus/cyclus#1674
- Closes #643 

# Associated Developers

@ahnaf-tahmid-chowdhury

# Design Notes

This PR, which I expect I will be told should be three PRs because it sort of does three separate (large) things, but which I'm going to do my darnedest to sneak by as one, was submitted as one PR because I used ChatGPT to help with a lot of the manual addition of `#pragma` protection, and while it was doing that I asked it to run a spelling/grammar/general style check as well. Then, and most importantly, it would have been almost impossible to correctly check that I had done this correctly had I not been able to actually run clang-format on the code, at which point I figured I'd just submit everything since it's all tied together in this way.

# Testing and Validation

The code was built locally on my machine. No additional tests were added.

# Checklist

 - [x] Read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide.
 - [x]  Compile and run locally.
 - [ ]  Add or update tests.
 - [ ]  Document if needed.
 - [x]  Follow style guidelines.
 - [ ]  Update the changelog.
 - [ ]  Address all review comments.
Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).