### PR TITLE
Adding DeployInst Start Year Features (after and during simulation)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Since last release
 * Added default keep packaging to reactor (#618, #619)
 * Added support for Ubuntu 24.04 (#633)
 * Added (negative)binomial distributions for disruption modeling to storage (#635)
+* Added new tests for Deploy Institution year (#676, #675)
+* Added new variable to Deploy Institution (#676, #675)
 
 **Changed:**
 * Cleaned up manual definitions of Position in favor of code injection (#641)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,6 @@ Since last release
 * Added support for Ubuntu 24.04 (#633)
 * Added (negative)binomial distributions for disruption modeling to storage (#635)
 * Added new variable to Deploy Institution to shift the deployment times (#677)
-* Added new tests for Deploy Institution year (#677)
 
 **Changed:**
 * Cleaned up manual definitions of Position in favor of code injection (#641)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,8 @@ Since last release
 * Added default keep packaging to reactor (#618, #619)
 * Added support for Ubuntu 24.04 (#633)
 * Added (negative)binomial distributions for disruption modeling to storage (#635)
-* Added new tests for Deploy Institution year (#676, #675)
-* Added new variable to Deploy Institution (#676, #675)
+* Added new variable to Deploy Institution to shift the deployment times (#677)
+* Added new tests for Deploy Institution year (#677)
 
 **Changed:**
 * Cleaned up manual definitions of Position in favor of code injection (#641)

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -39,9 +39,9 @@ void DeployInst::Build(cyclus::Agent* parent) {
     int y = context()->sim_info().y0;
     int sim_end = y + std::floor((context()->sim_info().m0 + 
                             context()->sim_info().duration)/12);
-    std::cout << build_times[i] + (deployyear[i] - y) << std::endl;
+
     int t = build_times[i];
-    if(deployyear.size() != 0){
+    if(deployyear.size() == prototypes.size()){
       if(deployyear[i] > sim_end){
         ss << " Deploy start year " <<  deployyear[i] << " must be less than simulation duration";
         throw cyclus::ValueError(ss.str());
@@ -49,10 +49,8 @@ void DeployInst::Build(cyclus::Agent* parent) {
         else{
           int t = (deployyear[i] < y) ? 1 : build_times[i] + (deployyear[i] - y); 
         } 
-    } else {
-        int t = build_times[i];
-    }
-    std::cout << t << std::endl;
+    } 
+
     for (int j = 0; j < n_build[i]; j++) {
         context()->SchedBuild(this, proto, t);
     }
@@ -78,12 +76,12 @@ void DeployInst::EnterNotify() {
        << " lifetimes vals, expected " << n;
     throw cyclus::ValueError(ss.str());
   }
-  else if (deployyear.size() > 0 && deployyear.size() != n) {
-    std::stringstream ss;
-    ss << "prototype '" << prototype() << "' has " << deployyear.size()
-       << " start year vals, expected " << n;
-    throw cyclus::ValueError(ss.str());
-  }
+  // else if (deployyear.size() > 0 && deployyear.size() != n) {
+  //   std::stringstream ss;
+  //   ss << "prototype '" << prototype() << "' has " << deployyear.size()
+  //      << " start year vals, expected " << n;
+  //   throw cyclus::ValueError(ss.str());
+  // }
 
 
   InitializePosition();

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -76,12 +76,12 @@ void DeployInst::EnterNotify() {
        << " lifetimes vals, expected " << n;
     throw cyclus::ValueError(ss.str());
   }
-  // else if (deployyear.size() > 0 && deployyear.size() != n) {
-  //   std::stringstream ss;
-  //   ss << "prototype '" << prototype() << "' has " << deployyear.size()
-  //      << " start year vals, expected " << n;
-  //   throw cyclus::ValueError(ss.str());
-  // }
+  else if (deployyear.size() > 0 && deployyear.size() != n) {
+    std::stringstream ss;
+    ss << "prototype '" << prototype() << "' has " << deployyear.size()
+       << " start year vals, expected " << n;
+    throw cyclus::ValueError(ss.str());
+  }
 
 
   InitializePosition();

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -41,20 +41,19 @@ void DeployInst::Build(cyclus::Agent* parent) {
                             context()->sim_info().duration)/12);
     std::cout << build_times[i] + (deployyear[i] - y) << std::endl;
     int t = build_times[i];
+ 
     if(deployyear[i] > sim_end){
       ss << " Deploy start year " <<  deployyear[i] << " must be less than simulation duration";
       throw cyclus::ValueError(ss.str());
-    }
-    else{
-      int t = (deployyear[i] < y) ? 0 : build_times[i] + (deployyear[i] - y); 
-      std::cout << t << std::endl;
-      for (int j = 0; j < n_build[i]; j++) {
-        context()->SchedBuild(this, proto, t);
       }
+      else{
+        int t = (deployyear[i] < y) ? 1 : build_times[i] + (deployyear[i] - y); 
+
+      } 
+    std::cout << t << std::endl;
+    for (int j = 0; j < n_build[i]; j++) {
+        context()->SchedBuild(this, proto, t);
     }
-    // for (int j = 0; j < n_build[i]; j++) {
-    //     context()->SchedBuild(this, proto, t);
-    // }
   }
 }
 

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -1,5 +1,6 @@
 // Implements the DeployInst class
 #include "deploy_inst.h"
+#include "error.h"
 
 namespace cycamore {
 
@@ -36,30 +37,31 @@ void DeployInst::Build(cyclus::Agent* parent) {
       }
     }
 
-    int y = context()->sim_info().y0; 
-    int sim_end = y + std::floor((context()->sim_info().m0 + 
-                            context()->sim_info().duration)/12); 
-    int t = build_times[i]; 
-    if(deployyear.size() == prototypes.size()){ 
-      if(deployyear[i] + build_times[i] => sim_end){
-        Warn<VALUE_WARNING>(
-        "deployment year, " <<  deployyear[i] + build_times[i] << ", must be less than simulation duration");
-        int t = build_times[i] + std::abs(deploy_year[i] - y)*12; 
-      } 
-      else if(deploy_year[i] + build_times[i] < y) {
-        Warn<EXPERIMENTAL_WARNING>(
-        "Facility deployment before simulation start is under development. Deployment time is reset to simulation start (t = 0).");
-        int t = 0;
+    int sim_start = 12*(context()->sim_info().y0) + 
+                            context()->sim_info().m0;
+    int t_build = build_times[i]; 
+
+    if(deployyear.size() == prototypes.size()) { 
+      if(t_build + deployyear[i]*12 < sim_start){
+          cyclus::Warn<cyclus::VALUE_WARNING>(
+          "Facility deployment before simulation start is under development. Deployment time is reset to simulation start (t = 0).");
+          t_build = 0;
       }
-      else {
-        int t = build_times[i] + std::abs(deploy_year[i] - y)*12; 
+     else {
+        t_build += deployyear[i]*12 - sim_start;
+        if(t_build >= context()->sim_info().duration) {
+          cyclus::Warn<cyclus::VALUE_WARNING>(
+          "Deployment year must be less than simulation duration");
+        }
       }
     }
+
     for (int j = 0; j < n_build[i]; j++) {
-        context()->SchedBuild(this, proto, t);
+        context()->SchedBuild(this, proto, t_build);
     }
   }
 }
+
 
 void DeployInst::EnterNotify() {
   cyclus::Institution::EnterNotify();

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -13,6 +13,14 @@ void DeployInst::Build(cyclus::Agent* parent) {
   cyclus::Institution::Build(parent);
   BuildSched::iterator it;
   std::set<std::string> protos;
+
+  int sim_start = 12*(context()->sim_info().y0) + 
+                            context()->sim_info().m0;
+  int d_t = 0;
+  if(deployyear!=-1){
+    d_t += deployyear*12 - sim_start;
+  }
+
   for (int i = 0; i < prototypes.size(); i++) {
     std::string proto = prototypes[i];
 
@@ -37,23 +45,18 @@ void DeployInst::Build(cyclus::Agent* parent) {
       }
     }
 
-    int sim_start = 12*(context()->sim_info().y0) + 
-                            context()->sim_info().m0;
-    int t_build = build_times[i]; 
-    if(deployyear > 0){
-      if(t_build + deployyear*12 < sim_start){
-        std::stringstream ss;
-        ss << "Deploy year is before simulation start. Adjust deployment time." ;
-        throw cyclus::ValueError(ss.str());
-      }
-     else {
-        t_build += deployyear*12 - sim_start;
-        if(t_build >= context()->sim_info().duration) {
-          cyclus::Warn<cyclus::VALUE_WARNING>(
-          "Deployment year must be less than simulation duration");
-        }
-      }
+    int t_build = build_times[i] + d_t;
+
+    if(t_build < 0){
+      std::stringstream ss;
+      ss << "Deploy year is before simulation start. Adjust deployment time." ;
+      throw cyclus::ValueError(ss.str());
     }
+    else if(t_build >= context()->sim_info().duration){
+      cyclus::Warn<cyclus::VALUE_WARNING>(
+      "Deployment year must be less than simulation duration");
+    }
+
     for (int j = 0; j < n_build[i]; j++) {
       context()->SchedBuild(this, proto, t_build);
     }

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -41,15 +41,17 @@ void DeployInst::Build(cyclus::Agent* parent) {
                             context()->sim_info().duration)/12);
     std::cout << build_times[i] + (deployyear[i] - y) << std::endl;
     int t = build_times[i];
- 
-    if(deployyear[i] > sim_end){
-      ss << " Deploy start year " <<  deployyear[i] << " must be less than simulation duration";
-      throw cyclus::ValueError(ss.str());
-      }
-      else{
-        int t = (deployyear[i] < y) ? 1 : build_times[i] + (deployyear[i] - y); 
-
-      } 
+    if(deployyear.size() != 0){
+      if(deployyear[i] > sim_end){
+        ss << " Deploy start year " <<  deployyear[i] << " must be less than simulation duration";
+        throw cyclus::ValueError(ss.str());
+        }
+        else{
+          int t = (deployyear[i] < y) ? 1 : build_times[i] + (deployyear[i] - y); 
+        } 
+    } else {
+        int t = build_times[i];
+    }
     std::cout << t << std::endl;
     for (int j = 0; j < n_build[i]; j++) {
         context()->SchedBuild(this, proto, t);
@@ -76,12 +78,12 @@ void DeployInst::EnterNotify() {
        << " lifetimes vals, expected " << n;
     throw cyclus::ValueError(ss.str());
   }
-  // else if (deployyear.size() > 0 && deployyear.size() != n) {
-  //   std::stringstream ss;
-  //   ss << "prototype '" << prototype() << "' has " << deployyear.size()
-  //      << " start year vals, expected " << n;
-  //   throw cyclus::ValueError(ss.str());
-  // }
+  else if (deployyear.size() > 0 && deployyear.size() != n) {
+    std::stringstream ss;
+    ss << "prototype '" << prototype() << "' has " << deployyear.size()
+       << " start year vals, expected " << n;
+    throw cyclus::ValueError(ss.str());
+  }
 
 
   InitializePosition();

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -43,7 +43,7 @@ void DeployInst::Build(cyclus::Agent* parent) {
     int t = build_times[i];
     if(deployyear.size() == prototypes.size()){
       if(deployyear[i] > sim_end){
-        ss << " Deploy start year " <<  deployyear[i] << " must be less than simulation duration";
+        ss << "'s deploy start year, " <<  deployyear[i] << ", must be less than simulation duration";
         throw cyclus::ValueError(ss.str());
         }
         else{

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -18,13 +18,13 @@ void DeployInst::Build(cyclus::Agent* parent) {
 
     std::stringstream ss;
     ss << proto;
-    // either decomnotif can be editted or we can always adjust the lifetimes 
+    
     if (lifetimes.size() == prototypes.size()) {
       cyclus::Agent* a = context()->CreateAgent<Agent>(proto);
       if (a->lifetime() != lifetimes[i]) {
         a->lifetime(lifetimes[i]);
 
-        if (lifetimes[i] == -1 ) {
+        if (lifetimes[i] == -1) {
           ss << "_life_forever";
         } else {
           ss << "_life_" << lifetimes[i];
@@ -56,7 +56,7 @@ void DeployInst::Build(cyclus::Agent* parent) {
       }
     }
     for (int j = 0; j < n_build[i]; j++) {
-        context()->SchedBuild(this, proto, t_build);
+      context()->SchedBuild(this, proto, t_build);
     }
   }
 }

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -45,7 +45,7 @@ void DeployInst::Build(cyclus::Agent* parent) {
       if(t_build + deployyear[i]*12 < sim_start){
           cyclus::Warn<cyclus::VALUE_WARNING>(
           "Facility deployment before simulation start is under development. Deployment time is reset to simulation start (t = 0).");
-          t_build = 0;
+          t_build = 1;
       }
      else {
         t_build += deployyear[i]*12 - sim_start;
@@ -55,7 +55,6 @@ void DeployInst::Build(cyclus::Agent* parent) {
         }
       }
     }
-
     for (int j = 0; j < n_build[i]; j++) {
         context()->SchedBuild(this, proto, t_build);
     }

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -47,7 +47,7 @@ void DeployInst::Build(cyclus::Agent* parent) {
         throw cyclus::ValueError(ss.str());
         }
         else{
-          int t = (deployyear[i] < y) ? 1 : build_times[i] + (deployyear[i] - y); 
+          int t = (deployyear[i] < y) ? 0 : build_times[i] + (deployyear[i] - y); 
         } 
     } 
 

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -40,15 +40,14 @@ void DeployInst::Build(cyclus::Agent* parent) {
     int sim_start = 12*(context()->sim_info().y0) + 
                             context()->sim_info().m0;
     int t_build = build_times[i]; 
-
-    if(deployyear.size() == prototypes.size()) { 
-      if(t_build + deployyear[i]*12 < sim_start){
-          cyclus::Warn<cyclus::VALUE_WARNING>(
-          "Facility deployment before simulation start is under development. Deployment time is reset to simulation start (t = 0).");
-          t_build = 1;
+    if(deployyear > 0){
+      if(t_build + deployyear*12 < sim_start){
+        std::stringstream ss;
+        ss << "Deploy year is before simulation start. Adjust deployment time." ;
+        throw cyclus::ValueError(ss.str());
       }
      else {
-        t_build += deployyear[i]*12 - sim_start;
+        t_build += deployyear*12 - sim_start;
         if(t_build >= context()->sim_info().duration) {
           cyclus::Warn<cyclus::VALUE_WARNING>(
           "Deployment year must be less than simulation duration");
@@ -81,13 +80,7 @@ void DeployInst::EnterNotify() {
        << " lifetimes vals, expected " << n;
     throw cyclus::ValueError(ss.str());
   }
-  else if (deployyear.size() > 0 && deployyear.size() != n) {
-    std::stringstream ss;
-    ss << "prototype '" << prototype() << "' has " << deployyear.size()
-       << " start year vals, expected " << n;
-    throw cyclus::ValueError(ss.str());
-  }
-
+  // maybe the inventory shit goes here? 
 
   InitializePosition();
 }

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -36,10 +36,25 @@ void DeployInst::Build(cyclus::Agent* parent) {
       }
     }
 
+    int y = context()->sim_info().y0;
+    int sim_end = y + std::floor((context()->sim_info().m0 + 
+                            context()->sim_info().duration)/12);
+    std::cout << build_times[i] + (deployyear[i] - y) << std::endl;
     int t = build_times[i];
-    for (int j = 0; j < n_build[i]; j++) {
-      context()->SchedBuild(this, proto, t);
+    if(deployyear[i] > sim_end){
+      ss << " Deploy start year " <<  deployyear[i] << " must be less than simulation duration";
+      throw cyclus::ValueError(ss.str());
     }
+    else{
+      int t = (deployyear[i] < y) ? 0 : build_times[i] + (deployyear[i] - y); 
+      std::cout << t << std::endl;
+      for (int j = 0; j < n_build[i]; j++) {
+        context()->SchedBuild(this, proto, t);
+      }
+    }
+    // for (int j = 0; j < n_build[i]; j++) {
+    //     context()->SchedBuild(this, proto, t);
+    // }
   }
 }
 
@@ -62,6 +77,13 @@ void DeployInst::EnterNotify() {
        << " lifetimes vals, expected " << n;
     throw cyclus::ValueError(ss.str());
   }
+  // else if (deployyear.size() > 0 && deployyear.size() != n) {
+  //   std::stringstream ss;
+  //   ss << "prototype '" << prototype() << "' has " << deployyear.size()
+  //      << " start year vals, expected " << n;
+  //   throw cyclus::ValueError(ss.str());
+  // }
+
 
   InitializePosition();
 }

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -36,21 +36,25 @@ void DeployInst::Build(cyclus::Agent* parent) {
       }
     }
 
-    int y = context()->sim_info().y0;
+    int y = context()->sim_info().y0; 
     int sim_end = y + std::floor((context()->sim_info().m0 + 
-                            context()->sim_info().duration)/12);
-    // need to convert deployyear to times 
-    int t = build_times[i];
-    if(deployyear.size() == prototypes.size()){
-      if(deployyear[i] > sim_end){
-        ss << "'s deploy start year, " <<  deployyear[i] << ", must be less than simulation duration";
-        throw cyclus::ValueError(ss.str());
-        }
-        else{
-          int t = (deployyear[i] < y) ? 0 : build_times[i] + (deployyear[i] - y)*12; 
-        } 
-    } 
-
+                            context()->sim_info().duration)/12); 
+    int t = build_times[i]; 
+    if(deployyear.size() == prototypes.size()){ 
+      if(deployyear[i] + build_times[i] => sim_end){
+        Warn<VALUE_WARNING>(
+        "deployment year, " <<  deployyear[i] + build_times[i] << ", must be less than simulation duration");
+        int t = build_times[i] + std::abs(deploy_year[i] - y)*12; 
+      } 
+      else if(deploy_year[i] + build_times[i] < y) {
+        Warn<EXPERIMENTAL_WARNING>(
+        "Facility deployment before simulation start is under development. Deployment time is reset to simulation start (t = 0).");
+        int t = 0;
+      }
+      else {
+        int t = build_times[i] + std::abs(deploy_year[i] - y)*12; 
+      }
+    }
     for (int j = 0; j < n_build[i]; j++) {
         context()->SchedBuild(this, proto, t);
     }

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -17,13 +17,13 @@ void DeployInst::Build(cyclus::Agent* parent) {
 
     std::stringstream ss;
     ss << proto;
-
+    // either decomnotif can be editted or we can always adjust the lifetimes 
     if (lifetimes.size() == prototypes.size()) {
       cyclus::Agent* a = context()->CreateAgent<Agent>(proto);
       if (a->lifetime() != lifetimes[i]) {
         a->lifetime(lifetimes[i]);
 
-        if (lifetimes[i] == -1) {
+        if (lifetimes[i] == -1 ) {
           ss << "_life_forever";
         } else {
           ss << "_life_" << lifetimes[i];
@@ -39,7 +39,7 @@ void DeployInst::Build(cyclus::Agent* parent) {
     int y = context()->sim_info().y0;
     int sim_end = y + std::floor((context()->sim_info().m0 + 
                             context()->sim_info().duration)/12);
-
+    // need to convert deployyear to times 
     int t = build_times[i];
     if(deployyear.size() == prototypes.size()){
       if(deployyear[i] > sim_end){
@@ -47,7 +47,7 @@ void DeployInst::Build(cyclus::Agent* parent) {
         throw cyclus::ValueError(ss.str());
         }
         else{
-          int t = (deployyear[i] < y) ? 0 : build_times[i] + (deployyear[i] - y); 
+          int t = (deployyear[i] < y) ? 0 : build_times[i] + (deployyear[i] - y)*12; 
         } 
     } 
 

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -80,8 +80,6 @@ void DeployInst::EnterNotify() {
        << " lifetimes vals, expected " << n;
     throw cyclus::ValueError(ss.str());
   }
-  // maybe the inventory shit goes here? 
-
   InitializePosition();
 }
 

--- a/src/deploy_inst.cc
+++ b/src/deploy_inst.cc
@@ -54,7 +54,8 @@ void DeployInst::Build(cyclus::Agent* parent) {
     }
     else if(t_build >= context()->sim_info().duration){
       cyclus::Warn<cyclus::VALUE_WARNING>(
-      "Deployment year must be less than simulation duration");
+      "Deployment year must be less than simulation duration;"
+      "A facility will not be deployed during the simulation.");
     }
 
     for (int j = 0; j < n_build[i]; j++) {

--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -86,14 +86,11 @@ class DeployInst :
 
   #pragma cyclus var {							\
     "doc": "start_year", \
+    "default":[],\
     "uilabel": "Start Year" \
   }
-  int start_year;
 
-  int y;
-  int m0;
-  int dur;
-  int sim_end; 
+  std::vector<int> start_year;
 
   #pragma cyclus var {							\
     "doc": "Lifetimes for each prototype in prototype list (same order)." \

--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -86,10 +86,10 @@ class DeployInst :
 
   #pragma cyclus var { \
     "doc": "Year to start deploying prototypes (same order).", \
-    "default": [], \
+    "default": 0, \
     "uilabel": "deploy year",\
   }
-  std::vector<int> deployyear;
+  int deployyear;
 
   #pragma cyclus var {							\
     "doc": "Lifetimes for each prototype in prototype list (same order)." \

--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -84,6 +84,16 @@ class DeployInst :
   }
   std::vector<int> n_build;
 
+  #pragma cyclus var {							\
+    "doc": "start_year", \
+    "uilabel": "Start Year" \
+  }
+  int start_year;
+
+  int y;
+  int m0;
+  int dur;
+  int sim_end; 
 
   #pragma cyclus var {							\
     "doc": "Lifetimes for each prototype in prototype list (same order)." \

--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -84,11 +84,12 @@ class DeployInst :
   }
   std::vector<int> n_build;
 
-  #pragma cyclus var {	\
-    "doc": "Each institution may be deployed at a start year different to the simulation start year. ", \
-    "uilabel": "Start year to begin deployment" \
+  #pragma cyclus var { \
+    "doc": "Year to start deploying prototypes (same order).", \
+    "default": [], \
+    "uilabel": "deploy year",\
   }
-  std::vector<int> start_year;
+  std::vector<int> deployyear;
 
   #pragma cyclus var {							\
     "doc": "Lifetimes for each prototype in prototype list (same order)." \

--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -86,7 +86,7 @@ class DeployInst :
 
   #pragma cyclus var { \
     "doc": "Year to start deploying prototypes.", \
-    "default": 0, \
+    "default": -1, \
     "uilabel": "deploy year",\
   }
   int deployyear;

--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -85,7 +85,7 @@ class DeployInst :
   std::vector<int> n_build;
 
   #pragma cyclus var { \
-    "doc": "Year to start deploying prototypes (same order).", \
+    "doc": "Year to start deploying prototypes.", \
     "default": 0, \
     "uilabel": "deploy year",\
   }

--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -85,8 +85,8 @@ class DeployInst :
   std::vector<int> n_build;
 
   #pragma cyclus var {	\
-    "doc": "start_year", \
-    "uilabel": "Start Year" \
+    "doc": "Each institution may be deployed at a start year different to the simulation start year. ", \
+    "uilabel": "Start year to begin deployment" \
   }
   std::vector<int> start_year;
 

--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -84,12 +84,10 @@ class DeployInst :
   }
   std::vector<int> n_build;
 
-  #pragma cyclus var {							\
+  #pragma cyclus var {	\
     "doc": "start_year", \
-    "default":[],\
     "uilabel": "Start Year" \
   }
-
   std::vector<int> start_year;
 
   #pragma cyclus var {							\

--- a/src/deploy_inst_tests.cc
+++ b/src/deploy_inst_tests.cc
@@ -154,7 +154,7 @@ TEST_F(DeployInstTests, NoDupProtos) {
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 }
-//this test makes sure that the institutions deployed before sim start are reset to 1. 
+
 TEST_F(DeployInstTests, DeployYear) {
   std::string config =
      "<prototypes>  <val>foobar</val> </prototypes>"
@@ -164,38 +164,19 @@ TEST_F(DeployInstTests, DeployYear) {
      ;
 
   int simdur = 30;
+  //MockSim starts in 2010 by default
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
-
+  // 2 years and 2 months after MockSim start is 25 time steps 
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
       "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = '25';"
       );
   stmt->Step();
-  EXPECT_EQ(3, stmt->GetInt(0)); //start year is 2010
+  EXPECT_EQ(3, stmt->GetInt(0)); 
 }
 
-TEST_F(DeployInstTests, DeployYear2) {
-  std::string config =
-     "<prototypes>  <val>foobar</val> </prototypes>"
-     "<build_times> <val>2</val>      </build_times>"
-     "<n_build>     <val>3</val>      </n_build>"
-     "<deployyear>    2015            </deployyear>"
-     ;
-
-  int simdur = 5;
-  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
-  sim.DummyProto("foobar");
-  int id = sim.Run();
-
-  cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar';"
-      );
-  stmt->Step();
-  EXPECT_EQ(0, stmt->GetInt(0));
-}
-
-TEST_F(DeployInstTests, DeployYear3) {
+TEST_F(DeployInstTests, DeployYearEarlyError) {
   std::string config =
      "<prototypes>  <val>foobar</val> </prototypes>"
      "<build_times> <val>2</val>      </build_times>"
@@ -209,7 +190,7 @@ TEST_F(DeployInstTests, DeployYear3) {
   EXPECT_THROW(sim.Run(),cyclus::ValueError); 
 }
 
-TEST_F(DeployInstTests, DeployYear4) {
+TEST_F(DeployInstTests, DeployYearLateWarn) {
   std::string config =
      "<prototypes>  <val>foobar</val> </prototypes>"
      "<build_times> <val>2</val>      </build_times>"
@@ -219,10 +200,18 @@ TEST_F(DeployInstTests, DeployYear4) {
 
   int simdur = 5;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+
   cyclus::warn_as_error = true;
   EXPECT_THROW(sim.Run(),
                cyclus::ValueError);
   cyclus::warn_as_error = false;
+
+  int id = sim.Run();
+  cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar';"
+      );
+  stmt->Step();
+  EXPECT_EQ(0, stmt->GetInt(0));
 }
 
 TEST_F(DeployInstTests, PositionInitialize) {

--- a/src/deploy_inst_tests.cc
+++ b/src/deploy_inst_tests.cc
@@ -1,5 +1,6 @@
 #include "deploy_inst_tests.h"
-
+#include "deploy_inst.h"
+#include "error.h"
 // make sure that the deployed agent's prototype name is identical to the
 // originally specified prototype name - this is important to test because
 // DeployInst does some mucking around with registering name-modded prototypes
@@ -192,6 +193,20 @@ TEST_F(DeployInstTests, DeployYear2) {
       );
   stmt->Step();
   EXPECT_EQ(0, stmt->GetInt(0));
+}
+
+TEST_F(DeployInstTests, DeployYear3) {
+  std::string config =
+     "<prototypes>  <val>foobar</val> </prototypes>"
+     "<build_times> <val>2</val>      </build_times>"
+     "<n_build>     <val>3</val>      </n_build>"
+     "<deployyear>    2000            </deployyear>"
+     ;
+
+  int simdur = 5;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+
+  EXPECT_THROW(sim.Run(),cyclus::ValueError); 
 }
 
 TEST_F(DeployInstTests, PositionInitialize) {

--- a/src/deploy_inst_tests.cc
+++ b/src/deploy_inst_tests.cc
@@ -209,6 +209,22 @@ TEST_F(DeployInstTests, DeployYear3) {
   EXPECT_THROW(sim.Run(),cyclus::ValueError); 
 }
 
+TEST_F(DeployInstTests, DeployYear4) {
+  std::string config =
+     "<prototypes>  <val>foobar</val> </prototypes>"
+     "<build_times> <val>2</val>      </build_times>"
+     "<n_build>     <val>3</val>      </n_build>"
+     "<deployyear>    2030          </deployyear>"
+     ;
+
+  int simdur = 5;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  cyclus::warn_as_error = true;
+  EXPECT_THROW(sim.Run(),
+               cyclus::ValueError);
+  cyclus::warn_as_error = false;
+}
+
 TEST_F(DeployInstTests, PositionInitialize) {
   std::string config =
      "<prototypes>  <val>foobar</val> </prototypes>"

--- a/src/deploy_inst_tests.cc
+++ b/src/deploy_inst_tests.cc
@@ -153,25 +153,45 @@ TEST_F(DeployInstTests, NoDupProtos) {
   stmt->Step();
   EXPECT_EQ(1, stmt->GetInt(0));
 }
-
+//this test makes sure that the institutions deployed before sim start are reset to 1. 
 TEST_F(DeployInstTests, DeployYear) {
   std::string config =
      "<prototypes>  <val>foobar</val> </prototypes>"
      "<build_times> <val>2</val>      </build_times>"
      "<n_build>     <val>3</val>      </n_build>"
-     "<lifetimes>   <val>10</val>     </lifetimes>"
+     "<deployyear>  <val>2012</val>      </deployyear>"
      ;
 
-  int simdur = 15;
+  int simdur = 30;
   cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
   sim.DummyProto("foobar");
   int id = sim.Run();
 
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT ExitTime from AgentExit AS x INNER JOIN AgentEntry AS e ON x.AgentId = e.AgentId"
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime = '25';"
       );
   stmt->Step();
-  EXPECT_EQ(11, stmt->GetInt(0));
+  EXPECT_EQ(3, stmt->GetInt(0)); //start year is 2010
+}
+
+TEST_F(DeployInstTests, DeployYear2) {
+  std::string config =
+     "<prototypes>  <val>foobar</val> </prototypes>"
+     "<build_times> <val>2</val>      </build_times>"
+     "<n_build>     <val>3</val>      </n_build>"
+     "<deployyear>  <val>2009</val>      </deployyear>"
+     ;
+
+  int simdur = 5;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  sim.DummyProto("foobar");
+  int id = sim.Run();
+
+  cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime='1';"
+      );
+  stmt->Step();
+  EXPECT_EQ(3, stmt->GetInt(0));
 }
 
 TEST_F(DeployInstTests, PositionInitialize) {

--- a/src/deploy_inst_tests.cc
+++ b/src/deploy_inst_tests.cc
@@ -154,6 +154,26 @@ TEST_F(DeployInstTests, NoDupProtos) {
   EXPECT_EQ(1, stmt->GetInt(0));
 }
 
+TEST_F(DeployInstTests, DeployYear) {
+  std::string config =
+     "<prototypes>  <val>foobar</val> </prototypes>"
+     "<build_times> <val>2</val>      </build_times>"
+     "<n_build>     <val>3</val>      </n_build>"
+     "<lifetimes>   <val>10</val>     </lifetimes>"
+     ;
+
+  int simdur = 15;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:DeployInst"), config, simdur);
+  sim.DummyProto("foobar");
+  int id = sim.Run();
+
+  cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
+      "SELECT ExitTime from AgentExit AS x INNER JOIN AgentEntry AS e ON x.AgentId = e.AgentId"
+      );
+  stmt->Step();
+  EXPECT_EQ(11, stmt->GetInt(0));
+}
+
 TEST_F(DeployInstTests, PositionInitialize) {
   std::string config =
      "<prototypes>  <val>foobar</val> </prototypes>"

--- a/src/deploy_inst_tests.cc
+++ b/src/deploy_inst_tests.cc
@@ -159,7 +159,7 @@ TEST_F(DeployInstTests, DeployYear) {
      "<prototypes>  <val>foobar</val> </prototypes>"
      "<build_times> <val>2</val>      </build_times>"
      "<n_build>     <val>3</val>      </n_build>"
-     "<deployyear>  <val>2012</val>      </deployyear>"
+     "<deployyear>     2012           </deployyear>"
      ;
 
   int simdur = 30;
@@ -179,7 +179,7 @@ TEST_F(DeployInstTests, DeployYear2) {
      "<prototypes>  <val>foobar</val> </prototypes>"
      "<build_times> <val>2</val>      </build_times>"
      "<n_build>     <val>3</val>      </n_build>"
-     "<deployyear>  <val>2009</val>      </deployyear>"
+     "<deployyear>    2015            </deployyear>"
      ;
 
   int simdur = 5;
@@ -188,10 +188,10 @@ TEST_F(DeployInstTests, DeployYear2) {
   int id = sim.Run();
 
   cyclus::SqlStatement::Ptr stmt = sim.db().db().Prepare(
-      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar' AND EnterTime='1';"
+      "SELECT COUNT(*) FROM AgentEntry WHERE Prototype = 'foobar';"
       );
   stmt->Step();
-  EXPECT_EQ(3, stmt->GetInt(0));
+  EXPECT_EQ(0, stmt->GetInt(0));
 }
 
 TEST_F(DeployInstTests, PositionInitialize) {

--- a/src/deploy_inst_tests.cc
+++ b/src/deploy_inst_tests.cc
@@ -1,6 +1,6 @@
 #include "deploy_inst_tests.h"
-#include "deploy_inst.h"
 #include "error.h"
+#include "deploy_inst.h"
 // make sure that the deployed agent's prototype name is identical to the
 // originally specified prototype name - this is important to test because
 // DeployInst does some mucking around with registering name-modded prototypes


### PR DESCRIPTION
<!-- If this PR adds a CEP, do not repeat all of the information in the CEP document in the summary. Instead, provide a short description of the CEP's purpose.  -->

# Summary of Changes
<!--- In one or more sentences, describe the PR you are submitting. -->
I added a optional deploy year variable to DeployInst.  This variable will allow the user to input a year that informs DeployInst of when facilities should be built **relative** to the build times. It is essentially an offset to build time.
The current changes should anticipate whether the optional deploy year *and* build time exceed or are within the simulation duration. A value error should be thrown in the event the combination of deploy year and build time exceed simulation duration but the offset is still applied.

This PR does not yet address issue #674 but it does anticipate that users could input a deploy year and build time that is before the simulation start. In this scenario, the time of deployment is reset to time step 1 and a value error thrown highlighting this reset. 

## Design Notes
<!--- Describe any design decisions or trade-offs you made. -->
I kept deploy year as an optional parameter but this means that build time + deploy year combination must together be considered when evaluating when a facility should be built. For example, deploy year could be within the sim duration but build time offset makes it exceed duration. Or, deploy year could be before sim duration but build time offset makes it within the simulation. 

Check the box if your change does not break any of the following:
- [x] API for Cyclus modules
- [x] Input files
- [x] Output tables for post processing tools

# Related CEPs and Issues
<!--- Reference the issue that this PR closes, any related CEPs, and describe how this PR contributes to or addresses the problem. -->
Fixes #676 and #675

# Testing and Validation
<!--- Describe how this change was tested. -->
Added two tests. One tests whether build time + deploy year falls on the expected year with in the simulation and deploys. Another test checks whether or not build time + deploy year falls before the simulation start and that the deploy times are properly reset to simulation start. 

As an aside, I am slightly unsure about the conversion from year to time-step in the code changes. 

- [x] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [x] I have compiled and run the code locally
- [x] I have added or updated relevant tests
- [x] I have added documentation for new or changed features
- [x] This code follows the style guide
- [x] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).