### PR TITLE
Add Conversion Facility to Cycamore

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Since last release
 ======================
 
 **Added:**
+* Added Conversion Facility (#657)
 * Replaced manual matl_buy/sell_policy code in storage with code injection (#639)
 * Added package parameter to storage (#603, #612, #616)
 * Added package parameter to source (#613, #617, #621, #623, #630)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,8 @@ SET(CYCLUS_CUSTOM_HEADERS "cycamore_version.h")
 
 USE_CYCLUS("cycamore" "reactor")
 
+USE_CYCLUS("cycamore" "conversion")
+
 USE_CYCLUS("cycamore" "fuel_fab")
 
 USE_CYCLUS("cycamore" "mixer")

--- a/src/conversion.cc
+++ b/src/conversion.cc
@@ -1,0 +1,205 @@
+#include <algorithm>
+#include <sstream>
+
+#include <boost/lexical_cast.hpp>
+#include "toolkit/mat_query.h"
+
+#include "conversion.h"
+
+using cyclus::RequestPortfolio;
+using cyclus::BidPortfolio;
+using cyclus::CommodMap;
+using cyclus::Request;
+using cyclus::Trade;
+using cyclus::Material;
+using cyclus::CapacityConstraint;
+using cyclus::toolkit::ResBuf;
+
+namespace cycamore {
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Conversion::Conversion(cyclus::Context* ctx)
+    : cyclus::Facility(ctx) {
+
+      // Make our Resource Buffers bulk buffers
+      input = ResBuf<Material>(true);
+      output = ResBuf<Material>(true);
+      waste = ResBuf<Material>(true);
+    }
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Conversion::~Conversion() {}
+
+#pragma cyclus def schema cycamore::Conversion
+#pragma cyclus def annotations cycamore::Conversion
+#pragma cyclus def infiletodb cycamore::Conversion
+#pragma cyclus def snapshot cycamore::Conversion
+#pragma cyclus def snapshotinv cycamore::Conversion
+#pragma cyclus def initinv cycamore::Conversion
+#pragma cyclus def clone cycamore::Conversion
+#pragma cyclus def initfromdb cycamore::Conversion
+#pragma cyclus def initfromcopy cycamore::Conversion
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void Conversion::EnterNotify() {
+  cyclus::Facility::EnterNotify();
+  InitializePosition();
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+std::string Conversion::str() {
+  using std::string;
+  using std::vector;
+  std::stringstream ss;
+  ss << cyclus::Facility::str();
+
+  string msg = "";
+  msg += "accepts commodities ";
+  for (vector<string>::iterator commod = incommods.begin();
+       commod != incommods.end();
+       commod++) {
+    msg += (commod == incommods.begin() ? "{" : ", ");
+    msg += (*commod);
+  }
+  msg += "} until its input is full at ";
+  msg += std::to_string(input.capacity());
+  msg += " kg.";
+
+  msg += "} and converts into commodity ";
+  ss << msg << outcommod;
+  return "" + ss.str();
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void Conversion::Tick() {
+  ConvertUranium();
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void Conversion::Tock() {
+  
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+double Conversion::CalculateNeededFeedstock() {
+  return input.capacity() - input.quantity();
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void Conversion::ConvertUranium() {
+  if (input.quantity() <= 0) return;
+  else if (input.quantity() < throughput) {
+    output.Push(input.Pop(input.quantity()));
+  } else {
+    output.Push(input.Pop(throughput));
+  }
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+std::set<RequestPortfolio<Material>::Ptr> Conversion::GetMatlRequests() {
+  std::set<RequestPortfolio<Material>::Ptr> ports;
+
+  // Check if we need material
+  double needed = CalculateNeededFeedstock();
+  if (needed <= 0) return ports;
+
+  // Create request portfolio
+  RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
+
+  // Create material request
+  Material::Ptr dummy = Material::CreateUntracked(needed,
+                                                 context()->GetRecipe(inrecipe_name));
+
+  // Add request for all commodities using default preference
+  for (std::vector<std::string>::iterator it = incommods.begin();
+       it != incommods.end(); ++it) {
+    Request<Material>* req = port->AddRequest(dummy, this, *it);
+  }
+
+  // Add capacity constraint to ensure we never get more feed than needed
+  CapacityConstraint<Material> cc(needed);
+  port->AddConstraint(cc);
+
+  ports.insert(port);
+  return ports;
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+std::set<BidPortfolio<Material>::Ptr> Conversion::GetMatlBids(
+  CommodMap<Material>::type& commod_requests) {
+  std::set<BidPortfolio<Material>::Ptr> ports;
+
+  // Check if we have material to offer
+  if (output.quantity() <= 0) return ports;
+
+  // Create bid portfolio
+  BidPortfolio<Material>::Ptr port(new BidPortfolio<Material>());
+
+  // Respond to requests for our commodity
+  std::vector<Request<Material>*>& requests = commod_requests[outcommod];
+  for (std::vector<Request<Material>*>::iterator it = requests.begin();
+      it != requests.end(); ++it) {
+
+    double available = output.quantity();
+    double requested = (*it)->target()->quantity();
+    double offer_qty = std::min(available, requested);
+
+    // This part may be wrong. Not sure if we really should pop here.
+    if (offer_qty > 0) {
+      Material::Ptr offer = Material::CreateUntracked(offer_qty, output.Peek()->comp());
+      port->AddBid(*it, offer, this);  // Note: *it, not **it
+    }
+  }
+
+  // Add capacity constraint so we never give out more than we have
+  CapacityConstraint<Material> cc(output.quantity());
+  port->AddConstraint(cc);
+
+  ports.insert(port);
+  return ports;
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void Conversion::AcceptMatlTrades(
+  const std::vector<std::pair<Trade<Material>, Material::Ptr>>& responses) {
+
+  for (std::vector<std::pair<Trade<Material>, Material::Ptr>>::const_iterator it =
+      responses.begin(); it != responses.end(); ++it) {
+
+    Material::Ptr mat = it->second;
+    cyclus::toolkit::MatQuery mq(mat);
+
+    // Check if there's uranium in the material
+    double u_mass = mq.mass(922350000) + mq.mass(922380000);
+
+    // If there's uranium, add it to the input buffer, otherwise add it to waste
+    if (u_mass > 0) {
+      input.Push(mat);
+    } else {
+      waste.Push(mat);
+    }
+  }
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void Conversion::GetMatlTrades(
+  const std::vector<Trade<Material>>& trades,
+  std::vector<std::pair<Trade<Material>, Material::Ptr>>& responses) {
+
+  for (std::vector<Trade<Material>>::const_iterator it = trades.begin();
+      it != trades.end(); ++it) {
+
+    double requested_qty = it->amt;
+    Material::Ptr response = output.Pop(requested_qty);
+
+    responses.push_back(std::make_pair(*it, response));
+  }
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+extern "C" cyclus::Agent* ConstructConversion(cyclus::Context* ctx) {
+  return new Conversion(ctx);
+}
+
+}  // namespace cycamore
+

--- a/src/conversion.cc
+++ b/src/conversion.cc
@@ -166,11 +166,9 @@ void Conversion::AcceptMatlTrades(
   for (std::vector<std::pair<Trade<Material>, Material::Ptr>>::const_iterator it =
       responses.begin(); it != responses.end(); ++it) {
 
-    Material::Ptr mat = it->second;
-    cyclus::toolkit::MatQuery mq(mat);
 
     // Add material to the input buffer
-    input.Push(mat);
+    input.Push(it->second);
     
   }
 }
@@ -183,8 +181,7 @@ void Conversion::GetMatlTrades(
   for (std::vector<Trade<Material>>::const_iterator it = trades.begin();
       it != trades.end(); ++it) {
 
-    double requested_qty = it->amt;
-    Material::Ptr response = output.Pop(requested_qty);
+    Material::Ptr response = output.Pop(it->amt);
 
     responses.push_back(std::make_pair(*it, response));
   }

--- a/src/conversion.cc
+++ b/src/conversion.cc
@@ -43,13 +43,6 @@ Conversion::~Conversion() {}
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Conversion::EnterNotify() {
   cyclus::Facility::EnterNotify();
-
-  // Handle the string to boolean conversion for track_flourine_str
-  if (track_flourine == "True") {
-    track_flourine_bool = true;
-  } else {
-    track_flourine_bool = false;
-  }
   InitializePosition();
 }
 
@@ -85,9 +78,7 @@ void Conversion::Tick() {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-void Conversion::Tock() {
-  RecordTimeSeries<double>("FlourineUsed", this, flourine_used, "kg");
-}
+void Conversion::Tock() {}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 double Conversion::AvailableFeedstockCapacity() {
@@ -96,11 +87,8 @@ double Conversion::AvailableFeedstockCapacity() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Conversion::Convert() {
-  flourine_used = 0.0;
   if (input.quantity() > 0) {
-    double converted_qty = std::min(input.quantity(), throughput);
-    output.Push(input.Pop(converted_qty));
-    flourine_used = converted_qty * flourine_uranium_ratio * track_flourine_bool;
+    output.Push(input.Pop(std::min(input.quantity(), throughput)));
   }
 }
 

--- a/src/conversion.cc
+++ b/src/conversion.cc
@@ -107,13 +107,17 @@ std::set<RequestPortfolio<Material>::Ptr> Conversion::GetMatlRequests() {
   RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
 
   // Create material request
-  Material::Ptr dummy = Material::CreateUntracked(needed,
-                                                 context()->GetRecipe(inrecipe_name));
+  Material::Ptr mat;
+  if (inrecipe_name.empty()) {
+    mat = cyclus::NewBlankMaterial(needed);
+  } else {
+    mat = Material::CreateUntracked(needed, context()->GetRecipe(inrecipe_name));
+  }
 
   // Add request for all commodities using default preference
   for (std::vector<std::string>::iterator it = incommods.begin();
        it != incommods.end(); ++it) {
-    Request<Material>* req = port->AddRequest(dummy, this, *it);
+    Request<Material>* req = port->AddRequest(mat, this, *it);
   }
 
   // Add capacity constraint to ensure we never get more feed than needed

--- a/src/conversion.cc
+++ b/src/conversion.cc
@@ -169,9 +169,6 @@ void Conversion::AcceptMatlTrades(
     Material::Ptr mat = it->second;
     cyclus::toolkit::MatQuery mq(mat);
 
-    // Check if there's uranium in the material
-    double u_mass = mq.mass(922350000) + mq.mass(922380000);
-
     // Add material to the input buffer
     input.Push(mat);
     

--- a/src/conversion.cc
+++ b/src/conversion.cc
@@ -103,13 +103,9 @@ std::set<RequestPortfolio<Material>::Ptr> Conversion::GetMatlRequests() {
   // Create request portfolio
   RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
 
-  // Create material request
-  Material::Ptr mat;
-  if (inrecipe_name.empty()) {
-    mat = cyclus::NewBlankMaterial(available_capacity);
-  } else {
-    mat = Material::CreateUntracked(available_capacity, context()->GetRecipe(inrecipe_name));
-  }
+  // Create material request with no recipe
+  Material::Ptr mat = cyclus::NewBlankMaterial(available_capacity);
+ 
 
   // Add request for all commodities using default preference
   for (std::vector<std::string>::iterator it = incommods.begin();

--- a/src/conversion.h
+++ b/src/conversion.h
@@ -79,27 +79,32 @@ class Conversion
 
   // clang-format off
   /// all facilities must have at least one input commodity
-  #pragma cyclus var {"tooltip": "input commodities", \
-                      "doc": "commodities that the conversion facility accepts", \
-                      "uilabel": "List of Input Commodities", \
-                      "uitype": ["oneormore", "incommodity"]}
+  #pragma cyclus var { \
+    "tooltip": "input commodities", \
+    "doc": "commodities that the conversion facility accepts", \
+    "uilabel": "List of Input Commodities", \
+    "uitype": ["oneormore", "incommodity"] \
+  }
   std::vector<std::string> incommods;
 
-    #pragma cyclus var {"default": [],\
-                      "doc":"preferences for each of the given commodities, in the same order."\
-                      "Defauts to 1 if unspecified",\
-                      "uilabel":"In Commody Preferences", \
-                      "range": [None, [CY_NEAR_ZERO, CY_LARGE_DOUBLE]], \
-                      "uitype":["oneormore", "range"]}
+    #pragma cyclus var { \
+      "default": [], \
+      "doc":"preferences for each of the given commodities, in the same order."\
+      "Defauts to 1 if unspecified",\
+      "uilabel":"In Commody Preferences", \
+      "range": [None, [CY_NEAR_ZERO, CY_LARGE_DOUBLE]], \
+      "uitype":["oneormore", "range"] \
+    }
   std::vector<double> incommod_prefs;
 
-   #pragma cyclus var {"default": "", \
-                      "tooltip": "requested composition", \
-                      "doc": "name of recipe to use for material requests, " \
-                             "where the default (empty string) is to accept " \
-                             "everything", \
-                      "uilabel": "Input Recipe", \
-                      "uitype": "inrecipe"}
+   #pragma cyclus var { \
+    "default": "", \
+    "tooltip": "requested composition", \
+    "doc": "name of recipe to use for material requests, where the default " \
+           "(empty string) is to accept everything", \
+    "uilabel": "Input Recipe", \
+    "uitype": "inrecipe" \
+  }
   std::string inrecipe_name;
   
   #pragma cyclus var { \
@@ -111,24 +116,53 @@ class Conversion
   std::string outcommod;
 
   /// throughput per timestep
-  #pragma cyclus var {"default": CY_LARGE_DOUBLE, \
-                      "tooltip": "conversion capacity", \
-                      "uilabel": "Maximum Throughput", \
-                      "uitype": "range", \
-                      "range": [0.0, CY_LARGE_DOUBLE], \
-                      "doc": "capacity the conversion facility can " \
-                             "convert at each time step"}
+  #pragma cyclus var { \
+    "default": CY_LARGE_DOUBLE, \
+    "tooltip": "conversion capacity", \
+    "uilabel": "Maximum Throughput", \
+    "uitype": "range", \
+    "range": [0.0, CY_LARGE_DOUBLE], \
+    "doc": "capacity the conversion facility can convert at each time step" \
+  }
   double throughput;
 
-  #pragma cyclus var {"default": CY_LARGE_DOUBLE, \
+  #pragma cyclus var { \
+    "default": CY_LARGE_DOUBLE, \
     "tooltip": "input buffer capacity", \
     "uilabel": "Maximum Storage of Input Buffer", \
     "uitype": "range", \
     "range": [0.0, CY_LARGE_DOUBLE], \
-    "doc": "capacity the conversion facility can " \
-           "accept at each time step"}
+    "doc": "capacity the conversion facility can accept at each time step" \
+  }
   double input_capacity;
+
+  #pragma cyclus var { \
+    "default": "False", \
+    "tooltip": "'True' or 'False'", \
+    "uilabel": "Boolean of whether to track flourine", \
+    "uitype": "combobox", \
+    "categorical": ["True", "False"], \
+    "doc": "Whether to track flourine in the conversion process. This is " \
+           "intended to be used ONLY when converting U3O8 into UF6." \
+           "This is a boolean variable, so it must be either 'True' or 'False'." \
+  }
+  std::string track_flourine;
+
+  #pragma cyclus var { \
+    "default": 0.47889, \
+    "tooltip": "kg of flourine per kg of uranium", \
+    "uilabel": "Flourine to Uranium Ratio", \
+    "uitype": "range", \
+    "range": [0.0, CY_LARGE_DOUBLE], \
+    "doc": "The ratio of flourine to uranium in the conversion process. This is " \
+           "intended to be used ONLY when converting U3O8 into UF6. Its default " \
+           "value is set to the stoichiometric ratio of flourine to uranium." \
+  }
+  double flourine_uranium_ratio;
   // clang-format on
+
+  double flourine_used;
+  bool track_flourine_bool;
 
   // clang-format off
   /// this facility holds a certain amount of material

--- a/src/conversion.h
+++ b/src/conversion.h
@@ -136,34 +136,6 @@ class Conversion
   }
   double input_capacity;
 
-  #pragma cyclus var { \
-    "default": "False", \
-    "tooltip": "'True' or 'False'", \
-    "uilabel": "Boolean of whether to track flourine", \
-    "uitype": "combobox", \
-    "categorical": ["True", "False"], \
-    "doc": "Whether to track flourine in the conversion process. This is " \
-           "intended to be used ONLY when converting U3O8 into UF6." \
-           "This is a boolean variable, so it must be either 'True' or 'False'." \
-  }
-  std::string track_flourine;
-
-  #pragma cyclus var { \
-    "default": 0.47889, \
-    "tooltip": "kg of flourine per kg of uranium", \
-    "uilabel": "Flourine to Uranium Ratio", \
-    "uitype": "range", \
-    "range": [0.0, CY_LARGE_DOUBLE], \
-    "doc": "The ratio of flourine to uranium in the conversion process. This is " \
-           "intended to be used ONLY when converting U3O8 into UF6. Its default " \
-           "value is set to the stoichiometric ratio of flourine to uranium." \
-  }
-  double flourine_uranium_ratio;
-  // clang-format on
-
-  double flourine_used;
-  bool track_flourine_bool;
-
   // clang-format off
   /// this facility holds a certain amount of material
   #pragma cyclus var {'capacity': 'input_capacity'}

--- a/src/conversion.h
+++ b/src/conversion.h
@@ -88,26 +88,6 @@ class Conversion
   std::vector<std::string> incommods;
 
   #pragma cyclus var { \
-    "default": [], \
-    "doc":"preferences for each of the given commodities, in the same order."\
-    "Defauts to 1 if unspecified",\
-    "uilabel":"In Commody Preferences", \
-    "range": [None, [CY_NEAR_ZERO, CY_LARGE_DOUBLE]], \
-    "uitype":["oneormore", "range"] \
-  }
-  std::vector<double> incommod_prefs;
-
-  #pragma cyclus var { \
-    "default": "", \
-    "tooltip": "requested composition", \
-    "doc": "name of recipe to use for material requests, where the default " \
-           "(empty string) is to accept everything", \
-    "uilabel": "Input Recipe", \
-    "uitype": "inrecipe" \
-  }
-  std::string inrecipe_name;
-  
-  #pragma cyclus var { \
     "tooltip": "output commodity", \
     "doc": "Output commodity on which the conversion facility offers material.", \
     "uilabel": "Output Commodity", \
@@ -115,14 +95,14 @@ class Conversion
   }
   std::string outcommod;
 
-  /// throughput per timestep
+  /// Conversion throughput per timestep
   #pragma cyclus var { \
     "default": CY_LARGE_DOUBLE, \
-    "tooltip": "conversion capacity", \
-    "uilabel": "Maximum Throughput", \
+    "tooltip": "conversion throughput per timestep", \
+    "uilabel": "Maximum conversion throughput", \
     "uitype": "range", \
     "range": [0.0, CY_LARGE_DOUBLE], \
-    "doc": "capacity the conversion facility can convert at each time step" \
+    "doc": "throughput the facility can convert at each time step" \
   }
   double throughput;
 
@@ -132,7 +112,9 @@ class Conversion
     "uilabel": "Maximum Storage of Input Buffer", \
     "uitype": "range", \
     "range": [0.0, CY_LARGE_DOUBLE], \
-    "doc": "capacity the conversion facility can accept at each time step" \
+    "doc": "Total capacity of the input buffer. The amount requested per " \
+    "time step is the minimum the conversion throughput and this capacity " \
+    "minus the amount of material in the input buffer." \
   }
   double input_capacity;
 

--- a/src/conversion.h
+++ b/src/conversion.h
@@ -87,17 +87,17 @@ class Conversion
   }
   std::vector<std::string> incommods;
 
