### PR TITLE
Add Default Test to Source

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Since last release
 ======================
 
 **Added:**
+* Added facility cost to source (#669)
 * Added Conversion Facility (#657)
 * Replaced manual matl_buy/sell_policy code in storage with code injection (#639)
 * Added package parameter to storage (#603, #612, #616)

--- a/src/source.cc
+++ b/src/source.cc
@@ -119,7 +119,9 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
       m = outrecipe.empty() ? \
           Material::CreateUntracked(*bit, target->comp()) : \
           Material::CreateUntracked(*bit, context()->GetRecipe(outrecipe));
-      port->AddBid(req, m, this);
+      
+      double cost = CalculateUnitPrice(throughput, target->quantity());
+      port->AddBid(req, m, this, false, 1/cost);
     }
   }
 

--- a/src/source.h
+++ b/src/source.h
@@ -83,6 +83,7 @@ class Source : public cyclus::Facility,
  private:
  // Code Injection:
  #include "toolkit/position.cycpp.h"
+ #include "toolkit/facility_cost.cycpp.h"
 
   #pragma cyclus var { \
     "tooltip": "source output commodity", \


### PR DESCRIPTION
# Summary of Changes

This PR adds the `CalculateUnitPrice()` function to the Source facility with default implementation such that it returns 1 for preference. 

# Related CEPs and Issues

This PR is related to:

- Closes #654 

# Associated Developers

None

# Design Notes

We decided to go ahead and add the whole function and not just have it default to 1.0 manually (`AddBid(req, m, this, false, 1.0))` because eventually we'll want to add the full economic implementation to Cycamore instead of some other repo.

# Testing and Validation

Built and ran both cyclus and cycamore, ran tests for both and all passed (no new tests). Double checked the transaction table to make sure that the preference it returned was 1. 

# Checklist

 - [x] Read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide.
 - [x]  Compile and run locally.
 - [ ]  Add or update tests.
 - [x]  Document if needed.
 - [x]  Follow style guidelines.
 - [ ]  Update the changelog.
 - [ ]  Address all review comments.
Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).