### PR TITLE
Implement CalculateBidPrice() functionality in Enrichment, Fuel_fab, and Source

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Since last release
 ======================
 
 **Added:**
+
+* Added CalculateBidPrice() functionality from facility_cost.cycpp.h to Enrichment, Source, and Fuel_Fab (#656)
 * Replaced manual matl_buy/sell_policy code in storage with code injection (#639)
 * Added package parameter to storage (#603, #612, #616)
 * Added package parameter to source (#613, #617, #621, #623, #630)

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -238,9 +238,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Enrichment::GetMatlBids(
         // swu_capacity here is wrong, but I'm not sure what's right...
         // Enrichment has a SWU capacity --> sells kg of U, but that cost depends
         // on how many SWUs it took to make it (???)
-        double bid_price = CalculateBidPrice(swu_capacity, swu_req, natu_req * avg_per_unit_cost);
-        double unit_price = bid_price/mat->quantity();
-        double pref = 1.0 / unit_price;
+        double pref = 1.0 / CalculateUnitPrice(swu_capacity, swu_req, natu_req * avg_per_unit_cost);
         
         commod_port->AddBid(req, offer, this, false, pref);
       }

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -253,6 +253,7 @@ class Enrichment
  private:
   // Code Injection:
   #include "toolkit/position.cycpp.h"
+  #include "toolkit/facility_cost.cycpp.h"
 
   ///   @brief adds a material into the natural uranium inventory
   ///   @throws if the material is not the same composition as the feed_recipe
@@ -377,6 +378,8 @@ class Enrichment
   double swu_capacity;
 
   double current_swu_capacity;
+  double total_qty_purchased = 0.0;
+  double avg_per_unit_cost = 0.0;
 
   #pragma cyclus var { 'capacity': 'max_feed_inventory' }
   cyclus::toolkit::ResBuf<cyclus::Material> inventory;  // natural u

--- a/src/fuel_fab.cc
+++ b/src/fuel_fab.cc
@@ -373,9 +373,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> FuelFab::GetMatlBids(
       Material::Ptr m2 = Material::CreateUntracked(fill_frac * tgt_qty, c_fill);
 
       double input_cost = m1->quantity() * avg_per_unit_fiss_cost + m2->quantity() * avg_per_unit_fill_cost;
-      double bid_price = CalculateBidPrice(throughput, tgt_qty, input_cost);
-      double unit_price = bid_price/tgt_qty;
-      double pref = 1.0 / unit_price;
+      double pref = 1.0 / CalculateUnitPrice(throughput, tgt_qty, input_cost);
 
       m1->Absorb(m2);
       bool exclusive = false;
@@ -393,9 +391,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> FuelFab::GetMatlBids(
       Material::Ptr m2 = Material::CreateUntracked(fiss_frac * tgt_qty, c_fiss);
 
       double input_cost = m1->quantity() * avg_per_unit_topup_cost + m2->quantity() * avg_per_unit_fiss_cost;
-      double bid_price = CalculateBidPrice(throughput, tgt_qty, input_cost);
-      double unit_price = bid_price/tgt_qty;
-      double pref = 1.0 / unit_price;
+      double pref = 1.0 / CalculateUnitPrice(throughput, tgt_qty, input_cost);
 
       m1->Absorb(m2);
       bool exclusive = false;

--- a/src/fuel_fab.h
+++ b/src/fuel_fab.h
@@ -136,6 +136,7 @@ class FuelFab
  private:
   // Code Injection:
   #include "toolkit/position.cycpp.h"
+  #include "toolkit/facility_cost.cycpp.h"
 
   #pragma cyclus var { \
     "doc": "Ordered list of commodities on which to requesting filler stream material.", \
@@ -264,6 +265,15 @@ class FuelFab
            " Use 'fission_spectrum_ave' for fast reactor compositions or 'thermal' for thermal reactors.", \
   }
   std::string spectrum;
+
+  double total_fiss_qty_purchased = 0.0;
+  double avg_per_unit_fiss_cost = 0.0;
+
+  double total_fill_qty_purchased = 0.0;
+  double avg_per_unit_fill_cost = 0.0;
+
+  double total_topup_qty_purchased = 0.0;
+  double avg_per_unit_topup_cost = 0.0;
 
   // intra-time-step state - no need to be a state var
   // map<request, inventory name>

--- a/src/source.cc
+++ b/src/source.cc
@@ -120,10 +120,7 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
           Material::CreateUntracked(*bit, target->comp()) : \
           Material::CreateUntracked(*bit, context()->GetRecipe(outrecipe));
       
-      // Calculate Pref in stages for readability
-      double bid_price = CalculateBidPrice(throughput, target->quantity());
-      double unit_price = bid_price/target->quantity();
-      double pref = 1.0 / unit_price;
+      double pref = 1.0 /CalculateUnitPrice(throughput, target->quantity());
 
       port->AddBid(req, m, this, false, pref);
     }

--- a/src/source.cc
+++ b/src/source.cc
@@ -119,7 +119,13 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
       m = outrecipe.empty() ? \
           Material::CreateUntracked(*bit, target->comp()) : \
           Material::CreateUntracked(*bit, context()->GetRecipe(outrecipe));
-      port->AddBid(req, m, this);
+      
+      // Calculate Pref in stages for readability
+      double bid_price = CalculateBidPrice(throughput, target->quantity());
+      double unit_price = bid_price/target->quantity();
+      double pref = 1.0 / unit_price;
+
+      port->AddBid(req, m, this, false, pref);
     }
   }
 

--- a/src/source.h
+++ b/src/source.h
@@ -83,6 +83,7 @@ class Source : public cyclus::Facility,
  private:
  // Code Injection:
  #include "toolkit/position.cycpp.h"
+ #include "toolkit/facility_cost.cycpp.h"
 
   #pragma cyclus var { \
     "tooltip": "source output commodity", \


### PR DESCRIPTION
# Summary of Changes

The functionality added by the CalculateBidCost()/CalculateBidPrice() functions was added to a few Cycamore facilities to open a wider conversation about the best way to implement this. 

# Related CEPs and Issues

This PR is related to:

- #642 
- Closes #648 
- Closes #654 
- Closes #649 

# Associated Developers

None.

# Design Notes

There are a few areas where I think this COULD be improved by some cleverness, but there are also some areas where I think a wider discussion about the way this is implemented generally could be good, so I didn't spend too long trying to make the code that may need to be changed anyway super slick.

# Testing and Validation

Built and tested Cyclus on my local machine. No tests were added, but I imagine some will be necessary.

# Checklist

 - [x] Read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide.
 - [x]  Compile and run locally.
 - [ ]  Add or update tests.
 - [ ]  Document if needed.
 - [x]  Follow style guidelines.
 - [ ]  Update the changelog.
 - [ ]  Address all review comments.
Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).