-    #pragma cyclus var { \
-      "default": [], \
-      "doc":"preferences for each of the given commodities, in the same order."\
-      "Defauts to 1 if unspecified",\
-      "uilabel":"In Commody Preferences", \
-      "range": [None, [CY_NEAR_ZERO, CY_LARGE_DOUBLE]], \
-      "uitype":["oneormore", "range"] \
-    }
+  #pragma cyclus var { \
+    "default": [], \
+    "doc":"preferences for each of the given commodities, in the same order."\
+    "Defauts to 1 if unspecified",\
+    "uilabel":"In Commody Preferences", \
+    "range": [None, [CY_NEAR_ZERO, CY_LARGE_DOUBLE]], \
+    "uitype":["oneormore", "range"] \
+  }
   std::vector<double> incommod_prefs;
 
-   #pragma cyclus var { \
+  #pragma cyclus var { \
     "default": "", \
     "tooltip": "requested composition", \
     "doc": "name of recipe to use for material requests, where the default " \
@@ -136,7 +136,6 @@ class Conversion
   }
   double input_capacity;
 
-  // clang-format off
   /// this facility holds a certain amount of material
   #pragma cyclus var {'capacity': 'input_capacity'}
   cyclus::toolkit::ResBuf<cyclus::Material> input;

--- a/src/conversion.h
+++ b/src/conversion.h
@@ -1,0 +1,151 @@
+#ifndef CYCAMORE_SRC_CONVERSION_H_
+#define CYCAMORE_SRC_CONVERSION_H_
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "cyclus.h"
+#include "cycamore_version.h"
+
+// clang-format off
+#pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
+// clang-format on
+
+namespace cycamore {
+
+class Context;
+
+/// This facility acts as a simple conversion facility. Its current fidelity
+/// is incredibly low, but it will be expanded to operate more realistically
+/// in the future. 
+class Conversion
+  : public cyclus::Facility,
+    public cyclus::toolkit::Position  {
+ public:
+  Conversion(cyclus::Context* ctx);
+
+  virtual ~Conversion();
+
+  virtual std::string version() { return CYCAMORE_VERSION; }
+
+  // clanag-format off
+  #pragma cyclus note { \
+    "doc": \
+    " A conversion facility that accepts materials and products with a fixed\n"\
+    " throughput (per time step) and converts them into its outcommod. More\n"\
+    " complex behavior is planned for the future." \
+    }
+
+  #pragma cyclus decl
+  // clang-format on
+
+  virtual std::string str();
+
+  virtual void EnterNotify();
+
+  virtual void Tick();
+
+  virtual void Tock();
+  
+  double CalculateNeededFeedstock();
+
+  void ConvertUranium();
+
+
+  /// @brief Conversion Facilities request Materials of their given commodity.
+  virtual std::set<cyclus::RequestPortfolio<cyclus::Material>::Ptr>
+      GetMatlRequests();
+
+  virtual std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
+  GetMatlBids(cyclus::CommodMap<cyclus::Material>::type&
+      commod_requests);
+
+  virtual void GetMatlTrades(
+      const std::vector< cyclus::Trade<cyclus::Material> >& trades,
+      std::vector<std::pair<cyclus::Trade<cyclus::Material>,
+      cyclus::Material::Ptr> >& responses);
+
+  /// @brief Conversion Facilities place accepted trade Materials in their Inventory
+  virtual void AcceptMatlTrades(
+      const std::vector< std::pair<cyclus::Trade<cyclus::Material>,
+      cyclus::Material::Ptr> >& responses);
+
+ 
+
+ private:
+  // Code Injection:
+  #include "toolkit/position.cycpp.h"
+
+  // clang-format off
+  /// all facilities must have at least one input commodity
+  #pragma cyclus var {"tooltip": "input commodities", \
+                      "doc": "commodities that the conversion facility accepts", \
+                      "uilabel": "List of Input Commodities", \
+                      "uitype": ["oneormore", "incommodity"]}
+  std::vector<std::string> incommods;
+
+    #pragma cyclus var {"default": [],\
+                      "doc":"preferences for each of the given commodities, in the same order."\
+                      "Defauts to 1 if unspecified",\
+                      "uilabel":"In Commody Preferences", \
+                      "range": [None, [CY_NEAR_ZERO, CY_LARGE_DOUBLE]], \
+                      "uitype":["oneormore", "range"]}
+  std::vector<double> incommod_prefs;
+
+   #pragma cyclus var {"default": "", \
+                      "tooltip": "requested composition", \
+                      "doc": "name of recipe to use for material requests, " \
+                             "where the default (empty string) is to accept " \
+                             "everything", \
+                      "uilabel": "Input Recipe", \
+                      "uitype": "inrecipe"}
+  std::string inrecipe_name;
+  
+  #pragma cyclus var { \
+    "tooltip": "source output commodity", \
+    "doc": "Output commodity on which the source offers material.", \
+    "uilabel": "Output Commodity", \
+    "uitype": "outcommodity", \
+  }
+  std::string outcommod;
+
+  /// throughput per timestep
+  #pragma cyclus var {"default": CY_LARGE_DOUBLE, \
+                      "tooltip": "conversion capacity", \
+                      "uilabel": "Maximum Throughput", \
+                      "uitype": "range", \
+                      "range": [0.0, CY_LARGE_DOUBLE], \
+                      "doc": "capacity the conversion facility can " \
+                             "convert at each time step"}
+  double throughput;
+
+  #pragma cyclus var {"default": CY_LARGE_DOUBLE, \
+    "tooltip": "input buffer capacity", \
+    "uilabel": "Maximum Storage of Input Buffer", \
+    "uitype": "range", \
+    "range": [0.0, CY_LARGE_DOUBLE], \
+    "doc": "capacity the conversion facility can " \
+           "accept at each time step"}
+  double input_capacity;
+  // clang-format on
+
+  // clang-format off
+  /// this facility holds a certain amount of material
+  #pragma cyclus var {'capacity': 'input_capacity'}
+  cyclus::toolkit::ResBuf<cyclus::Material> input;
+
+  /// a buffer for outgoing material
+  cyclus::toolkit::ResBuf<cyclus::Material> output;
+
+  /// a buffer for waste material
+  cyclus::toolkit::ResBuf<cyclus::Material> waste;
+  // clang-format on
+
+};
+
+}  // namespace cycamore
+
+#endif  // CYCAMORE_SRC_CONVERSION_H_
+

