### PR TITLE
Add a PR Template to Cycamore

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,58 @@
+# Summary of Changes
+
+<!-- 
+Provide a clear and concise description of what this PR accomplishes.
+Include the main functionality added, modified, or removed.
+-->
+
+# Related CEPs and Issues
+
+This PR is related to:
+
+<!-- 
+List any related Cyclus Enhancement Proposals (CEPs) and GitHub issues.
+Use the format:
+- Closes #1234
+- Resolves #1111 
+- Implements CEP-001
+- Related to #9999
+-->
+
+# Associated Developers
+
+<!-- 
+List any additional developers who contributed to this work.
+Include their GitHub usernames and brief description of their contribution.
+-->
+
+# Design Notes
+
+<!-- 
+Provide details about the design decisions made in this PR.
+-->
+
+# Testing and Validation
+
+<!-- 
+Describe how this change has been tested and validated.
+-->
+
+# Checklist
+
+<!-- 
+Please ensure all items are completed before submitting the PR.
+Check each box by replacing [ ] with [x] when the item is complete.
+-->
+
+- [ ] Read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide.
+- [ ] Compile and run locally.
+- [ ] Add or update tests.
+- [ ] Document if needed.
+- [ ] Follow style guidelines.
+- [ ] Update the changelog (see [CHANGELOG.rst](CHANGELOG.rst) for format).
+- [ ] Run clang-format on modified files.
+- [ ] Address all review comments.
+---
+
+**Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).**
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Since last release
 ======================
 
 **Added:**
+* Added pull request template (#666)
 * Added Conversion Facility (#657)
 * Replaced manual matl_buy/sell_policy code in storage with code injection (#639)
 * Added package parameter to storage (#603, #612, #616)


### PR DESCRIPTION
# Summary of Changes

This PR adds a PR Template to Cycamore. It's pretty straightforward.


# Related CEPs and Issues

This PR is related to:

- Closes #665 
- cyclus/cyclus#1908

# Associated Developers

Cursor AI

# Design Notes

I based this template off of the one I've been copy and pasting into this box for the past few weeks. Happy to change the style of it, but I figured that was at least a good starting point!
 
# Testing and Validation

None. This is hard to test outside of GitHub

# Checklist

 - [x] Read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide.
 - [x]  Follow style guidelines.
 - [x]  Update the changelog.
 - [ ]  Address all review comments.
Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).