### PR TITLE
Tariff Region

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Since last release
 ======================
 
 **Added:**
+* Added TariffRegion Region (#661)
 * Added Conversion Facility (#657)
 * Replaced manual matl_buy/sell_policy code in storage with code injection (#639)
 * Added package parameter to storage (#603, #612, #616)

--- a/input/tariff_region.xml
+++ b/input/tariff_region.xml
@@ -1,0 +1,331 @@
+<simulation>
+  <control>
+    <duration>12</duration>
+    <startmonth>1</startmonth>
+    <startyear>2000</startyear>
+  </control>
+
+  <archetypes>
+    <spec><lib>cycamore</lib><name>Source</name></spec>
+    <spec><lib>cycamore</lib><name>Sink</name></spec>
+    <spec><lib>cycamore</lib><name>Conversion</name></spec>
+    <spec><lib>cycamore</lib><name>TariffRegion</name></spec>
+    <spec><lib>agents</lib><name>NullInst</name></spec>
+    <spec><lib>agents</lib><name>NullRegion</name></spec>
+  </archetypes>
+
+  <!--Start of the Recipe Section (REQUIRED)-->
+  <recipe>
+    <name>NaturalUranium</name>
+    <basis>atom</basis>
+    <nuclide>
+        <id>922350000</id>
+        <comp>0.007204</comp>
+    </nuclide>
+    <nuclide>
+        <id>922380000</id>
+        <comp>0.992796</comp>
+    </nuclide>
+  </recipe>
+
+  <!-- Start of the Facility Section (REQUIRED)-->
+  <facility>
+    <name>Uranium Mine</name>
+    <config>
+        <Source>
+            <outcommod>Yellowcake</outcommod>
+            <outrecipe>NaturalUranium</outrecipe>
+            <throughput>1000</throughput>
+        </Source>
+    </config>
+  </facility>
+
+   <facility>
+    <name>Iron Mine</name>
+    <config>
+        <Source>
+            <outcommod>IronOre</outcommod>
+            <throughput>1000</throughput>
+        </Source>
+    </config>
+  </facility>
+
+  <facility>
+    <name>Copper Mine</name>
+    <config>
+        <Source>
+            <outcommod>CopperOre</outcommod>
+            <throughput>1000</throughput>
+        </Source>
+    </config>
+  </facility>
+
+  <facility>
+    <name>Conversion</name>
+    <config>
+        <Conversion>
+            <incommods>
+                <val>Yellowcake</val>
+            </incommods>
+            <outcommod>UF6</outcommod>
+            <throughput>2000000000</throughput>
+        </Conversion>
+    </config>
+  </facility>
+
+  <facility>
+    <name>Iron Sink</name>
+    <config>
+        <Sink>
+            <in_commods>
+                <val>IronOre</val>
+            </in_commods>
+            <capacity>10000000000</capacity>
+        </Sink>
+    </config>
+  </facility>
+
+  <facility>
+    <name>Copper Sink</name>
+    <config>
+        <Sink>
+            <in_commods>
+                <val>CopperOre</val>
+            </in_commods>
+            <capacity>10000000000</capacity>
+        </Sink>
+    </config>
+  </facility>
+
+  <region>
+    <name>North Korea</name>
+    <config> <NullRegion /> </config>
+    <institution>
+      <name>OneInst</name>
+      <initialfacilitylist>
+        <entry>
+          <prototype>Uranium Mine</prototype>
+          <number>1</number>
+        </entry>
+        <entry>
+          <prototype>Iron Mine</prototype>
+          <number>1</number>
+        </entry>
+        <entry>
+          <prototype>Copper Mine</prototype>
+          <number>1</number>
+        </entry>
+      </initialfacilitylist>
+      <config>
+      <NullInst/>
+    </config>
+    </institution>
+  </region>
+
+  <region>
+    <name>Russia</name>
+    <config> <NullRegion /> </config>
+    <institution>
+      <name>TwoInst</name>
+      <initialfacilitylist>
+        <entry>
+          <prototype>Uranium Mine</prototype>
+          <number>1</number>
+        </entry>
+        <entry>
+          <prototype>Iron Mine</prototype>
+          <number>1</number>
+        </entry>
+        <entry>
+          <prototype>Copper Mine</prototype>
+          <number>1</number>
+        </entry>
+      </initialfacilitylist>
+      <config>
+      <NullInst/>
+    </config>
+    </institution>
+  </region>
+
+    <region>
+    <name>United Kingdom</name>
+    <config> <NullRegion /> </config>
+    <institution>
+      <name>ThreeInst</name>
+      <initialfacilitylist>
+        <entry>
+          <prototype>Uranium Mine</prototype>
+          <number>1</number>
+        </entry>
+        <entry>
+          <prototype>Iron Mine</prototype>
+          <number>1</number>
+        </entry>
+        <entry>
+          <prototype>Copper Mine</prototype>
+          <number>1</number>
+        </entry>
+      </initialfacilitylist>
+      <config>
+      <NullInst/>
+    </config>
+    </institution>
+  </region>
+
+    <region>
+    <name>France</name>
+    <config> <NullRegion /> </config>
+    <institution>
+      <name>FourInst</name>
+      <initialfacilitylist>
+        <entry>
+          <prototype>Uranium Mine</prototype>
+          <number>1</number>
+        </entry>
+        <entry>
+          <prototype>Iron Mine</prototype>
+          <number>1</number>
+        </entry>
+        <entry>
+          <prototype>Copper Mine</prototype>
+          <number>1</number>
+        </entry>
+      </initialfacilitylist>
+      <config>
+      <NullInst/>
+    </config>
+    </institution>
+  </region>
+
+    <region>
+    <name>Germany</name>
+    <config> <NullRegion /> </config>
+    <institution>
+      <name>FiveInst</name>
+      <initialfacilitylist>
+        <entry>
+          <prototype>Uranium Mine</prototype>
+          <number>1</number>
+        </entry>
+        <entry>
+          <prototype>Iron Mine</prototype>
+          <number>1</number>
+        </entry>
+        <entry>
+          <prototype>Copper Mine</prototype>
+          <number>1</number>
+        </entry>
+      </initialfacilitylist>
+      <config>
+      <NullInst/>
+    </config>
+    </institution>
+  </region>
+
+  <region>
+    <name>United States</name>
+    <config>
+      <TariffRegion>
+        <adjustment_regions>
+          <!-- North Korea: blanket 0.10, with specific adjustments for Yellowcake and IronOre -->
+          <item>
+            <region>North Korea</region>
+            <RegionConfig>
+              <blanket_adjustment>0.10</blanket_adjustment>
+              <commodity_adjustments>
+                <item>
+                  <commodity>Yellowcake</commodity>
+                  <adjustment>0.15</adjustment>
+                </item>
+                <item>
+                  <commodity>IronOre</commodity>
+                  <adjustment>0.25</adjustment>
+                </item>
+              </commodity_adjustments>
+            </RegionConfig>
+          </item>
+          <!-- Russia: blanket 0.20, with specific adjustments for Yellowcake and CopperOre -->
+          <item>
+            <region>Russia</region>
+            <RegionConfig>
+              <blanket_adjustment>0.20</blanket_adjustment>
+              <commodity_adjustments>
+                <item>
+                  <commodity>Yellowcake</commodity>
+                  <adjustment>-0.15</adjustment>
+                </item>
+                <item>
+                  <commodity>CopperOre</commodity>
+                  <adjustment>-0.25</adjustment>
+                </item>
+              </commodity_adjustments>
+            </RegionConfig>
+          </item>
+          <!-- United Kingdom: blanket 0.30, with specific adjustments for Yellowcake, IronOre, and CopperOre -->
+          <item>
+            <region>United Kingdom</region>
+            <RegionConfig>
+              <blanket_adjustment>0.30</blanket_adjustment>
+              <commodity_adjustments>
+                <item>
+                  <commodity>Yellowcake</commodity>
+                  <adjustment>0.35</adjustment>
+                </item>
+                <item>
+                  <commodity>IronOre</commodity>
+                  <adjustment>0.45</adjustment>
+                </item>
+                <item>
+                  <commodity>CopperOre</commodity>
+                  <adjustment>0.55</adjustment>
+                </item>
+              </commodity_adjustments>
+            </RegionConfig>
+          </item>
+          <!-- France: blanket 0.40, with specific adjustment for Yellowcake -->
+          <item>
+            <region>France</region>
+            <RegionConfig>
+              <blanket_adjustment>0.40</blanket_adjustment>
+              <commodity_adjustments>
+                <item>
+                  <commodity>Yellowcake</commodity>
+                  <adjustment>0.45</adjustment>
+                </item>
+              </commodity_adjustments>
+            </RegionConfig>
+          </item>
+          <!-- Germany: blanket -0.10, no commodity-specific adjustments -->
+          <item>
+            <region>Germany</region>
+            <RegionConfig>
+              <blanket_adjustment>-0.10</blanket_adjustment>
+              <commodity_adjustments/>
+            </RegionConfig>
+          </item>
+        </adjustment_regions>
+      </TariffRegion>
+    </config>
+    <institution>
+      <name>SixInst</name>
+      <initialfacilitylist>
+        <entry>
+          <prototype>Conversion</prototype>
+          <number>1</number>
+        </entry>
+        <entry>
+          <prototype>Iron Sink</prototype>
+          <number>1</number>
+        </entry>
+        <entry>
+          <prototype>Copper Sink</prototype>
+          <number>1</number>
+        </entry>
+      </initialfacilitylist>
+      <config>
+      <NullInst/>
+    </config>
+    </institution>
+  </region>
+
+</simulation>

--- a/input/tariff_region.xml
+++ b/input/tariff_region.xml
@@ -304,6 +304,19 @@
             </RegionConfig>
           </item>
         </adjustment_regions>
+        <!-- Global blanket adjustment: applies to all regions and commodities when no more specific tariff exists -->
+        <global_blanket_adjustment>0.05</global_blanket_adjustment>
+        <!-- Global commodity adjustments: apply to all regions for specific commodities when no more specific tariff exists -->
+        <global_commodity_adjustments>
+          <item>
+            <commodity>UF6</commodity>
+            <adjustment>0.20</adjustment>
+          </item>
+          <item>
+            <commodity>IronOre</commodity>
+            <adjustment>-0.05</adjustment>
+          </item>
+        </global_commodity_adjustments>
       </TariffRegion>
     </config>
     <institution>

--- a/input/tariff_region.xml
+++ b/input/tariff_region.xml
@@ -230,7 +230,7 @@
           <!-- North Korea: blanket 0.10, with specific adjustments for Yellowcake and IronOre -->
           <item>
             <region>North Korea</region>
-            <RegionConfig>
+            <AdjustmentConfig>
               <blanket_adjustment>0.10</blanket_adjustment>
               <commodity_adjustments>
                 <item>
@@ -242,12 +242,12 @@
                   <adjustment>0.25</adjustment>
                 </item>
               </commodity_adjustments>
-            </RegionConfig>
+            </AdjustmentConfig>
           </item>
           <!-- Russia: blanket 0.20, with specific adjustments for Yellowcake and CopperOre -->
           <item>
             <region>Russia</region>
-            <RegionConfig>
+            <AdjustmentConfig>
               <blanket_adjustment>0.20</blanket_adjustment>
               <commodity_adjustments>
                 <item>
@@ -259,12 +259,12 @@
                   <adjustment>-0.25</adjustment>
                 </item>
               </commodity_adjustments>
-            </RegionConfig>
+            </AdjustmentConfig>
           </item>
           <!-- United Kingdom: blanket 0.30, with specific adjustments for Yellowcake, IronOre, and CopperOre -->
           <item>
             <region>United Kingdom</region>
-            <RegionConfig>
+            <AdjustmentConfig>
               <blanket_adjustment>0.30</blanket_adjustment>
               <commodity_adjustments>
                 <item>
@@ -280,12 +280,12 @@
                   <adjustment>0.55</adjustment>
                 </item>
               </commodity_adjustments>
-            </RegionConfig>
+            </AdjustmentConfig>
           </item>
           <!-- France: blanket 0.40, with specific adjustment for Yellowcake -->
           <item>
             <region>France</region>
-            <RegionConfig>
+            <AdjustmentConfig>
               <blanket_adjustment>0.40</blanket_adjustment>
               <commodity_adjustments>
                 <item>
@@ -293,12 +293,12 @@
                   <adjustment>0.45</adjustment>
                 </item>
               </commodity_adjustments>
-            </RegionConfig>
+            </AdjustmentConfig>
           </item>
           <!-- Germany: blanket -0.10, no commodity-specific adjustments -->
           <item>
             <region>Germany</region>
-            <RegionConfig>
+            <AdjustmentConfig>
               <blanket_adjustment>-0.10</blanket_adjustment>
               <commodity_adjustments>
               <!-- Dummy commodity to allow for no commodity specific 
@@ -309,7 +309,7 @@
                   <adjustment>0.00</adjustment>
                 </item>
               </commodity_adjustments>
-            </RegionConfig>
+            </AdjustmentConfig>
           </item>
         </adjustment_regions>
         <!-- Global blanket adjustment: applies to all regions and commodities when no more specific tariff exists -->

--- a/input/tariff_region.xml
+++ b/input/tariff_region.xml
@@ -300,7 +300,15 @@
             <region>Germany</region>
             <RegionConfig>
               <blanket_adjustment>-0.10</blanket_adjustment>
-              <commodity_adjustments/>
+              <commodity_adjustments>
+              <!-- Dummy commodity to allow for no commodity specific 
+              adjustments. There MUST be at least one commodity in this list, 
+              otherwise RelaxNG Error will occur-->
+                <item>
+                  <commodity>None</commodity> 
+                  <adjustment>0.00</adjustment>
+                </item>
+              </commodity_adjustments>
             </RegionConfig>
           </item>
         </adjustment_regions>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,8 @@ USE_CYCLUS("cycamore" "manager_inst")
 
 USE_CYCLUS("cycamore" "growth_region")
 
+USE_CYCLUS("cycamore" "tariff_region")
+
 USE_CYCLUS("cycamore" "storage")
 
 INSTALL_CYCLUS_MODULE("cycamore" "" "NONE")

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -110,18 +110,18 @@ bool SortBids(cyclus::Bid<Material>* i,
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Sort offers of input material to have higher preference for more
 //  U-235 content
-void Enrichment::AdjustMatlPrefs(
-    cyclus::PrefMap<Material>::type& prefs) {
+void Enrichment::AdjustMatlParams(
+    cyclus::RequestBidMap<Material>::type& rb_map) {
   using cyclus::Bid;
 
   if (order_prefs == false) {
     return;
   }
 
-  cyclus::PrefMap<Material>::type::iterator reqit;
+  cyclus::RequestBidMap<Material>::type::iterator reqit;
 
   // Loop over all requests
-  for (reqit = prefs.begin(); reqit != prefs.end(); ++reqit) {
+  for (reqit = rb_map.begin(); reqit != rb_map.end(); ++reqit) {
     std::vector<Bid<Material>*> bids_vector;
     std::map<Bid<Material>*, double>::iterator mit;
     for (mit = reqit->second.begin(); mit != reqit->second.end(); ++mit) {

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -202,7 +202,7 @@ class Enrichment
   /// @brief The Enrichment adjusts preferences for offers of
   /// natural uranium it has received to maximize U-235 content
   /// Any offers that have zero U-235 content are not accepted
-  virtual void AdjustMatlPrefs(cyclus::PrefMap<cyclus::Material>::type& prefs);
+  virtual void AdjustMatlParams(cyclus::RequestBidMap<cyclus::Material>::type& rb_map);
 
   /// @brief The Enrichment place accepted trade Materials in their
   /// Inventory

--- a/src/fuel_fab.cc
+++ b/src/fuel_fab.cc
@@ -141,7 +141,7 @@ void FuelFab::EnterNotify() {
 
   if (fiss_commod_prefs.empty()) {
     for (int i = 0; i < fiss_commods.size(); i++) {
-      fiss_commod_prefs.push_back(cyclus::kDefaultPref);
+      fiss_commod_prefs.push_back(cyclus::kDefaultUnitCostMod);
     }
   } else if (fiss_commod_prefs.size() != fiss_commods.size()) {
     std::stringstream ss;
@@ -152,7 +152,7 @@ void FuelFab::EnterNotify() {
 
   if (fill_commod_prefs.empty()) {
     for (int i = 0; i < fill_commods.size(); i++) {
-      fill_commod_prefs.push_back(cyclus::kDefaultPref);
+      fill_commod_prefs.push_back(cyclus::kDefaultUnitCostMod);
     }
   } else if (fill_commod_prefs.size() != fill_commods.size()) {
     std::stringstream ss;

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -69,7 +69,7 @@ void Reactor::EnterNotify() {
   // type.  Without this segfaults could occur - yuck.
   if (fuel_prefs.size() == 0) {
     for (int i = 0; i < fuel_outcommods.size(); i++) {
-      fuel_prefs.push_back(cyclus::kDefaultPref);
+      fuel_prefs.push_back(cyclus::kDefaultUnitCostMod);
     }
   }
 

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -92,7 +92,7 @@ void Separations::EnterNotify() {
 
   if (feed_commod_prefs.size() == 0) {
     for (int i = 0; i < feed_commods.size(); i++) {
-      feed_commod_prefs.push_back(cyclus::kDefaultPref);
+      feed_commod_prefs.push_back(cyclus::kDefaultUnitCostMod);
     }
   }
 }

--- a/src/sink.cc
+++ b/src/sink.cc
@@ -45,7 +45,7 @@ void Sink::EnterNotify() {
 
   if (in_commod_prefs.size() == 0) {
     for (int i = 0; i < in_commods.size(); ++i) {
-      in_commod_prefs.push_back(cyclus::kDefaultPref);
+      in_commod_prefs.push_back(cyclus::kDefaultUnitCostMod);
     }
   } else if (in_commod_prefs.size() != in_commods.size()) {
     std::stringstream ss;

--- a/src/sink_tests.cc
+++ b/src/sink_tests.cc
@@ -52,7 +52,7 @@ TEST_F(SinkTest, InitialState) {
   EXPECT_EQ(vexp, src_facility->input_commodities());
 
   src_facility->EnterNotify();
-  double pref[] = {cyclus::kDefaultPref, cyclus::kDefaultPref};
+  double pref[] = {cyclus::kDefaultUnitCostMod, cyclus::kDefaultUnitCostMod};
   std::vector<double> vpref (pref, pref + sizeof(pref) / sizeof(pref[0]) );
   EXPECT_EQ(vpref, src_facility->input_commodity_preferences());
 }

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -84,7 +84,7 @@ void Storage::EnterNotify() {
 
   if (in_commod_prefs.size() == 0) {
     for (int i = 0; i < in_commods.size(); ++i) {
-      in_commod_prefs.push_back(cyclus::kDefaultPref);
+      in_commod_prefs.push_back(cyclus::kDefaultUnitCostMod);
     }
   } else if (in_commod_prefs.size() != in_commods.size()) {
     std::stringstream ss;

--- a/src/tariff_region.cc
+++ b/src/tariff_region.cc
@@ -78,17 +78,18 @@ void TariffRegion::AdjustProductPrefs(cyclus::PrefMap<cyclus::Product>::type& pr
       }
 
       // If the supplier is from a friend region, apply the appropriate subsidy
-      auto it = std::find(friend_regions.begin(), friend_regions.end(), 
-                      supplier_region);
-      if (it != friend_regions.end()) {
-        bid_pair.second *= 1.0 / (1.0 + friend_subsidies[it - friend_regions.begin()]);
+      auto it = std::find(friend_region_names.begin(), friend_region_names.end(), 
+                      supplier_region->prototype());
+      if (it != friend_region_names.end()) {
+        double cost_multiplier = 1.0 - friend_subsidies[it - friend_region_names.begin()];
+        bid_pair.second *= cost_multiplier > 0.0 ? 1.0 / cost_multiplier : std::numeric_limits<double>::infinity();
       }
 
       // If the supplier is from an enemy region, apply the appropriate tariff
-      it = std::find(enemy_regions.begin(), enemy_regions.end(), 
-                      supplier_region);
-      if (it != enemy_regions.end()) {
-        bid_pair.second *= 1.0 / enemy_tariffs[it - enemy_regions.begin()];
+      it = std::find(enemy_region_names.begin(), enemy_region_names.end(), 
+                      supplier_region->prototype());
+      if (it != enemy_region_names.end()) {
+        bid_pair.second *= 1.0 / enemy_tariffs[it - enemy_region_names.begin()];
       }
     }
   }

--- a/src/tariff_region.cc
+++ b/src/tariff_region.cc
@@ -35,11 +35,11 @@ void TariffRegion::AdjustMatlPrefs(cyclus::PrefMap<cyclus::Material>::type& pref
         current = current->parent();
       }
       
-      // If the supplier is in the region list, apply the appropriate tariff
+      // If the supplier is in the region list, apply the appropriate adjustment
       auto it = std::find(region_names.begin(), region_names.end(), 
           supplier_region->prototype());
       if (it != region_names.end()) {
-        double cost_multiplier = 1.0 + tariffs[it - region_names.begin()];
+        double cost_multiplier = 1.0 + adjustments[it - region_names.begin()];
         bid_pair.second *= cost_multiplier > 0.0 ? 1.0 / cost_multiplier : std::numeric_limits<double>::infinity();
       }
     }
@@ -70,11 +70,11 @@ void TariffRegion::AdjustProductPrefs(cyclus::PrefMap<cyclus::Product>::type& pr
         current = current->parent();
       }
 
-      // If the supplier is in the region list, apply the appropriate tariff
+      // If the supplier is in the region list, apply the appropriate adjustment
       auto it = std::find(region_names.begin(), region_names.end(), 
                       supplier_region->prototype());
       if (it != region_names.end()) {
-        double cost_multiplier = 1.0 + tariffs[it - region_names.begin()];
+        double cost_multiplier = 1.0 + adjustments[it - region_names.begin()];
         bid_pair.second *= cost_multiplier > 0.0 ? 1.0 / cost_multiplier : std::numeric_limits<double>::infinity();
       }
     }

--- a/src/tariff_region.cc
+++ b/src/tariff_region.cc
@@ -35,19 +35,12 @@ void TariffRegion::AdjustMatlPrefs(cyclus::PrefMap<cyclus::Material>::type& pref
         current = current->parent();
       }
       
-      // If the supplier is from a friend region, apply the appropriate subsidy
-      auto it = std::find(friend_region_names.begin(), friend_region_names.end(), 
+      // If the supplier is in the region list, apply the appropriate tariff
+      auto it = std::find(region_names.begin(), region_names.end(), 
           supplier_region->prototype());
-      if (it != friend_region_names.end()) {
-        double cost_multiplier = 1.0 - friend_subsidies[it - friend_region_names.begin()];
+      if (it != region_names.end()) {
+        double cost_multiplier = 1.0 + tariffs[it - region_names.begin()];
         bid_pair.second *= cost_multiplier > 0.0 ? 1.0 / cost_multiplier : std::numeric_limits<double>::infinity();
-      }
-
-      // If the supplier is from an enemy region, apply the appropriate tariff
-      it = std::find(enemy_region_names.begin(), enemy_region_names.end(), 
-          supplier_region->prototype());
-      if (it != enemy_region_names.end()) {
-        bid_pair.second *= 1.0 / enemy_tariffs[it - enemy_region_names.begin()];
       }
     }
   }
@@ -77,19 +70,12 @@ void TariffRegion::AdjustProductPrefs(cyclus::PrefMap<cyclus::Product>::type& pr
         current = current->parent();
       }
 
-      // If the supplier is from a friend region, apply the appropriate subsidy
-      auto it = std::find(friend_region_names.begin(), friend_region_names.end(), 
+      // If the supplier is in the region list, apply the appropriate tariff
+      auto it = std::find(region_names.begin(), region_names.end(), 
                       supplier_region->prototype());
-      if (it != friend_region_names.end()) {
-        double cost_multiplier = 1.0 - friend_subsidies[it - friend_region_names.begin()];
+      if (it != region_names.end()) {
+        double cost_multiplier = 1.0 + tariffs[it - region_names.begin()];
         bid_pair.second *= cost_multiplier > 0.0 ? 1.0 / cost_multiplier : std::numeric_limits<double>::infinity();
-      }
-
-      // If the supplier is from an enemy region, apply the appropriate tariff
-      it = std::find(enemy_region_names.begin(), enemy_region_names.end(), 
-                      supplier_region->prototype());
-      if (it != enemy_region_names.end()) {
-        bid_pair.second *= 1.0 / enemy_tariffs[it - enemy_region_names.begin()];
       }
     }
   }

--- a/src/tariff_region.cc
+++ b/src/tariff_region.cc
@@ -9,7 +9,9 @@ TariffRegion::~TariffRegion() {}
 
 void TariffRegion::EnterNotify() {
   Region::EnterNotify();
-
+  BuildRegionSet();
+  ValidateConfiguration();
+  BuildTariffLookups();
 }
 
 // Actual implementation of the DRE Functions using the template function:
@@ -19,6 +21,150 @@ void TariffRegion::AdjustMatlPrefs(cyclus::PrefMap<cyclus::Material>::type& pref
 
 void TariffRegion::AdjustProductPrefs(cyclus::PrefMap<cyclus::Product>::type& prefs) {
   AdjustPrefsImpl<cyclus::Product>(prefs);
+}
+
+void TariffRegion::BuildRegionSet() {
+  region_agents_.clear();
+  
+  // Get all agents in the simulation
+  const std::set<cyclus::Agent*>& all_agents = context()->GetAgentList();
+  
+  // Find all regions that match our region_names list
+  for (const auto& agent : all_agents) {
+    if (agent->kind() == "Region") {
+      cyclus::Region* region = static_cast<cyclus::Region*>(agent);
+      // Check if this region's prototype matches any in our list
+      auto it = std::find(region_names.begin(), region_names.end(), 
+                         region->prototype());
+      if (it != region_names.end()) {
+        region_agents_.insert(region);
+      }
+    }
+  }
+}
+
+std::pair<cyclus::Region*, int> TariffRegion::FindMatchingRegion(cyclus::Facility* supplier) {
+  // Get all parent regions of the supplier
+  std::vector<cyclus::Region*> parent_regions = supplier->GetAllParentRegions();
+  
+  // Check each parent region to see if it's in our tariff list
+  for (cyclus::Region* parent_region : parent_regions) {
+    if (region_agents_.find(parent_region) != region_agents_.end()) {
+      // Found a match! Find the corresponding adjustment index
+      auto it = std::find(region_names.begin(), region_names.end(), 
+                         parent_region->prototype());
+      if (it != region_names.end()) {
+        int index = it - region_names.begin();
+        return {parent_region, index};
+      }
+    }
+  }
+  
+  // No matching region found
+  return {nullptr, -1};
+}
+
+void TariffRegion::BuildTariffLookups() {
+  // Build fast lookup map
+  for (size_t i = 0; i < region_names.size(); ++i) {
+    // Populate the lookup map with the region name and its index
+    region_lookup_[region_names[i]] = i;
+  }
+}
+
+double TariffRegion::FindTariffForCommodity(cyclus::Region* region, const std::string& commodity) {
+  std::string region_name = region->prototype();
+  
+  // Check if the region is in the list, if not return 0.0
+  if (region_lookup_.find(region_name) == region_lookup_.end()) {
+    return 0.0;
+  }
+  
+  // We now know the region is in the list, so we can get the index:
+  size_t region_index = region_lookup_[region_name];
+  
+  // Check for commodity-specific tariff first
+  if (region_index < region_commodity_counts.size()) {
+    // Calculate the starting index for this region's commodities in the flattened list
+    size_t start_index = 0;
+    for (size_t i = 0; i < region_index; ++i) {
+      if (i < region_commodity_counts.size()) {
+        start_index += region_commodity_counts[i];
+      }
+    }
+    
+    // Search through this region's commodities
+    for (size_t j = 0; j < region_commodity_counts[region_index]; ++j) {
+      size_t commodity_index = start_index + j;
+      if (commodity_index < region_commodities.size() && 
+          commodity_index < region_adjustments.size() &&
+          region_commodities[commodity_index] == commodity) {
+        return region_adjustments[commodity_index];
+      }
+    }
+  }
+  
+  // Fall back to flat adjustment for this region
+  return (region_index < region_flat_adjustments.size()) ? 
+         region_flat_adjustments[region_index] : 0.0;
+}
+
+// A safety check to validate input since we're using a complex configuration
+void TariffRegion::ValidateConfiguration() {
+  // Check if we have any commodity-specific tariff configuration
+  if (region_names.empty()) {
+    return; // No configuration to validate
+  }
+  
+  size_t num_regions = region_names.size();
+  
+  // Helper lambda function to check list sizes and log warnings
+  auto check_list_size = [&](const std::string& list_name, size_t actual_size, 
+                             const std::string& fallback_msg) {
+    if (actual_size != num_regions) {
+      CLOG(cyclus::LEV_WARN) << "TariffRegion: Mismatch in region configuration. "
+                     << "Found " << num_regions << " region names but "
+                     << actual_size << " " << list_name << ". "
+                     << fallback_msg;
+    }
+  };
+  
+  // Check high-level list sizes
+  check_list_size("commodity counts", region_commodity_counts.size(), 
+                  "Using flat adjustments for missing regions.");
+  check_list_size("flat adjustments", region_flat_adjustments.size(), 
+                  "Using 0.0 tariff for missing flat adjustments.");
+  
+  // Validate flattened commodity/adjustment lists
+  size_t total_expected_commodities = 0;
+  for (size_t i = 0; i < region_commodity_counts.size(); ++i) {
+    total_expected_commodities += region_commodity_counts[i];
+  }
+  
+  if (region_commodities.size() != total_expected_commodities) {
+    CLOG(cyclus::LEV_WARN) << "TariffRegion: Mismatch in commodity list. "
+                   << "Expected " << total_expected_commodities 
+                   << " commodities based on region_commodity_counts but found "
+                   << region_commodities.size() << ". Using flat adjustments.";
+  }
+  
+  if (region_adjustments.size() != total_expected_commodities) {
+    CLOG(cyclus::LEV_WARN) << "TariffRegion: Mismatch in adjustment list. "
+                   << "Expected " << total_expected_commodities 
+                   << " adjustments based on region_commodity_counts but found "
+                   << region_adjustments.size() << ". Using flat adjustments.";
+  }
+  
+  // Check individual region configurations
+  for (size_t i = 0; i < num_regions; ++i) {
+    std::string region_name = region_names[i];
+    
+    // Check if this region has a flat adjustment
+    if (i >= region_flat_adjustments.size()) {
+      CLOG(cyclus::LEV_WARN) << "TariffRegion: Region '" << region_name 
+                     << "' has no flat adjustment specified. Using 0.0 tariff.";
+    }
+  }
 }
 
 extern "C" cyclus::Agent* ConstructTariffRegion(cyclus::Context* ctx) {

--- a/src/tariff_region.cc
+++ b/src/tariff_region.cc
@@ -1,0 +1,101 @@
+#include "tariff_region.h"
+
+namespace cycamore {
+
+TariffRegion::TariffRegion(cyclus::Context* ctx)
+: cyclus::Region(ctx) {}
+
+TariffRegion::~TariffRegion() {}
+
+void TariffRegion::EnterNotify() {
+  Region::EnterNotify();
+
+}
+
+void TariffRegion::AdjustMatlPrefs(cyclus::PrefMap<cyclus::Material>::type& prefs) {
+  for (auto& req_pair : prefs) {
+
+    // Iterate over the bids in the request portfolio
+    for (auto& bid_pair : req_pair.second) {
+
+      // Get the bid
+      cyclus::Bid<cyclus::Material>* bid = bid_pair.first;
+
+      // Get the supplier - use manager() to get the Agent* from the Trader*
+      cyclus::Agent* supplier = bid->bidder()->manager();
+
+      // Traverse up the hierarchy to get the supplier's region
+      cyclus::Region* supplier_region = nullptr;
+      cyclus::Agent* current = supplier;
+      while (current != nullptr) {
+        supplier_region = dynamic_cast<cyclus::Region*>(current);
+        if (supplier_region != nullptr) {
+          break;  // Found a region
+        }
+        current = current->parent();
+      }
+      
+      // If the supplier is from a friend region, apply the appropriate subsidy
+      auto it = std::find(friend_region_names.begin(), friend_region_names.end(), 
+          supplier_region->prototype());
+      if (it != friend_region_names.end()) {
+        double cost_multiplier = 1.0 - friend_subsidies[it - friend_region_names.begin()];
+        bid_pair.second *= cost_multiplier > 0.0 ? 1.0 / cost_multiplier : std::numeric_limits<double>::infinity();
+      }
+
+      // If the supplier is from an enemy region, apply the appropriate tariff
+      it = std::find(enemy_region_names.begin(), enemy_region_names.end(), 
+          supplier_region->prototype());
+      if (it != enemy_region_names.end()) {
+        bid_pair.second *= 1.0 / enemy_tariffs[it - enemy_region_names.begin()];
+      }
+    }
+  }
+}
+
+void TariffRegion::AdjustProductPrefs(cyclus::PrefMap<cyclus::Product>::type& prefs) {
+
+  // Iterate over the preferences
+  for (auto& req_pair : prefs) {
+    // Iterate over the bids in the request portfolio
+    for (auto& bid_pair : req_pair.second) {
+
+      // Get the bid
+      cyclus::Bid<cyclus::Product>* bid = bid_pair.first;
+
+      // Get the supplier - use manager() to get the Agent* from the Trader*
+      cyclus::Agent* supplier = bid->bidder()->manager();
+
+      // Traverse up the hierarchy to get the supplier's region
+      cyclus::Region* supplier_region = nullptr;
+      cyclus::Agent* current = supplier;
+      while (current != nullptr) {
+        supplier_region = dynamic_cast<cyclus::Region*>(current);
+        if (supplier_region != nullptr) {
+          break;  // Found a region
+        }
+        current = current->parent();
+      }
+
+      // If the supplier is from a friend region, apply the appropriate subsidy
+      auto it = std::find(friend_regions.begin(), friend_regions.end(), 
+                      supplier_region);
+      if (it != friend_regions.end()) {
+        bid_pair.second *= 1.0 / (1.0 + friend_subsidies[it - friend_regions.begin()]);
+      }
+
+      // If the supplier is from an enemy region, apply the appropriate tariff
+      it = std::find(enemy_regions.begin(), enemy_regions.end(), 
+                      supplier_region);
+      if (it != enemy_regions.end()) {
+        bid_pair.second *= 1.0 / enemy_tariffs[it - enemy_regions.begin()];
+      }
+    }
+  }
+}
+
+extern "C" cyclus::Agent* ConstructTariffRegion(cyclus::Context* ctx) {
+  return new TariffRegion(ctx);
+}
+
+}  // namespace cycamore

--- a/src/tariff_region.cc
+++ b/src/tariff_region.cc
@@ -12,73 +12,13 @@ void TariffRegion::EnterNotify() {
 
 }
 
+// Actual implementation of the DRE Functions using the template function:
 void TariffRegion::AdjustMatlPrefs(cyclus::PrefMap<cyclus::Material>::type& prefs) {
-  for (auto& req_pair : prefs) {
-
-    // Iterate over the bids in the request portfolio
-    for (auto& bid_pair : req_pair.second) {
-
-      // Get the bid
-      cyclus::Bid<cyclus::Material>* bid = bid_pair.first;
-
-      // Get the supplier - use manager() to get the Agent* from the Trader*
-      cyclus::Agent* supplier = bid->bidder()->manager();
-
-      // Traverse up the hierarchy to get the supplier's region
-      cyclus::Region* supplier_region = nullptr;
-      cyclus::Agent* current = supplier;
-      while (current != nullptr) {
-        supplier_region = dynamic_cast<cyclus::Region*>(current);
-        if (supplier_region != nullptr) {
-          break;  // Found a region
-        }
-        current = current->parent();
-      }
-      
-      // If the supplier is in the region list, apply the appropriate adjustment
-      auto it = std::find(region_names.begin(), region_names.end(), 
-          supplier_region->prototype());
-      if (it != region_names.end()) {
-        double cost_multiplier = 1.0 + adjustments[it - region_names.begin()];
-        bid_pair.second *= cost_multiplier > 0.0 ? 1.0 / cost_multiplier : std::numeric_limits<double>::infinity();
-      }
-    }
-  }
+  AdjustPrefsImpl<cyclus::Material>(prefs);
 }
 
 void TariffRegion::AdjustProductPrefs(cyclus::PrefMap<cyclus::Product>::type& prefs) {
-
-  // Iterate over the preferences
-  for (auto& req_pair : prefs) {
-    // Iterate over the bids in the request portfolio
-    for (auto& bid_pair : req_pair.second) {
-
-      // Get the bid
-      cyclus::Bid<cyclus::Product>* bid = bid_pair.first;
-
-      // Get the supplier - use manager() to get the Agent* from the Trader*
-      cyclus::Agent* supplier = bid->bidder()->manager();
-
-      // Traverse up the hierarchy to get the supplier's region
-      cyclus::Region* supplier_region = nullptr;
-      cyclus::Agent* current = supplier;
-      while (current != nullptr) {
-        supplier_region = dynamic_cast<cyclus::Region*>(current);
-        if (supplier_region != nullptr) {
-          break;  // Found a region
-        }
-        current = current->parent();
-      }
-
-      // If the supplier is in the region list, apply the appropriate adjustment
-      auto it = std::find(region_names.begin(), region_names.end(), 
-                      supplier_region->prototype());
-      if (it != region_names.end()) {
-        double cost_multiplier = 1.0 + adjustments[it - region_names.begin()];
-        bid_pair.second *= cost_multiplier > 0.0 ? 1.0 / cost_multiplier : std::numeric_limits<double>::infinity();
-      }
-    }
-  }
+  AdjustPrefsImpl<cyclus::Product>(prefs);
 }
 
 extern "C" cyclus::Agent* ConstructTariffRegion(cyclus::Context* ctx) {

--- a/src/tariff_region.cc
+++ b/src/tariff_region.cc
@@ -11,18 +11,11 @@ void TariffRegion::EnterNotify() {
   Region::EnterNotify();
   BuildRegionSet();
   ValidateConfiguration();
-  BuildTariffLookups();
+  BuildTariffRules();
 }
 
-
 void TariffRegion::Tock() {
-  // Record tariff configuration to database only once during first tock
-  if (!configuration_recorded_) {
-    CLOG(cyclus::LEV_INFO3) << "TariffRegion: Recording configuration to database during Tock";
     RecordTariffConfiguration();
-    configuration_recorded_ = true;
-    CLOG(cyclus::LEV_INFO3) << "TariffRegion: Configuration recorded successfully";
-  }
 }
 
 // Actual implementation of the DRE Functions using the template function:
@@ -35,8 +28,6 @@ void TariffRegion::AdjustProductPrefs(cyclus::PrefMap<cyclus::Product>::type& pr
 }
 
 void TariffRegion::BuildRegionSet() {
-  region_agents_.clear();
-  
   // Get all agents in the simulation
   const std::set<cyclus::Agent*>& all_agents = context()->GetAgentList();
   
@@ -48,52 +39,42 @@ void TariffRegion::BuildRegionSet() {
       auto it = std::find(region_names.begin(), region_names.end(), 
                          region->prototype());
       if (it != region_names.end()) {
-        region_agents_.insert(region);
+        adjustment_regions_.insert(region);
       }
     }
   }
 }
 
-std::pair<cyclus::Region*, int> TariffRegion::FindMatchingRegion(cyclus::Facility* supplier) {
+cyclus::Region* TariffRegion::FindMatchingRegion(cyclus::Facility* supplier) {
   // Get all parent regions of the supplier
   std::vector<cyclus::Region*> parent_regions = supplier->GetAllParentRegions();
   
   // Check each parent region to see if it's in our tariff list
   for (cyclus::Region* parent_region : parent_regions) {
-    if (region_agents_.find(parent_region) != region_agents_.end()) {
-      // Found a match! Find the corresponding adjustment index
-      auto it = std::find(region_names.begin(), region_names.end(), 
-                         parent_region->prototype());
-      if (it != region_names.end()) {
-        int index = it - region_names.begin();
-        return {parent_region, index};
-      }
+    if (adjustment_regions_.find(parent_region) != adjustment_regions_.end()) {
+      return parent_region;
     }
   }
   
   // No matching region found
-  return {nullptr, -1};
+  return nullptr;
 }
 
-void TariffRegion::BuildTariffLookups() {
-  // Build fast lookup map
-  for (size_t i = 0; i < region_names.size(); ++i) {
-    // Populate the lookup map with the region name and its index
-    region_lookup_[region_names[i]] = i;
-  }
+void TariffRegion::BuildTariffRules() {
+  tariff_rules_.clear();
+  region_flat_adjustments_map_.clear();
   
-  // Build tariff combinations for database recording
-  tariff_combinations_.clear();
-  
+  // Build tariff rules from the input configuration
   for (size_t i = 0; i < region_names.size(); ++i) {
     std::string region_name = region_names[i];
     double flat_adjustment = (i < region_flat_adjustments.size()) ? 
                              region_flat_adjustments[i] : 0.0;
     
-    // Add flat adjustment
-    tariff_combinations_.emplace_back(region_name, "Flat Adjustment", flat_adjustment);
+    // Store flat adjustment for this region
+    region_flat_adjustments_map_[region_name] = flat_adjustment;
     
-    // Add commodity-specific tariffs
+    // Figure out where in the list of commodities we start for this region
+    // Necessary because of the way we've implemented the input file
     if (i < region_commodity_counts.size()) {
       size_t start_index = 0;
       for (size_t j = 0; j < i; ++j) {
@@ -102,12 +83,13 @@ void TariffRegion::BuildTariffLookups() {
         }
       }
       
+      // Add commodity-specific tariff rules
       for (size_t j = 0; j < region_commodity_counts[i]; ++j) {
         size_t commodity_index = start_index + j;
         if (commodity_index < region_commodities.size() && 
             commodity_index < region_adjustments.size()) {
           
-          tariff_combinations_.emplace_back(
+          tariff_rules_.emplace_back(
             region_name, 
             region_commodities[commodity_index], 
             region_adjustments[commodity_index]
@@ -121,41 +103,31 @@ void TariffRegion::BuildTariffLookups() {
 double TariffRegion::FindTariffForCommodity(cyclus::Region* region, const std::string& commodity) {
   std::string region_name = region->prototype();
   
-  // Check if the region is in the list, if not return 0.0
-  if (region_lookup_.find(region_name) == region_lookup_.end()) {
-    return 0.0;
-  }
-  
-  // We now know the region is in the list, so we can get the index:
-  size_t region_index = region_lookup_[region_name];
-  
-  // Check for commodity-specific tariff first
-  if (region_index < region_commodity_counts.size()) {
-    // Calculate the starting index for this region's commodities in the flattened list
-    size_t start_index = 0;
-    for (size_t i = 0; i < region_index; ++i) {
-      if (i < region_commodity_counts.size()) {
-        start_index += region_commodity_counts[i];
-      }
-    }
-    
-    // Search through this region's commodities
-    for (size_t j = 0; j < region_commodity_counts[region_index]; ++j) {
-      size_t commodity_index = start_index + j;
-      if (commodity_index < region_commodities.size() && 
-          commodity_index < region_adjustments.size() &&
-          region_commodities[commodity_index] == commodity) {
-        return region_adjustments[commodity_index];
-      }
+  // First, look for a specific commodity tariff
+  for (const auto& rule : tariff_rules_) {
+    if (rule.region_name == region_name && rule.commodity == commodity) {
+      return rule.adjustment;
     }
   }
   
-  // Fall back to flat adjustment for this region
-  return (region_index < region_flat_adjustments.size()) ? 
-         region_flat_adjustments[region_index] : 0.0;
+  // If no specific tariff found, look for flat adjustment for this region
+  size_t region_index = 0;
+  for (size_t i = 0; i < region_names.size(); ++i) {
+    if (region_names[i] == region_name) {
+      region_index = i;
+      break;
+    }
+  }
+  
+  // Return flat adjustment if it exists for this region
+  if (region_index < region_flat_adjustments.size()) {
+    return region_flat_adjustments[region_index];
+  }
+  
+  // No tariff found, return 0.0
+  return 0.0;
 }
 
-// A simple validation check (no database recording)
 void TariffRegion::ValidateConfiguration() {
   // Simple validation: check if all input vectors have the same length
   if (!region_names.empty() && 
@@ -169,22 +141,18 @@ void TariffRegion::ValidateConfiguration() {
 
 void TariffRegion::RecordTariffConfiguration() {
   // Safety check: only record if we have valid data
-  if (tariff_combinations_.empty()) {
+  if (region_names.empty()) {
     return;  // No configuration to record
   }
-  
-  // Record each tariff combination
-  for (const auto& combo : tariff_combinations_) {
-    std::string region_name = std::get<0>(combo);
-    std::string commodity = std::get<1>(combo);
-    double adjustment = std::get<2>(combo);
-    
-    context()->NewDatum("TariffSummaryTable")
+
+  // Record each tariff rule (specific commodity tariffs)
+  for (const auto& rule : tariff_rules_) {
+    context()->NewDatum("CommoditySpecificTariffs")
         ->AddVal("AgentId", id())
         ->AddVal("Time", context()->time())
-        ->AddVal("Region", region_name)
-        ->AddVal("Commodity", commodity)
-        ->AddVal("Adjustment", adjustment)  // Convert to percentage
+        ->AddVal("Region", rule.region_name)
+        ->AddVal("Commodity", rule.commodity)
+        ->AddVal("Adjustment", rule.adjustment)
         ->Record();
   }
 }

--- a/src/tariff_region.cc
+++ b/src/tariff_region.cc
@@ -19,16 +19,18 @@ void TariffRegion::Tock() {
 }
 
 // Actual implementation of the DRE Functions using the template function:
-void TariffRegion::AdjustMatlPrefs(cyclus::PrefMap<cyclus::Material>::type& prefs) {
-  AdjustPrefsImpl<cyclus::Material>(prefs);
+void TariffRegion::AdjustMatlParams(RequestBidMap<Material>::type& rb_map) {
+  AdjustParams<cyclus::Material>(rb_map);
 }
 
-void TariffRegion::AdjustProductPrefs(cyclus::PrefMap<cyclus::Product>::type& prefs) {
-  AdjustPrefsImpl<cyclus::Product>(prefs);
+void TariffRegion::AdjustProductParams(RequestBidMap<Product>::type& rb_map) {
+  AdjustParams<cyclus::Product>(rb_map);
 }
 
 bool TariffRegion::HasTariffConfiguration() const {
-  return !adjustment_regions_.empty() || global_blanket_adjustment != 0.0 || 
+  return !region_commodity_adjustments_.empty() || 
+         !region_blanket_adjustments_.empty() || 
+         global_blanket_adjustment_.first != 0.0 || 
          !global_commodity_adjustments_.empty();
 }
 
@@ -36,157 +38,54 @@ bool TariffRegion::ConfigurationRecorded() const {
   return configuration_recorded_;
 }
 
-std::string TariffRegion::GetRegionName(cyclus::Region* region) const {
+std::string TariffRegion::GetRegionName(Region* region) const {
   return region->prototype();
 }
 
-std::vector<cyclus::Region*> TariffRegion::GetAncestorChain(cyclus::Region* region) {
-  std::vector<cyclus::Region*> chain;
-  cyclus::Agent* current = region;
-  
-  while (current != nullptr) {
-    cyclus::Region* current_region = dynamic_cast<cyclus::Region*>(current);
-    if (current_region != nullptr) {
-      chain.push_back(current_region);
-    }
-    current = current->parent();
-  }
-  
-  return chain;
-}
+Adjustment TariffRegion::FindAdjustmentForCommodity(
+    Region* region, const std::string& commodity) {
+  const std::string region_name = GetRegionName(region);
 
-cyclus::Region* TariffRegion::FindLowestCommonAncestor(cyclus::Region* r1, cyclus::Region* r2) {
-  // Get ancestor chains for both regions
-  std::vector<cyclus::Region*> chain1 = GetAncestorChain(r1);
-  std::vector<cyclus::Region*> chain2 = GetAncestorChain(r2);
-  
-  for (cyclus::Region* ancestor1 : chain1) {
-    for (cyclus::Region* ancestor2 : chain2) {
-      if (ancestor1 == ancestor2) {
-        return ancestor1;  // Found the lowest common ancestor
-      }
-    }
-  }
-  
-  // No common ancestor found (shouldn't happen in a well-formed simulation)
-  return nullptr;
-}
-
-double TariffRegion::FindMostSpecificTariff(cyclus::Region* importer_region,
-                                             const std::vector<cyclus::Region*>& supplier_hierarchy,
-                                             const std::string& commodity) {
-  // Check if this importer region is a TariffRegion with configuration
-  TariffRegion* tariff_importer = dynamic_cast<TariffRegion*>(importer_region);
-  if (tariff_importer == nullptr || !tariff_importer->HasTariffConfiguration()) {
-    return 0.0;  // Not a TariffRegion or has no configuration
-  }
-  
-  // Check supplier hierarchy from most specific (supplier itself) to least specific (root)
-  for (cyclus::Region* supplier_ancestor : supplier_hierarchy) {
-    std::string supplier_ancestor_name = GetRegionName(supplier_ancestor);
-    
-    // Check if this tariff region has any configuration for this supplier ancestor
-    auto region_it = tariff_importer->adjustment_regions_.find(supplier_ancestor_name);
-    if (region_it != tariff_importer->adjustment_regions_.end()) {
-      // Found a match! Now apply the tiered override system for this specific region
-      return tariff_importer->FindTariffForCommodity(supplier_ancestor, commodity);
-    }
-  }
-  
-  // No specific rule found for any level of supplier hierarchy
-  // Check if there are global rules (commodity-specific or blanket)
-  auto global_commodity_it = tariff_importer->global_commodity_adjustments_.find(commodity);
-  if (global_commodity_it != tariff_importer->global_commodity_adjustments_.end()) {
-    return global_commodity_it->second;
-  }
-  
-  return tariff_importer->global_blanket_adjustment;
-}
-
-double TariffRegion::ComputeAggregatedTariff(cyclus::Facility* supplier,
-                                              cyclus::Facility* requester,
-                                              const std::string& commodity) {
-  // Get the parent regions for both facilities
-  std::vector<cyclus::Region*> supplier_regions = supplier->GetAllParentRegions();
-  std::vector<cyclus::Region*> requester_regions = requester->GetAllParentRegions();
-  
-  // Handle edge cases
-  if (supplier_regions.empty() || requester_regions.empty()) {
-    return 0.0;  // No regions to compare
-  }
-  
-  // Get the immediate parent regions (first in the list)
-  cyclus::Region* supplier_region = supplier_regions[0];
-  cyclus::Region* requester_region = requester_regions[0];
-  
-  // If they're in the same region, no tariff applies
-  if (supplier_region == requester_region) {
-    return 0.0;
-  }
-  
-  // Find the Lowest Common Ancestor
-  cyclus::Region* lca = FindLowestCommonAncestor(supplier_region, requester_region);
-  
-  // Get supplier's full ancestor chain (for "most specific" lookups)
-  std::vector<cyclus::Region*> supplier_hierarchy = GetAncestorChain(supplier_region);
-  
-  // Get importer chain: from requester up to (but not including) LCA
-  std::vector<cyclus::Region*> importer_chain;
-  cyclus::Agent* current = requester_region;
-  while (current != nullptr && current != lca) {
-    cyclus::Region* current_region = dynamic_cast<cyclus::Region*>(current);
-    if (current_region != nullptr) {
-      importer_chain.push_back(current_region);
-    }
-    current = current->parent();
-  }
-  
-  // Aggregate tariffs from all importer regions
-  double total_tariff = 0.0;
-  for (cyclus::Region* importer : importer_chain) {
-    double tariff = FindMostSpecificTariff(importer, supplier_hierarchy, commodity);
-    total_tariff += tariff;
-  }
-  
-  return total_tariff;
-}
-
-double TariffRegion::FindTariffForCommodity(cyclus::Region* region, const std::string& commodity) {
-  std::string region_name = GetRegionName(region);
-  
-  // Tiered override system (most specific to least specific):
-  // 1. Region-specific commodity adjustment (highest priority)
+  // Tiered override system, from most specific to least specific:
+  //
+  // 1. Region-specific commodity adjustment
   // 2. Region blanket adjustment
   // 3. Global commodity adjustment
-  // 4. Global blanket adjustment (lowest priority)
-  
-  // Look up the region in our adjustment_regions_ map
-  auto region_it = adjustment_regions_.find(region_name);
-  if (region_it != adjustment_regions_.end()) {
-    const auto& region_data = region_it->second;
-    const auto& commodity_adjustments = region_data.second;
-    
-    // Tier 1: Check for region-specific commodity adjustment
+  // 4. Global blanket adjustment
+
+  // 1: Look for an adjustment matching both the supplier region and commodity.
+  auto region_it = region_commodity_adjustments_.find(region_name);
+
+  if (region_it != region_commodity_adjustments_.end()) {
+    const auto& commodity_adjustments = region_it->second;
     auto commodity_it = commodity_adjustments.find(commodity);
+
     if (commodity_it != commodity_adjustments.end()) {
-      return commodity_it->second;  // Most specific - override everything
-    }
-    
-    // Tier 2: Use region blanket adjustment
-    double region_blanket = region_data.first;
-    if (region_blanket != 0.0) {
-      return region_blanket;  // Override global adjustments
+      return commodity_it->second;
     }
   }
-  
-  // Tier 3: Check for global commodity-specific adjustment
-  auto global_commodity_it = global_commodity_adjustments_.find(commodity);
+
+  // 2: Look for a blanket adjustment matching the supplier region.
+  // NOTE: A missing entry means that this region inherits the applicable global
+  // adjustment. An entry with an adjustment of zero is an explicit exemption
+  // from the global adjustment.
+  auto region_blanket_it =
+      region_blanket_adjustments_.find(region_name);
+
+  if (region_blanket_it != region_blanket_adjustments_.end()) {
+    return region_blanket_it->second;
+  }
+
+  // 3: Look for a global adjustment matching the commodity.
+  auto global_commodity_it =
+      global_commodity_adjustments_.find(commodity);
+
   if (global_commodity_it != global_commodity_adjustments_.end()) {
-    return global_commodity_it->second;  // Override global blanket
+    return global_commodity_it->second;
   }
-  
-  // Tier 4: Use global blanket adjustment (lowest priority)
-  return global_blanket_adjustment;
+
+  // 4: Use the global blanket adjustment as the final fallback.
+  return global_blanket_adjustment_;
 }
 
 void TariffRegion::ValidateConfiguration() {
@@ -199,58 +98,66 @@ void TariffRegion::ValidateConfiguration() {
 }
 
 void TariffRegion::RecordTariffConfiguration() {
-  // Safety check: only record if we have valid data
   if (!HasTariffConfiguration()) {
-    configuration_recorded_ = true;  // Mark as recorded even if empty
-    return;  // No configuration to record
+    configuration_recorded_ = true;
+    return;
   }
-  
-  // Mark as recorded before actually recording (in case recording throws)
-  configuration_recorded_ = true;
 
-  // Record region-specific tariff configurations
-  for (const auto& region_entry : adjustment_regions_) {
+  for (const auto& region_entry : region_commodity_adjustments_) {
     const std::string& region_name = region_entry.first;
-    double blanket_adjustment = region_entry.second.first;
-    const auto& commodity_adjustments = region_entry.second.second;
-    
-    // Record blanket adjustment for this region
-    context()->NewDatum("RegionBlanketTariffs")
-        ->AddVal("AgentId", id())
-        ->AddVal("Time", context()->time())
-        ->AddVal("Region", region_name)
-        ->AddVal("Adjustment", blanket_adjustment)
-        ->Record();
-    
-    // Record commodity-specific adjustments for this region
+    const auto& commodity_adjustments = region_entry.second;
+
     for (const auto& commodity_entry : commodity_adjustments) {
+      const std::string& commodity = commodity_entry.first;
+      const Adjustment& adjustment = commodity_entry.second;
+
       context()->NewDatum("CommoditySpecificTariffs")
           ->AddVal("AgentId", id())
           ->AddVal("Time", context()->time())
           ->AddVal("Region", region_name)
-          ->AddVal("Commodity", commodity_entry.first)
-          ->AddVal("Adjustment", commodity_entry.second)
+          ->AddVal("Commodity", commodity)
+          ->AddVal("Adjustment", adjustment.first)
+          ->AddVal("Type", adjustment.second)
           ->Record();
     }
   }
-  
-  // Record global adjustments if present
-  if (global_blanket_adjustment != 0.0) {
+
+  for (const auto& region_entry : region_blanket_adjustments_) {
+    const std::string& region_name = region_entry.first;
+    const Adjustment& blanket = region_entry.second;
+
+    context()->NewDatum("RegionBlanketTariffs")
+        ->AddVal("AgentId", id())
+        ->AddVal("Time", context()->time())
+        ->AddVal("Region", region_name)
+        ->AddVal("Adjustment", blanket.first)
+        ->AddVal("Type", blanket.second)
+        ->Record();
+  }
+
+  if (global_blanket_adjustment_.first != 0.0) {
     context()->NewDatum("GlobalBlanketTariff")
         ->AddVal("AgentId", id())
         ->AddVal("Time", context()->time())
-        ->AddVal("Adjustment", global_blanket_adjustment)
+        ->AddVal("Adjustment", global_blanket_adjustment_.first)
+        ->AddVal("Type", global_blanket_adjustment_.second)
         ->Record();
   }
-  
+
   for (const auto& global_entry : global_commodity_adjustments_) {
+    const std::string& commodity = global_entry.first;
+    const Adjustment& adjustment = global_entry.second;
+
     context()->NewDatum("GlobalCommodityTariffs")
         ->AddVal("AgentId", id())
         ->AddVal("Time", context()->time())
-        ->AddVal("Commodity", global_entry.first)
-        ->AddVal("Adjustment", global_entry.second)
+        ->AddVal("Commodity", commodity)
+        ->AddVal("Adjustment", adjustment.first)
+        ->AddVal("Type", adjustment.second)
         ->Record();
   }
+
+  configuration_recorded_ = true;
 }
 
 extern "C" cyclus::Agent* ConstructTariffRegion(cyclus::Context* ctx) {

--- a/src/tariff_region.cc
+++ b/src/tariff_region.cc
@@ -3,7 +3,7 @@
 namespace cycamore {
 
 TariffRegion::TariffRegion(cyclus::Context* ctx)
-: cyclus::Region(ctx) {}
+: cyclus::Region(ctx), configuration_recorded_(false) {}
 
 TariffRegion::~TariffRegion() {}
 
@@ -13,7 +13,9 @@ void TariffRegion::EnterNotify() {
 }
 
 void TariffRegion::Tock() {
+  if (!ConfigurationRecorded()) {
     RecordTariffConfiguration();
+  }
 }
 
 // Actual implementation of the DRE Functions using the template function:
@@ -28,6 +30,10 @@ void TariffRegion::AdjustProductPrefs(cyclus::PrefMap<cyclus::Product>::type& pr
 bool TariffRegion::HasTariffConfiguration() const {
   return !adjustment_regions.empty() || global_blanket_adjustment != 0.0 || 
          !global_commodity_adjustments.empty();
+}
+
+bool TariffRegion::ConfigurationRecorded() const {
+  return configuration_recorded_;
 }
 
 std::string TariffRegion::GetRegionName(cyclus::Region* region) const {
@@ -93,7 +99,7 @@ void TariffRegion::ValidateConfiguration() {
   // Basic validation: check that adjustment_regions map is not empty if we expect tariffs
   // The nested structure itself enforces correctness (no parallel list mismatches possible)
   if (!HasTariffConfiguration()) {
-    CLOG(cyclus::LEV_INFO) << "TariffRegion: No tariff configuration specified. "
+    LOG(cyclus::LEV_INFO1, "TariffRegion") << "No tariff configuration specified. "
                    << "No adjustments will be applied.";
   }
 }
@@ -101,8 +107,12 @@ void TariffRegion::ValidateConfiguration() {
 void TariffRegion::RecordTariffConfiguration() {
   // Safety check: only record if we have valid data
   if (!HasTariffConfiguration()) {
+    configuration_recorded_ = true;  // Mark as recorded even if empty
     return;  // No configuration to record
   }
+  
+  // Mark as recorded before actually recording (in case recording throws)
+  configuration_recorded_ = true;
 
   // Record region-specific tariff configurations
   for (const auto& region_entry : adjustment_regions) {

--- a/src/tariff_region.cc
+++ b/src/tariff_region.cc
@@ -40,21 +40,115 @@ std::string TariffRegion::GetRegionName(cyclus::Region* region) const {
   return region->prototype();
 }
 
-cyclus::Region* TariffRegion::FindMatchingRegion(cyclus::Facility* supplier) {
-  // Get all parent regions of the supplier
-  std::vector<cyclus::Region*> parent_regions = supplier->GetAllParentRegions();
+std::vector<cyclus::Region*> TariffRegion::GetAncestorChain(cyclus::Region* region) {
+  std::vector<cyclus::Region*> chain;
+  cyclus::Agent* current = region;
   
-  // Check each parent region to see if it's in our tariff configuration
-  // We can directly look up by prototype name in the map (O(1) lookup)
-  for (cyclus::Region* parent_region : parent_regions) {
-    std::string region_name = GetRegionName(parent_region);
-    if (adjustment_regions_.find(region_name) != adjustment_regions_.end()) {
-      return parent_region;
+  while (current != nullptr) {
+    cyclus::Region* current_region = dynamic_cast<cyclus::Region*>(current);
+    if (current_region != nullptr) {
+      chain.push_back(current_region);
+    }
+    current = current->parent();
+  }
+  
+  return chain;
+}
+
+cyclus::Region* TariffRegion::FindLowestCommonAncestor(cyclus::Region* r1, cyclus::Region* r2) {
+  // Get ancestor chains for both regions
+  std::vector<cyclus::Region*> chain1 = GetAncestorChain(r1);
+  std::vector<cyclus::Region*> chain2 = GetAncestorChain(r2);
+  
+  for (cyclus::Region* ancestor1 : chain1) {
+    for (cyclus::Region* ancestor2 : chain2) {
+      if (ancestor1 == ancestor2) {
+        return ancestor1;  // Found the lowest common ancestor
+      }
     }
   }
   
-  // No matching region found
+  // No common ancestor found (shouldn't happen in a well-formed simulation)
   return nullptr;
+}
+
+double TariffRegion::FindMostSpecificTariff(cyclus::Region* importer_region,
+                                             const std::vector<cyclus::Region*>& supplier_hierarchy,
+                                             const std::string& commodity) {
+  // Check if this importer region is a TariffRegion with configuration
+  TariffRegion* tariff_importer = dynamic_cast<TariffRegion*>(importer_region);
+  if (tariff_importer == nullptr || !tariff_importer->HasTariffConfiguration()) {
+    return 0.0;  // Not a TariffRegion or has no configuration
+  }
+  
+  // Check supplier hierarchy from most specific (supplier itself) to least specific (root)
+  for (cyclus::Region* supplier_ancestor : supplier_hierarchy) {
+    std::string supplier_ancestor_name = GetRegionName(supplier_ancestor);
+    
+    // Check if this tariff region has any configuration for this supplier ancestor
+    auto region_it = tariff_importer->adjustment_regions_.find(supplier_ancestor_name);
+    if (region_it != tariff_importer->adjustment_regions_.end()) {
+      // Found a match! Now apply the tiered override system for this specific region
+      return tariff_importer->FindTariffForCommodity(supplier_ancestor, commodity);
+    }
+  }
+  
+  // No specific rule found for any level of supplier hierarchy
+  // Check if there are global rules (commodity-specific or blanket)
+  auto global_commodity_it = tariff_importer->global_commodity_adjustments_.find(commodity);
+  if (global_commodity_it != tariff_importer->global_commodity_adjustments_.end()) {
+    return global_commodity_it->second;
+  }
+  
+  return tariff_importer->global_blanket_adjustment;
+}
+
+double TariffRegion::ComputeAggregatedTariff(cyclus::Facility* supplier,
+                                              cyclus::Facility* requester,
+                                              const std::string& commodity) {
+  // Get the parent regions for both facilities
+  std::vector<cyclus::Region*> supplier_regions = supplier->GetAllParentRegions();
+  std::vector<cyclus::Region*> requester_regions = requester->GetAllParentRegions();
+  
+  // Handle edge cases
+  if (supplier_regions.empty() || requester_regions.empty()) {
+    return 0.0;  // No regions to compare
+  }
+  
+  // Get the immediate parent regions (first in the list)
+  cyclus::Region* supplier_region = supplier_regions[0];
+  cyclus::Region* requester_region = requester_regions[0];
+  
+  // If they're in the same region, no tariff applies
+  if (supplier_region == requester_region) {
+    return 0.0;
+  }
+  
+  // Find the Lowest Common Ancestor
+  cyclus::Region* lca = FindLowestCommonAncestor(supplier_region, requester_region);
+  
+  // Get supplier's full ancestor chain (for "most specific" lookups)
+  std::vector<cyclus::Region*> supplier_hierarchy = GetAncestorChain(supplier_region);
+  
+  // Get importer chain: from requester up to (but not including) LCA
+  std::vector<cyclus::Region*> importer_chain;
+  cyclus::Agent* current = requester_region;
+  while (current != nullptr && current != lca) {
+    cyclus::Region* current_region = dynamic_cast<cyclus::Region*>(current);
+    if (current_region != nullptr) {
+      importer_chain.push_back(current_region);
+    }
+    current = current->parent();
+  }
+  
+  // Aggregate tariffs from all importer regions
+  double total_tariff = 0.0;
+  for (cyclus::Region* importer : importer_chain) {
+    double tariff = FindMostSpecificTariff(importer, supplier_hierarchy, commodity);
+    total_tariff += tariff;
+  }
+  
+  return total_tariff;
 }
 
 double TariffRegion::FindTariffForCommodity(cyclus::Region* region, const std::string& commodity) {

--- a/src/tariff_region.cc
+++ b/src/tariff_region.cc
@@ -9,9 +9,7 @@ TariffRegion::~TariffRegion() {}
 
 void TariffRegion::EnterNotify() {
   Region::EnterNotify();
-  BuildRegionSet();
   ValidateConfiguration();
-  BuildTariffRules();
 }
 
 void TariffRegion::Tock() {
@@ -27,31 +25,24 @@ void TariffRegion::AdjustProductPrefs(cyclus::PrefMap<cyclus::Product>::type& pr
   AdjustPrefsImpl<cyclus::Product>(prefs);
 }
 
-void TariffRegion::BuildRegionSet() {
-  // Get all agents in the simulation
-  const std::set<cyclus::Agent*>& all_agents = context()->GetAgentList();
-  
-  // Find all regions that match our region_names list
-  for (const auto& agent : all_agents) {
-    if (agent->kind() == "Region") {
-      cyclus::Region* region = static_cast<cyclus::Region*>(agent);
-      // Check if this region's prototype matches any in our list
-      auto it = std::find(region_names.begin(), region_names.end(), 
-                         region->prototype());
-      if (it != region_names.end()) {
-        adjustment_regions_.insert(region);
-      }
-    }
-  }
+bool TariffRegion::HasTariffConfiguration() const {
+  return !adjustment_regions.empty() || global_blanket_adjustment != 0.0 || 
+         !global_commodity_adjustments.empty();
+}
+
+std::string TariffRegion::GetRegionName(cyclus::Region* region) const {
+  return region->prototype();
 }
 
 cyclus::Region* TariffRegion::FindMatchingRegion(cyclus::Facility* supplier) {
   // Get all parent regions of the supplier
   std::vector<cyclus::Region*> parent_regions = supplier->GetAllParentRegions();
   
-  // Check each parent region to see if it's in our tariff list
+  // Check each parent region to see if it's in our tariff configuration
+  // We can directly look up by prototype name in the map (O(1) lookup)
   for (cyclus::Region* parent_region : parent_regions) {
-    if (adjustment_regions_.find(parent_region) != adjustment_regions_.end()) {
+    std::string region_name = GetRegionName(parent_region);
+    if (adjustment_regions.find(region_name) != adjustment_regions.end()) {
       return parent_region;
     }
   }
@@ -60,93 +51,100 @@ cyclus::Region* TariffRegion::FindMatchingRegion(cyclus::Facility* supplier) {
   return nullptr;
 }
 
-void TariffRegion::BuildTariffRules() {
-  tariff_rules_.clear();
-  region_flat_adjustments_map_.clear();
-  
-  // Build tariff rules from the input configuration
-  size_t commodity_offset = 0;
-  for (size_t i = 0; i < region_names.size(); ++i) {
-    std::string region_name = region_names[i];
-    double flat_adjustment = (i < region_flat_adjustments.size()) ? 
-                             region_flat_adjustments[i] : 0.0;
-    
-    // Store flat adjustment for this region
-    region_flat_adjustments_map_[region_name] = flat_adjustment;
-    
-    // Figure out where in the list of commodities we start for this region
-    // Necessary because of the way we've implemented the input file
-    size_t commodities_for_region =
-        (i < commodity_counts_per_region.size()) ? commodity_counts_per_region[i] : 0;
-    size_t start_index = commodity_offset;
-    
-    // Add commodity-specific tariff rules
-    for (size_t j = 0; j < commodities_for_region; ++j) {
-      size_t commodity_index = start_index + j;
-      if (commodity_index < adjusted_commodities.size() && 
-          commodity_index < commodity_adjustments.size()) {
-        
-        tariff_rules_.emplace_back(
-          region_name, 
-          adjusted_commodities[commodity_index], 
-          commodity_adjustments[commodity_index]
-        );
-      }
-    }
-    
-    commodity_offset += commodities_for_region;
-  }
-}
-
 double TariffRegion::FindTariffForCommodity(cyclus::Region* region, const std::string& commodity) {
-  std::string region_name = region->prototype();
+  std::string region_name = GetRegionName(region);
   
-  // First, look for a specific commodity tariff
-  for (const auto& rule : tariff_rules_) {
-    if (rule.region_name == region_name && rule.commodity == commodity) {
-      return rule.adjustment;
+  // Tiered override system (most specific to least specific):
+  // 1. Region-specific commodity adjustment (highest priority)
+  // 2. Region blanket adjustment
+  // 3. Global commodity adjustment
+  // 4. Global blanket adjustment (lowest priority)
+  
+  // Look up the region in our adjustment_regions map
+  auto region_it = adjustment_regions.find(region_name);
+  if (region_it != adjustment_regions.end()) {
+    const auto& region_data = region_it->second;
+    const auto& commodity_adjustments = region_data.second;
+    
+    // Tier 1: Check for region-specific commodity adjustment
+    auto commodity_it = commodity_adjustments.find(commodity);
+    if (commodity_it != commodity_adjustments.end()) {
+      return commodity_it->second;  // Most specific - override everything
+    }
+    
+    // Tier 2: Use region blanket adjustment
+    double region_blanket = region_data.first;
+    if (region_blanket != 0.0) {
+      return region_blanket;  // Override global adjustments
     }
   }
   
-  // If no specific tariff found, fall back to the flat adjustment for this region
-  std::map<std::string, double>::const_iterator flat_it =
-      region_flat_adjustments_map_.find(region_name);
-  if (flat_it != region_flat_adjustments_map_.end()) {
-    return flat_it->second;
+  // Tier 3: Check for global commodity-specific adjustment
+  auto global_commodity_it = global_commodity_adjustments.find(commodity);
+  if (global_commodity_it != global_commodity_adjustments.end()) {
+    return global_commodity_it->second;  // Override global blanket
   }
   
-  // No tariff found, return 0.0
-  return 0.0;
+  // Tier 4: Use global blanket adjustment (lowest priority)
+  return global_blanket_adjustment;
 }
 
 void TariffRegion::ValidateConfiguration() {
-  // Simple validation: check if all input vectors have the same length
-  int num_adjusted_commodities = std::accumulate(commodity_counts_per_region.begin(), commodity_counts_per_region.end(), 0);
-  if (!region_names.empty() && 
-      (region_names.size() != commodity_counts_per_region.size() ||
-       region_names.size() != region_flat_adjustments.size()) ||
-       num_adjusted_commodities != adjusted_commodities.size() ||
-       num_adjusted_commodities != commodity_adjustments.size()) {
-    CLOG(cyclus::LEV_WARN) << "TariffRegion: Input vector length mismatch. "
-                   << "All input vectors should have the same length. "
-                   << "Using flat adjustments for missing regions.";
+  // Basic validation: check that adjustment_regions map is not empty if we expect tariffs
+  // The nested structure itself enforces correctness (no parallel list mismatches possible)
+  if (!HasTariffConfiguration()) {
+    CLOG(cyclus::LEV_INFO) << "TariffRegion: No tariff configuration specified. "
+                   << "No adjustments will be applied.";
   }
 }
 
 void TariffRegion::RecordTariffConfiguration() {
   // Safety check: only record if we have valid data
-  if (region_names.empty()) {
+  if (!HasTariffConfiguration()) {
     return;  // No configuration to record
   }
 
-  // Record each tariff rule (specific commodity tariffs)
-  for (const auto& rule : tariff_rules_) {
-    context()->NewDatum("CommoditySpecificTariffs")
+  // Record region-specific tariff configurations
+  for (const auto& region_entry : adjustment_regions) {
+    const std::string& region_name = region_entry.first;
+    double blanket_adjustment = region_entry.second.first;
+    const auto& commodity_adjustments = region_entry.second.second;
+    
+    // Record blanket adjustment for this region
+    context()->NewDatum("RegionBlanketTariffs")
         ->AddVal("AgentId", id())
         ->AddVal("Time", context()->time())
-        ->AddVal("Region", rule.region_name)
-        ->AddVal("Commodity", rule.commodity)
-        ->AddVal("Adjustment", rule.adjustment)
+        ->AddVal("Region", region_name)
+        ->AddVal("Adjustment", blanket_adjustment)
+        ->Record();
+    
+    // Record commodity-specific adjustments for this region
+    for (const auto& commodity_entry : commodity_adjustments) {
+      context()->NewDatum("CommoditySpecificTariffs")
+          ->AddVal("AgentId", id())
+          ->AddVal("Time", context()->time())
+          ->AddVal("Region", region_name)
+          ->AddVal("Commodity", commodity_entry.first)
+          ->AddVal("Adjustment", commodity_entry.second)
+          ->Record();
+    }
+  }
+  
+  // Record global adjustments if present
+  if (global_blanket_adjustment != 0.0) {
+    context()->NewDatum("GlobalBlanketTariff")
+        ->AddVal("AgentId", id())
+        ->AddVal("Time", context()->time())
+        ->AddVal("Adjustment", global_blanket_adjustment)
+        ->Record();
+  }
+  
+  for (const auto& global_entry : global_commodity_adjustments) {
+    context()->NewDatum("GlobalCommodityTariffs")
+        ->AddVal("AgentId", id())
+        ->AddVal("Time", context()->time())
+        ->AddVal("Commodity", global_entry.first)
+        ->AddVal("Adjustment", global_entry.second)
         ->Record();
   }
 }

--- a/src/tariff_region.cc
+++ b/src/tariff_region.cc
@@ -28,8 +28,8 @@ void TariffRegion::AdjustProductPrefs(cyclus::PrefMap<cyclus::Product>::type& pr
 }
 
 bool TariffRegion::HasTariffConfiguration() const {
-  return !adjustment_regions.empty() || global_blanket_adjustment != 0.0 || 
-         !global_commodity_adjustments.empty();
+  return !adjustment_regions_.empty() || global_blanket_adjustment != 0.0 || 
+         !global_commodity_adjustments_.empty();
 }
 
 bool TariffRegion::ConfigurationRecorded() const {
@@ -48,7 +48,7 @@ cyclus::Region* TariffRegion::FindMatchingRegion(cyclus::Facility* supplier) {
   // We can directly look up by prototype name in the map (O(1) lookup)
   for (cyclus::Region* parent_region : parent_regions) {
     std::string region_name = GetRegionName(parent_region);
-    if (adjustment_regions.find(region_name) != adjustment_regions.end()) {
+    if (adjustment_regions_.find(region_name) != adjustment_regions_.end()) {
       return parent_region;
     }
   }
@@ -66,9 +66,9 @@ double TariffRegion::FindTariffForCommodity(cyclus::Region* region, const std::s
   // 3. Global commodity adjustment
   // 4. Global blanket adjustment (lowest priority)
   
-  // Look up the region in our adjustment_regions map
-  auto region_it = adjustment_regions.find(region_name);
-  if (region_it != adjustment_regions.end()) {
+  // Look up the region in our adjustment_regions_ map
+  auto region_it = adjustment_regions_.find(region_name);
+  if (region_it != adjustment_regions_.end()) {
     const auto& region_data = region_it->second;
     const auto& commodity_adjustments = region_data.second;
     
@@ -86,8 +86,8 @@ double TariffRegion::FindTariffForCommodity(cyclus::Region* region, const std::s
   }
   
   // Tier 3: Check for global commodity-specific adjustment
-  auto global_commodity_it = global_commodity_adjustments.find(commodity);
-  if (global_commodity_it != global_commodity_adjustments.end()) {
+  auto global_commodity_it = global_commodity_adjustments_.find(commodity);
+  if (global_commodity_it != global_commodity_adjustments_.end()) {
     return global_commodity_it->second;  // Override global blanket
   }
   
@@ -96,7 +96,7 @@ double TariffRegion::FindTariffForCommodity(cyclus::Region* region, const std::s
 }
 
 void TariffRegion::ValidateConfiguration() {
-  // Basic validation: check that adjustment_regions map is not empty if we expect tariffs
+  // Basic validation: check that adjustment_regions_ map is not empty if we expect tariffs
   // The nested structure itself enforces correctness (no parallel list mismatches possible)
   if (!HasTariffConfiguration()) {
     LOG(cyclus::LEV_INFO1, "TariffRegion") << "No tariff configuration specified. "
@@ -115,7 +115,7 @@ void TariffRegion::RecordTariffConfiguration() {
   configuration_recorded_ = true;
 
   // Record region-specific tariff configurations
-  for (const auto& region_entry : adjustment_regions) {
+  for (const auto& region_entry : adjustment_regions_) {
     const std::string& region_name = region_entry.first;
     double blanket_adjustment = region_entry.second.first;
     const auto& commodity_adjustments = region_entry.second.second;
@@ -149,7 +149,7 @@ void TariffRegion::RecordTariffConfiguration() {
         ->Record();
   }
   
-  for (const auto& global_entry : global_commodity_adjustments) {
+  for (const auto& global_entry : global_commodity_adjustments_) {
     context()->NewDatum("GlobalCommodityTariffs")
         ->AddVal("AgentId", id())
         ->AddVal("Time", context()->time())

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -18,9 +18,6 @@ class TariffRegion : public cyclus::Region {
   #pragma cyclus
 
  private:
-  cyclus::Region* FindRegionByName(const std::string& name);
-  cyclus::Region* FindRegionInHierarchy(cyclus::Agent* agent, const std::string& name);
-
   #pragma cyclus var { \
     "default": [], \
     "doc": "List of regions that will have a trade adjustment applied to them." \

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -30,11 +30,11 @@ class TariffRegion : public cyclus::Region {
 
   #pragma cyclus var { \
     "default": [], \
-    "doc": "Multiplicative tariffs to apply to trades from affected " \
+    "doc": "Adjustments (1+val) to apply to trades from affected " \
     "regions (percent as decimal, must be in same order as " \
     "region_names). Positive values are tariffs, negative values are subsidies." \
   }
-  std::vector<double> tariffs;
+  std::vector<double> adjustments;
 
 };
 

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -23,16 +23,16 @@ class TariffRegion : public cyclus::Region {
 
   #pragma cyclus var { \
     "default": [], \
-    "doc": "List of regions that will have a trade adjustment " \
-    "(subsidy)" \
+    "doc": "List of regions that will have a trade adjustment applied to them." \
   }
   std::vector<std::string> region_names;
 
   #pragma cyclus var { \
     "default": [], \
-    "doc": "Adjustments (1+val) to apply to trades from affected " \
-    "regions (percent as decimal, must be in same order as " \
-    "region_names). Positive values are tariffs, negative values are subsidies." \
+    "doc": "Adjustments (multiply by (1+val)) to apply to cost of trades from " \
+           "affected regions. Positive values are tariffs, negative values " \
+           "are subsidies. Must be in same order as region_names." , \
+    "tooltip": "Percent as decimal." \
   }
   std::vector<double> adjustments;
 

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -23,32 +23,19 @@ class TariffRegion : public cyclus::Region {
 
   #pragma cyclus var { \
     "default": [], \
-    "doc": "List of regions that will have an advantageous trade adjustment " \
+    "doc": "List of regions that will have a trade adjustment " \
     "(subsidy)" \
   }
-  std::vector<std::string> friend_region_names;
+  std::vector<std::string> region_names;
 
   #pragma cyclus var { \
     "default": [], \
-    "doc": "List of regions that will have a disadvantageous trade adjustment " \
-    "(tariff)" \
-  }
-  std::vector<std::string> enemy_region_names;
-
-  #pragma cyclus var { \
-    "default": [], \
-    "doc": "Multiplicative tariff penalties to apply to trades from enemy " \
+    "doc": "Multiplicative tariffs to apply to trades from affected " \
     "regions (percent as decimal, must be in same order as " \
-    "enemy_region_names)" \
+    "region_names)" \
   }
-  std::vector<double> enemy_tariffs;
+  std::vector<double> tariffs;
 
-  #pragma cyclus var { \
-    "default": [], \
-    "doc": "Multiplicative subsidies to apply to trades from friend regions " \
-    "(percent as decimal, must be in same order as friend_region_names)" \
-  }
-  std::vector<double> friend_subsidies;
 };
 
 } // namespace cycamore

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -91,27 +91,28 @@ class TariffRegion : public cyclus::Region {
 
   #pragma cyclus var { \
     "default": [], \
-    "doc": "Commodities for each region (flattened list, use region_commodity_counts to parse)." \
+    "doc": "Commodities for each region (flattened list, use commodity_counts_per_region to parse)." \
   }
-  std::vector<std::string> region_commodities;
+  std::vector<std::string> adjusted_commodities;
 
   #pragma cyclus var { \
     "default": [], \
     "doc": "Adjustments for each region's commodities (flattened list, use region_commodity_counts to parse)." \
   }
-  std::vector<double> region_adjustments;
+  std::vector<double> commodity_adjustments;
 
   #pragma cyclus var { \
     "default": [], \
     "doc": "Number of commodities for each region (used to parse flattened commodity/adjustment lists)." \
   }
-  std::vector<int> region_commodity_counts;
+  std::vector<int> commodity_counts_per_region;
 
   #pragma cyclus var { \
     "default": [], \
     "doc": "Flat adjustment for each region (default tariff for unspecified commodities)." \
   }
   std::vector<double> region_flat_adjustments;
+
   // clang-format on
   
   // Pre-computed set of region agents for faster lookups

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -19,6 +19,8 @@ class TariffRegion : public cyclus::Region {
 
   virtual void EnterNotify();
 
+  virtual void Tock();
+
   // Required DRE Functions
   virtual void AdjustMatlPrefs(cyclus::PrefMap<cyclus::Material>::type& prefs);
   virtual void AdjustProductPrefs(cyclus::PrefMap<cyclus::Product>::type& prefs);
@@ -38,6 +40,9 @@ class TariffRegion : public cyclus::Region {
   
   // Validate the tariff configuration
   void ValidateConfiguration();
+  
+  // Record tariff configuration to database
+  void RecordTariffConfiguration();
 
   #pragma cyclus
 
@@ -106,6 +111,12 @@ class TariffRegion : public cyclus::Region {
   
   // Fast lookup map for performance
   std::map<std::string, size_t> region_lookup_;
+  
+  // Tariff combinations for database recording
+  std::vector<std::tuple<std::string, std::string, double>> tariff_combinations_;
+  
+  // Flag to track if configuration has been recorded to database
+  bool configuration_recorded_ = false;
   // clang-format on
 };
 

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -47,10 +47,10 @@ class TariffRegion : public cyclus::Region {
             supplier_region->prototype());
         if (it != region_names.end()) {
           double cost_multiplier = 1.0 + adjustments[it - region_names.begin()];
-          double pref = 1.0 / cost_multiplier;
+          double pref_multiplier = 1.0 / cost_multiplier;
           double inf = std::numeric_limits<double>::infinity(); 
 
-          bid_pair.second *= cost_multiplier > 0.0 ? pref : inf; 
+          bid_pair.second *= cost_multiplier > 0.0 ? pref_multiplier : inf; 
         }
       }
     }

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -34,9 +34,9 @@ class TariffRegion : public cyclus::Region {
 
         cyclus::Region* supplier_region = nullptr;
         cyclus::Agent* current = supplier;
-        while (current != nullptr) {
+        while (current) {
           supplier_region = dynamic_cast<cyclus::Region*>(current);
-          if (supplier_region != nullptr) {
+          if (supplier_region) {
             break;  // Found a region
           }
           current = current->parent();

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -32,7 +32,7 @@ class TariffRegion : public cyclus::Region {
     "default": [], \
     "doc": "Multiplicative tariffs to apply to trades from affected " \
     "regions (percent as decimal, must be in same order as " \
-    "region_names)" \
+    "region_names). Positive values are tariffs, negative values are subsidies." \
   }
   std::vector<double> tariffs;
 

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -1,0 +1,59 @@
+#ifndef CYCAMORE_SRC_TARIFF_REGION_H_
+#define CYCAMORE_SRC_TARIFF_REGION_H_
+
+#include "cyclus.h"
+#include <string>
+
+namespace cycamore {
+
+class TariffRegion : public cyclus::Region {
+ public:
+  TariffRegion(cyclus::Context* ctx);
+  virtual ~TariffRegion();
+
+  virtual void EnterNotify();
+  virtual void AdjustMatlPrefs(cyclus::PrefMap<cyclus::Material>::type& prefs);
+  virtual void AdjustProductPrefs(cyclus::PrefMap<cyclus::Product>::type& prefs);
+
+  #pragma cyclus
+
+ private:
+  cyclus::Region* FindRegionByName(const std::string& name);
+  cyclus::Region* FindRegionInHierarchy(cyclus::Agent* agent, const std::string& name);
+
+  #pragma cyclus var { \
+    "default": [], \
+    "doc": "List of regions that will have an advantageous trade adjustment " \
+    "(subsidy)" \
+  }
+  std::vector<std::string> friend_region_names;
+
+  #pragma cyclus var { \
+    "default": [], \
+    "doc": "List of regions that will have a disadvantageous trade adjustment " \
+    "(tariff)" \
+  }
+  std::vector<std::string> enemy_region_names;
+
+  #pragma cyclus var { \
+    "default": [], \
+    "doc": "Multiplicative tariff penalties to apply to trades from enemy " \
+    "regions (percent as decimal, must be in same order as " \
+    "enemy_region_names)" \
+  }
+  std::vector<double> enemy_tariffs;
+
+  #pragma cyclus var { \
+    "default": [], \
+    "doc": "Multiplicative subsidies to apply to trades from friend regions " \
+    "(percent as decimal, must be in same order as friend_region_names)" \
+  }
+  std::vector<double> friend_subsidies;
+
+  std::vector<cyclus::Region*> friend_regions;
+  std::vector<cyclus::Region*> enemy_regions;
+};
+
+} // namespace cycamore
+
+#endif  // CYCAMORE_SRC_TARIFF_REGION_H_

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -49,9 +49,6 @@ class TariffRegion : public cyclus::Region {
     "(percent as decimal, must be in same order as friend_region_names)" \
   }
   std::vector<double> friend_subsidies;
-
-  std::vector<cyclus::Region*> friend_regions;
-  std::vector<cyclus::Region*> enemy_regions;
 };
 
 } // namespace cycamore

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -30,17 +30,9 @@ class TariffRegion : public cyclus::Region {
       for (auto& bid_pair : req_pair.second) {
         cyclus::Bid<T>* bid = bid_pair.first;
 
-        cyclus::Agent* supplier = bid->bidder()->manager();
-
-        cyclus::Region* supplier_region = nullptr;
-        cyclus::Agent* current = supplier;
-        while (current) {
-          supplier_region = dynamic_cast<cyclus::Region*>(current);
-          if (supplier_region) {
-            break;  // Found a region
-          }
-          current = current->parent();
-        }
+        // The supplier should always be a facility, so we can cast to that
+        cyclus::Facility* supplier = dynamic_cast<cyclus::Facility*>(bid->bidder()->manager());
+        cyclus::Region* supplier_region = supplier->GetRegion();
         
         // If the supplier is in the region list, apply the appropriate adjustment
         auto it = std::find(region_names.begin(), region_names.end(), 
@@ -55,7 +47,7 @@ class TariffRegion : public cyclus::Region {
       }
     }
   }
-
+  // clang-format off
   #pragma cyclus var { \
     "default": [], \
     "doc": "List of regions that will have a trade adjustment applied to them." \
@@ -70,7 +62,7 @@ class TariffRegion : public cyclus::Region {
     "tooltip": "Percent as decimal." \
   }
   std::vector<double> adjustments;
-
+  // clang-format on
 };
 
 } // namespace cycamore

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -34,6 +34,9 @@ class TariffRegion : public cyclus::Region {
   // Helper: Check if any tariff configuration exists
   bool HasTariffConfiguration() const;
   
+  // Helper: Check if configuration has been recorded
+  bool ConfigurationRecorded() const;
+  
   // Helper: Get region prototype name (reduces repeated code)
   std::string GetRegionName(cyclus::Region* region) const;
   
@@ -48,28 +51,7 @@ class TariffRegion : public cyclus::Region {
   // Template function to reduce code duplication between AdjustMatlPrefs and 
   // AdjustProductPrefs
   template<typename T>
-  void AdjustPrefsImpl(typename cyclus::PrefMap<T>::type& prefs) {
-    for (auto& req_pair : prefs) {
-      std::string commodity = req_pair.first->commodity();
-      
-      for (auto& bid_pair : req_pair.second) {
-        cyclus::Bid<T>* bid = bid_pair.first;
-        cyclus::Facility* supplier = dynamic_cast<cyclus::Facility*>(bid->bidder()->manager());
-        
-        // Find if any of the supplier's parent regions match our tariff list
-        cyclus::Region* matching_region = FindMatchingRegion(supplier);
-        if (matching_region) {
-          double adjustment = FindTariffForCommodity(matching_region, commodity);
-          
-          double cost_multiplier = 1.0 + adjustment;
-          double pref_multiplier = 1.0 / cost_multiplier;
-          double inf = std::numeric_limits<double>::infinity(); 
-
-          bid_pair.second *= cost_multiplier > 0.0 ? pref_multiplier : inf; 
-        }
-      }
-    }
-  }
+  void AdjustPrefsImpl(typename cyclus::PrefMap<T>::type& prefs);
   
   // clang-format off
   #pragma cyclus var { \
@@ -92,7 +74,35 @@ class TariffRegion : public cyclus::Region {
 
   // clang-format on
   
+  // Flag to track if configuration has been recorded
+  bool configuration_recorded_;
+  
 };
+
+// Template function implementation (must be in header for template instantiation)
+template<typename T>
+void TariffRegion::AdjustPrefsImpl(typename cyclus::PrefMap<T>::type& prefs) {
+  for (auto& req_pair : prefs) {
+    std::string commodity = req_pair.first->commodity();
+    
+    for (auto& bid_pair : req_pair.second) {
+      cyclus::Bid<T>* bid = bid_pair.first;
+      cyclus::Facility* supplier = dynamic_cast<cyclus::Facility*>(bid->bidder()->manager());
+      
+      // Find if any of the supplier's parent regions match our tariff list
+      cyclus::Region* matching_region = FindMatchingRegion(supplier);
+      if (matching_region) {
+        double adjustment = FindTariffForCommodity(matching_region, commodity);
+        
+        double cost_multiplier = 1.0 + adjustment;
+        double pref_multiplier = 1.0 / cost_multiplier;
+        double inf = std::numeric_limits<double>::infinity(); 
+
+        bid_pair.second *= cost_multiplier > 0.0 ? pref_multiplier : inf; 
+      }
+    }
+  }
+}
 
 } // namespace cycamore
 

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -3,14 +3,18 @@
 
 #include "cyclus.h"
 #include <string>
-#include <limits>
 #include <utility>
 #include <map>
-#include <vector>
 
 namespace cycamore {
 
-class TariffRegion : public cyclus::Region {
+using cyclus::RequestBidMap;
+using cyclus::Material;
+using cyclus::Product;
+using cyclus::Region;
+using Adjustment = std::pair<double, std::string>;
+
+class TariffRegion : public Region {
  public:
   TariffRegion(cyclus::Context* ctx);
   virtual ~TariffRegion();
@@ -19,31 +23,15 @@ class TariffRegion : public cyclus::Region {
   virtual void Tock();
 
   // Required DRE Functions
-  virtual void AdjustMatlPrefs(cyclus::PrefMap<cyclus::Material>::type& prefs);
-  virtual void AdjustProductPrefs(cyclus::PrefMap<cyclus::Product>::type& prefs);
+  virtual void AdjustMatlParams(RequestBidMap<Material>::type& rb_map);
+  virtual void AdjustProductParams(RequestBidMap<Product>::type& rb_map);
 
  private:
-  // Compute aggregated tariff from all importer regions along the hierarchy
-  double ComputeAggregatedTariff(cyclus::Facility* supplier, 
-                                  cyclus::Facility* requester,
-                                  const std::string& commodity);
-  
-  // Find the Lowest Common Ancestor of two regions
-  cyclus::Region* FindLowestCommonAncestor(cyclus::Region* r1, cyclus::Region* r2);
-  
-  // Get the chain of ancestors from a region up to (and including) root
-  std::vector<cyclus::Region*> GetAncestorChain(cyclus::Region* region);
-  
-  // Find the most specific tariff rule for a supplier's hierarchy from an importer's perspective
-  // Returns the tariff value, checking supplier region hierarchy from most to least specific
-  double FindMostSpecificTariff(cyclus::Region* importer_region,
-                                const std::vector<cyclus::Region*>& supplier_hierarchy,
-                                const std::string& commodity);
-  
-  // Find the appropriate tariff for a given region and commodity
+
+  // Find the appropriate adjustment for a given region and commodity
   // Uses tiered override system: region-specific commodity > region blanket > 
   // global commodity > global blanket
-  double FindTariffForCommodity(cyclus::Region* region, const std::string& commodity);
+  Adjustment FindAdjustmentForCommodity(Region* region, const std::string& commodity);
   
   // Helper: Check if any tariff configuration exists
   bool HasTariffConfiguration() const;
@@ -52,7 +40,7 @@ class TariffRegion : public cyclus::Region {
   bool ConfigurationRecorded() const;
   
   // Helper: Get region prototype name (reduces repeated code)
-  std::string GetRegionName(cyclus::Region* region) const;
+  std::string GetRegionName(Region* region) const;
   
   // Validate the tariff configuration
   void ValidateConfiguration();
@@ -62,31 +50,48 @@ class TariffRegion : public cyclus::Region {
 
   #pragma cyclus
 
-  // Template function to reduce code duplication between AdjustMatlPrefs and 
-  // AdjustProductPrefs
+  // Template function to reduce code duplication between Adjust functions
   template<typename T>
-  void AdjustPrefsImpl(typename cyclus::PrefMap<T>::type& prefs);
+  void AdjustParams(typename RequestBidMap<T>::type& rb_map);
   
   // clang-format off
+  
+  /*
   #pragma cyclus var { \
     "default": {}, \
-    "alias": ["adjustment_regions", "region", ["AdjustmentConfig", "blanket_adjustment", ["commodity_adjustments", "commodity", "adjustment"]]], \
+    "alias": ["adjustment_regions", "region", ["AdjustmentConfig", ["blanket", "adjustment", "type"], ["commodity_adjustments", "commodity", ["Adjustment", "adjustment", "type"]]]], \
     "doc": "Tariff configuration: map from region name to (blanket_adjustment, commodity_adjustments_map). Each region can have a blanket adjustment for all commodities and specific adjustments per commodity." \
   }
-  std::map<std::string, std::pair<double, std::map<std::string, double>>> adjustment_regions_;
-
-  #pragma cyclus var { \
-    "default": 0.0, \
-    "doc": "Optional global blanket adjustment applied to all regions and commodities." \
-  }
-  double global_blanket_adjustment;
+  std::map<std::string, std::pair<std::pair<double, std::string>, std::map<std::string, std::pair<double, std::string>>>> adjustment_regions_;
+  */
 
   #pragma cyclus var { \
     "default": {}, \
-    "alias": ["global_commodity_adjustments", "commodity", "adjustment"], \
+    "alias": ["region_commodity_adjustments", "region", ["commodity_adjustments", "commodity", ["Adjustment", "val", "type"]]], \
+    "doc": "Commodity-specific adjustments for individual supplier regions." \
+  }
+  std::map<std::string, std::map<std::string, std::pair<double, std::string>>> region_commodity_adjustments_;
+
+  #pragma cyclus var { \
+    "default": {}, \
+    "alias": ["region_blanket_adjustments", "region", ["Adjustment", "val", "type"]], \
+    "doc": "Optional blanket adjustments for individual supplier regions." \
+  } 
+  std::map<std::string, std::pair<double, std::string>> region_blanket_adjustments_;
+
+  #pragma cyclus var { \
+    "default": [0.0, "unit_cost"], \
+    "alias": ["global_blanket_adjustment", "val", "type"], \
+    "doc": "Optional global blanket adjustment applied to all regions and commodities." \
+  }
+  std::pair<double, std::string> global_blanket_adjustment_;
+
+  #pragma cyclus var { \
+    "default": {}, \
+    "alias": ["global_commodity_adjustments", "commodity", ["Adjustment", "val", "type"]], \
     "doc": "Optional global commodity adjustments applied to all regions for specific commodities." \
   }
-  std::map<std::string, double> global_commodity_adjustments_;
+  std::map<std::string, std::pair<double, std::string>> global_commodity_adjustments_;
 
   // clang-format on
   
@@ -97,25 +102,38 @@ class TariffRegion : public cyclus::Region {
 
 // Template function implementation (must be in header for template instantiation)
 template<typename T>
-void TariffRegion::AdjustPrefsImpl(typename cyclus::PrefMap<T>::type& prefs) {
-  for (auto& req_pair : prefs) {
+void TariffRegion::AdjustParams(typename RequestBidMap<T>::type& rb_map) {
+  for (auto& req_pair : rb_map) {
     cyclus::Request<T>* request = req_pair.first;
     std::string commodity = request->commodity();
-    cyclus::Facility* requester = dynamic_cast<cyclus::Facility*>(request->requester()->manager());
     
     for (auto& bid_pair : req_pair.second) {
       cyclus::Bid<T>* bid = bid_pair.first;
       cyclus::Facility* supplier = dynamic_cast<cyclus::Facility*>(bid->bidder()->manager());
-      
-      // Compute aggregated tariff from all importer regions along the hierarchy
-      double adjustment = ComputeAggregatedTariff(supplier, requester, commodity);
-      
-      if (adjustment != 0.0) {
-        double cost_multiplier = 1.0 + adjustment;
-        double pref_multiplier = 1.0 / cost_multiplier;
-        double inf = std::numeric_limits<double>::infinity(); 
+      Region* supplier_region = supplier->GetParentRegion();
 
-        bid_pair.second *= cost_multiplier > 0.0 ? pref_multiplier : inf; 
+      if (supplier_region == this) {
+        continue;
+      }
+
+      Adjustment adjustment = FindAdjustmentForCommodity(supplier_region, commodity);
+
+      if (adjustment.second == "unit_cost") {
+        const double original_unit_cost = bid->unit_cost();
+        const double adjusted_unit_cost =
+            original_unit_cost * (1.0 + adjustment.first);
+
+        bid->unit_cost(adjusted_unit_cost);
+        bid_pair.second += adjusted_unit_cost - original_unit_cost; 
+      } 
+      else if (adjustment.second == "arc_cost") {
+        bid_pair.second *= (1.0 + adjustment.first);
+      } 
+      else {
+        std::string msg = "Adjustment configured incorrectly. "
+                          "Must be unit_cost or arc_cost. Was: " +
+                          adjustment.second;
+        throw cyclus::ValueError(cyclus::Agent::InformErrorMsg(msg));
       }
     }
   }

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -56,9 +56,10 @@ class TariffRegion : public cyclus::Region {
   // clang-format off
   #pragma cyclus var { \
     "default": {}, \
+    "alias": ["adjustment_regions", "region", ["RegionConfig", "blanket_adjustment", ["commodity_adjustments", "commodity", "adjustment"]]], \
     "doc": "Tariff configuration: map from region name to (blanket_adjustment, commodity_adjustments_map). Each region can have a blanket adjustment for all commodities and specific adjustments per commodity." \
   }
-  std::map<std::string, std::pair<double, std::map<std::string, double>>> adjustment_regions;
+  std::map<std::string, std::pair<double, std::map<std::string, double>>> adjustment_regions_;
 
   #pragma cyclus var { \
     "default": 0.0, \
@@ -68,9 +69,10 @@ class TariffRegion : public cyclus::Region {
 
   #pragma cyclus var { \
     "default": {}, \
+    "alias": ["global_commodity_adjustments", "commodity", "adjustment"], \
     "doc": "Optional global commodity adjustments applied to all regions for specific commodities." \
   }
-  std::map<std::string, double> global_commodity_adjustments;
+  std::map<std::string, double> global_commodity_adjustments_;
 
   // clang-format on
   

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -3,25 +3,12 @@
 
 #include "cyclus.h"
 #include <string>
-#include <algorithm>
 #include <limits>
-#include <set>
 #include <utility>
 #include <map>
-#include <unordered_map>
 #include <vector>
 
 namespace cycamore {
-
-// Simple structure to represent a tariff rule
-struct TariffRule {
-  std::string region_name;
-  std::string commodity;
-  double adjustment;
-  
-  TariffRule(const std::string& region, const std::string& comm, double adj)
-      : region_name(region), commodity(comm), adjustment(adj) {}
-};
 
 class TariffRegion : public cyclus::Region {
  public:
@@ -36,17 +23,19 @@ class TariffRegion : public cyclus::Region {
   virtual void AdjustProductPrefs(cyclus::PrefMap<cyclus::Product>::type& prefs);
 
  private:
-  // Build the set of region agents for faster lookups
-  void BuildRegionSet();
-  
   // Find the best matching region for a supplier
   cyclus::Region* FindMatchingRegion(cyclus::Facility* supplier);
   
   // Find the appropriate tariff for a given region and commodity
+  // Uses tiered override system: region-specific commodity > region blanket > 
+  // global commodity > global blanket
   double FindTariffForCommodity(cyclus::Region* region, const std::string& commodity);
   
-  // Build tariff rules from the input configuration
-  void BuildTariffRules();
+  // Helper: Check if any tariff configuration exists
+  bool HasTariffConfiguration() const;
+  
+  // Helper: Get region prototype name (reduces repeated code)
+  std::string GetRegionName(cyclus::Region* region) const;
   
   // Validate the tariff configuration
   void ValidateConfiguration();
@@ -84,45 +73,24 @@ class TariffRegion : public cyclus::Region {
   
   // clang-format off
   #pragma cyclus var { \
-    "default": [], \
-    "doc": "Region names for tariff configuration." \
+    "default": {}, \
+    "doc": "Tariff configuration: map from region name to (blanket_adjustment, commodity_adjustments_map). Each region can have a blanket adjustment for all commodities and specific adjustments per commodity." \
   }
-  std::vector<std::string> region_names;
+  std::map<std::string, std::pair<double, std::map<std::string, double>>> adjustment_regions;
 
   #pragma cyclus var { \
-    "default": [], \
-    "doc": "Commodities for each region (flattened list, use commodity_counts_per_region to parse)." \
+    "default": 0.0, \
+    "doc": "Optional global blanket adjustment applied to all regions and commodities." \
   }
-  std::vector<std::string> adjusted_commodities;
+  double global_blanket_adjustment;
 
   #pragma cyclus var { \
-    "default": [], \
-    "doc": "Adjustments for each region's commodities (flattened list, use region_commodity_counts to parse)." \
+    "default": {}, \
+    "doc": "Optional global commodity adjustments applied to all regions for specific commodities." \
   }
-  std::vector<double> commodity_adjustments;
-
-  #pragma cyclus var { \
-    "default": [], \
-    "doc": "Number of commodities for each region (used to parse flattened commodity/adjustment lists)." \
-  }
-  std::vector<int> commodity_counts_per_region;
-
-  #pragma cyclus var { \
-    "default": [], \
-    "doc": "Flat adjustment for each region (default tariff for unspecified commodities)." \
-  }
-  std::vector<double> region_flat_adjustments;
+  std::map<std::string, double> global_commodity_adjustments;
 
   // clang-format on
-  
-  // Pre-computed set of region agents for faster lookups
-  std::set<cyclus::Region*> adjustment_regions_;
-  
-  // Simple tariff rules - much cleaner than the complex nested structures
-  std::vector<TariffRule> tariff_rules_;
-  
-  // map of region names to flat adjustments
-  std::map<std::string, double> region_flat_adjustments_map_;
   
 };
 

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -56,7 +56,7 @@ class TariffRegion : public cyclus::Region {
   // clang-format off
   #pragma cyclus var { \
     "default": {}, \
-    "alias": ["adjustment_regions", "region", ["RegionConfig", "blanket_adjustment", ["commodity_adjustments", "commodity", "adjustment"]]], \
+    "alias": ["adjustment_regions", "region", ["AdjustmentConfig", "blanket_adjustment", ["commodity_adjustments", "commodity", "adjustment"]]], \
     "doc": "Tariff configuration: map from region name to (blanket_adjustment, commodity_adjustments_map). Each region can have a blanket adjustment for all commodities and specific adjustments per commodity." \
   }
   std::map<std::string, std::pair<double, std::map<std::string, double>>> adjustment_regions_;

--- a/src/tariff_region.h
+++ b/src/tariff_region.h
@@ -23,8 +23,22 @@ class TariffRegion : public cyclus::Region {
   virtual void AdjustProductPrefs(cyclus::PrefMap<cyclus::Product>::type& prefs);
 
  private:
-  // Find the best matching region for a supplier
-  cyclus::Region* FindMatchingRegion(cyclus::Facility* supplier);
+  // Compute aggregated tariff from all importer regions along the hierarchy
+  double ComputeAggregatedTariff(cyclus::Facility* supplier, 
+                                  cyclus::Facility* requester,
+                                  const std::string& commodity);
+  
+  // Find the Lowest Common Ancestor of two regions
+  cyclus::Region* FindLowestCommonAncestor(cyclus::Region* r1, cyclus::Region* r2);
+  
+  // Get the chain of ancestors from a region up to (and including) root
+  std::vector<cyclus::Region*> GetAncestorChain(cyclus::Region* region);
+  
+  // Find the most specific tariff rule for a supplier's hierarchy from an importer's perspective
+  // Returns the tariff value, checking supplier region hierarchy from most to least specific
+  double FindMostSpecificTariff(cyclus::Region* importer_region,
+                                const std::vector<cyclus::Region*>& supplier_hierarchy,
+                                const std::string& commodity);
   
   // Find the appropriate tariff for a given region and commodity
   // Uses tiered override system: region-specific commodity > region blanket > 
@@ -85,17 +99,18 @@ class TariffRegion : public cyclus::Region {
 template<typename T>
 void TariffRegion::AdjustPrefsImpl(typename cyclus::PrefMap<T>::type& prefs) {
   for (auto& req_pair : prefs) {
-    std::string commodity = req_pair.first->commodity();
+    cyclus::Request<T>* request = req_pair.first;
+    std::string commodity = request->commodity();
+    cyclus::Facility* requester = dynamic_cast<cyclus::Facility*>(request->requester()->manager());
     
     for (auto& bid_pair : req_pair.second) {
       cyclus::Bid<T>* bid = bid_pair.first;
       cyclus::Facility* supplier = dynamic_cast<cyclus::Facility*>(bid->bidder()->manager());
       
-      // Find if any of the supplier's parent regions match our tariff list
-      cyclus::Region* matching_region = FindMatchingRegion(supplier);
-      if (matching_region) {
-        double adjustment = FindTariffForCommodity(matching_region, commodity);
-        
+      // Compute aggregated tariff from all importer regions along the hierarchy
+      double adjustment = ComputeAggregatedTariff(supplier, requester, commodity);
+      
+      if (adjustment != 0.0) {
         double cost_multiplier = 1.0 + adjustment;
         double pref_multiplier = 1.0 / cost_multiplier;
         double inf = std::numeric_limits<double>::infinity(); 


### PR DESCRIPTION
# Summary of Changes

I feel like I've seen this suggestion for a region pop up often enough, especially in my conversations with @gonuke that I figured it'd be fun to just go ahead and make one. 

This is TariffRegion. It allows users to specify "friend" regions and "enemy" regions within the simulation and then impose tariffs on the enemies, and subsidies on the friends. The subsidies and tariffs are applied to all trades coming from those regions, so this is fairly basic (it'd be nice maybe later to make it so that only specific commodities from those regions got affected, but I threw this together last night and this afternoon, so I didn't get that far). 


# Related CEPs and Issues

This PR is related to:

- Closes #660 
- Closes #667
- cyclus/cyclus#1897 (this is what I was messing with when I found this issue)
- cyclus/cyclus#1914

# Associated Developers

Cursor AI

# Design Notes

Believe it or not, I did most of this on my own. Cursor helped a bit here and there, obviously, but mostly with me understanding how things worked (and the occasional quick "hit tab to fill in the rest of this in that similar function" bits). The basics of this were based on the tutorial PR version of TariffRegion, so I guess in that sense Cursor did a bit more of the heavy lifting.
 
# Testing and Validation

All tests pass. Cyclus and Cycamore both build, and both sets of tests pass with these changes. Unit tests have NOT been added for this Agent.

# Checklist

 - [x] Read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide.
 - [x]  Compile and run locally.
 - [x]  Follow style guidelines.
 - [x]  Update the changelog.
 - [ ]  Address all review comments.
Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).