--- a/src/conversion.h
+++ b/src/conversion.h
@@ -17,9 +17,9 @@ namespace cycamore {
 
 class Context;
 
-/// This facility acts as a simple conversion facility. Its current fidelity
-/// is incredibly low, but it will be expanded to operate more realistically
-/// in the future. 
+/// This facility acts as a simple conversion facility from its input commodity
+/// to its output commodity. It has a fixed throughput (per time step), and 
+/// converts without regard to the composition of the input material.
 class Conversion
   : public cyclus::Facility,
     public cyclus::toolkit::Position  {
@@ -33,9 +33,8 @@ class Conversion
   // clanag-format off
   #pragma cyclus note { \
     "doc": \
-    " A conversion facility that accepts materials and products with a fixed\n"\
-    " throughput (per time step) and converts them into its outcommod. More\n"\
-    " complex behavior is planned for the future." \
+    " A conversion facility that accepts materials and products and with a \n"\
+    " fixed throughput (per time step) converts them into its outcommod. " \
     }
 
   #pragma cyclus decl
@@ -49,9 +48,9 @@ class Conversion
 
   virtual void Tock();
   
-  double CalculateNeededFeedstock();
+  double AvailableFeedstockCapacity();
 
-  void ConvertUranium();
+  void Convert();
 
 
   /// @brief Conversion Facilities request Materials of their given commodity.
@@ -104,8 +103,8 @@ class Conversion
   std::string inrecipe_name;
   
   #pragma cyclus var { \
-    "tooltip": "source output commodity", \
-    "doc": "Output commodity on which the source offers material.", \
+    "tooltip": "output commodity", \
+    "doc": "Output commodity on which the conversion facility offers material.", \
     "uilabel": "Output Commodity", \
     "uitype": "outcommodity", \
   }
@@ -138,9 +137,6 @@ class Conversion
 
   /// a buffer for outgoing material
   cyclus::toolkit::ResBuf<cyclus::Material> output;
-
-  /// a buffer for waste material
-  cyclus::toolkit::ResBuf<cyclus::Material> waste;
   // clang-format on
 
 };


### PR DESCRIPTION
# Summary of Changes

Cycamore lacks a facility labeled "Conversion", which is a little confusing when you're trying to build out a whole fuel cycle model out of Cycamore. You CAN use other facilities to emulate a conversion facility (they're pretty simple), but that's not totally obvious how to do, and so I thought it might be nice to just add one.

# Related CEPs and Issues

This PR is related to:

- Closes #646 

# Associated Developers

None

# Design Notes

I used making this facility as a way to vet an "advanced cyclus agent development" tutorial I've been working on, and so that's why I defined the DRE functions manually instead of using the toolkit. It was good practice, since I've done it the other way (and also my tutorial worked great btw).

# Testing and Validation

I don't have any tests for this yet, since I wanted to run it by people first before I spent time on the not-so-fun parts of Agent development, but I did run and build this locally and then did some manual testing on my end to make sure it was doing the right things. It can buy and sell material and it "converts" it from Yellowcake to UF6 commodities. It also checks to make sure that there's actually uranium in its input, and if not it tosses that stuff out (adds it to a waste buffer). 


# Checklist

 - [x] Read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide.
 - [x]  Compile and run locally.
 - [ ]  Add or update tests.
 - [ ]  Document if needed.
 - [x]  Follow style guidelines.
 - [x]  Update the changelog.
 - [ ]  Address all review comments.
Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).