### PR TITLE
Add MC/MU to a few Cycamore Facilities

### DIFF
--- a/src/conversion.cc
+++ b/src/conversion.cc
@@ -44,6 +44,8 @@ Conversion::~Conversion() {}
 void Conversion::EnterNotify() {
   cyclus::Facility::EnterNotify();
   InitializePosition();
+  InitializeMarginalUtility(incommods, incommod_prefs);
+  InitializeMarginalCost();
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -100,6 +102,11 @@ std::set<RequestPortfolio<Material>::Ptr> Conversion::GetMatlRequests() {
   double available_capacity = AvailableFeedstockCapacity();
   if (available_capacity <= 0) return ports;
 
+  // Calculate Marginal Utility for each commodity using its preference
+  auto mu_results = CalcMarginalUtility(incommods, incommod_prefs);
+  std::vector<std::string> mu_commods = mu_results.first;
+  std::vector<double> mu_values = mu_results.second;
+
   // Create request portfolio
   RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
 
@@ -107,21 +114,15 @@ std::set<RequestPortfolio<Material>::Ptr> Conversion::GetMatlRequests() {
   Material::Ptr mat = cyclus::NewBlankMaterial(available_capacity);
  
 
-  // Add request for all commodities using default preference
-  for (std::vector<std::string>::iterator it = incommods.begin();
-       it != incommods.end(); ++it) {
-    Request<Material>* req = port->AddRequest(mat, this, *it);
-  }
-
-  // Add capacity constraint to ensure we never get more feed than capacity
-  CapacityConstraint<Material> cc(available_capacity);
-  port->AddConstraint(cc);
-
-  ports.insert(port);
+  // Add request for all commodities using their marginal utility values
+  for (int i = 0; i < incommods.size(); i++) {
+    Request<Material>* req = port->AddRequest(mat, this, mu_commods[i], mu_values[i]);
+    }
+    ports.insert(port);
   return ports;
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::set<BidPortfolio<Material>::Ptr> Conversion::GetMatlBids(
   CommodMap<Material>::type& commod_requests) {
   std::set<BidPortfolio<Material>::Ptr> ports;
@@ -140,10 +141,11 @@ std::set<BidPortfolio<Material>::Ptr> Conversion::GetMatlBids(
     double available = output.quantity();
     double requested = (*it)->target()->quantity();
     double offer_qty = std::min(available, requested);
+    double marginal_cost = CalcMarginalCost(output.Peek()->UnitValue());
 
     if (offer_qty > 0) {
       Material::Ptr offer = Material::CreateUntracked(offer_qty, output.Peek()->comp());
-      port->AddBid(*it, offer, this);  // Note: *it, not **it
+      port->AddBid(*it, offer, this, false, marginal_cost);  // Note: *it, not **it
     }
   }
 

--- a/src/conversion.cc
+++ b/src/conversion.cc
@@ -126,8 +126,6 @@ std::set<RequestPortfolio<Material>::Ptr> Conversion::GetMatlRequests() {
  
   // Add request for all commodities using their marginal utility values
   for (int i = 0; i < incommods.size(); i++) {
-    std::cout << mu_commods.size() << std::endl;
-    std::cout << mu_values.size() << std::endl;
     Request<Material>* req = port->AddRequest(mat, this, mu_commods[i], mu_values[i]);
   }
 

--- a/src/conversion.cc
+++ b/src/conversion.cc
@@ -44,8 +44,19 @@ Conversion::~Conversion() {}
 void Conversion::EnterNotify() {
   cyclus::Facility::EnterNotify();
   InitializePosition();
-  InitializeMarginalUtility(incommods, incommod_prefs);
   InitializeMarginalCost();
+  
+  // Initialize default preferences if not provided
+  if (incommod_prefs.size() == 0) {
+    for (int i = 0; i < incommods.size(); ++i) {
+      incommod_prefs.push_back(cyclus::kDefaultPref);
+    }
+  } else if (incommod_prefs.size() != incommods.size()) {
+    std::stringstream ss;
+    ss << "incommod_prefs has " << incommod_prefs.size()
+       << " values, expected " << incommods.size();
+    throw cyclus::ValueError(ss.str());
+  }
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -113,12 +124,18 @@ std::set<RequestPortfolio<Material>::Ptr> Conversion::GetMatlRequests() {
   // Create material request with no recipe
   Material::Ptr mat = cyclus::NewBlankMaterial(available_capacity);
  
-
   // Add request for all commodities using their marginal utility values
   for (int i = 0; i < incommods.size(); i++) {
+    std::cout << mu_commods.size() << std::endl;
+    std::cout << mu_values.size() << std::endl;
     Request<Material>* req = port->AddRequest(mat, this, mu_commods[i], mu_values[i]);
-    }
-    ports.insert(port);
+  }
+
+  // Add capacity constraint to ensure we never get more feed than capacity
+  CapacityConstraint<Material> cc(available_capacity);
+  port->AddConstraint(cc);
+
+  ports.insert(port);
   return ports;
 }
 

--- a/src/conversion.h
+++ b/src/conversion.h
@@ -91,6 +91,7 @@ class Conversion
   std::vector<std::string> incommods;
 
   #pragma cyclus var { \
+    "default": [], \
     "tooltip": "input commodity preferences", \
     "doc": "preferences for each of the given commodities, in the same order.", \
     "uilabel": "Input Commodity Preferences", \

--- a/src/conversion.h
+++ b/src/conversion.h
@@ -77,6 +77,8 @@ class Conversion
  private:
   // Code Injection:
   #include "toolkit/position.cycpp.h"
+  #include "toolkit/marginal_cost.cycpp.h"
+  #include "toolkit/marginal_utility.cycpp.h"
 
   // clang-format off
   /// all facilities must have at least one input commodity
@@ -87,6 +89,14 @@ class Conversion
     "uitype": ["oneormore", "incommodity"] \
   }
   std::vector<std::string> incommods;
+
+  #pragma cyclus var { \
+    "tooltip": "input commodity preferences", \
+    "doc": "preferences for each of the given commodities, in the same order.", \
+    "uilabel": "Input Commodity Preferences", \
+    "uitype": ["oneormore", "range"] \
+  }
+  std::vector<double> incommod_prefs; 
 
   #pragma cyclus var { \
     "tooltip": "output commodity", \

--- a/src/conversion_tests.h
+++ b/src/conversion_tests.h
@@ -35,12 +35,16 @@ class ConversionTest : public ::testing::Test {
   const double DEFAULT_INPUT_CAPACITY = 50.0;
   
   const std::string INCOMMOD1 = "incommod1";
+  const double INCOMMOD1_PREF = 0.5;
   const std::string OUTCOMMOD_NAME = "outcommod";
 
   const std::string DEFAULT_CONFIG = 
     "<incommods>"
     "  <incommodity>" + INCOMMOD1 + "</incommodity>"
     "</incommods>"
+    "<incommod_prefs>"
+    "  <incommodity_preference>" + std::to_string(INCOMMOD1_PREF) + "</incommodity_preference>"
+    "</incommod_prefs>"
     "<outcommod>" + OUTCOMMOD_NAME + "</outcommod>"
     "<throughput>" + std::to_string(DEFAULT_THROUGHPUT) + "</throughput>"
     "<input_capacity>" + std::to_string(DEFAULT_INPUT_CAPACITY) + "</input_capacity>";

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -111,17 +111,18 @@ bool SortBids(cyclus::Bid<Material>* i,
 // Sort offers of input material to have higher preference for more
 //  U-235 content
 void Enrichment::AdjustMatlPrefs(
-    cyclus::PrefMap<Material>::type& prefs) {
+    cyclus::MCMap<Material>::type& mc_prefs,
+    cyclus::MUMap<Material>::type& mu_prefs) {
   using cyclus::Bid;
 
   if (order_prefs == false) {
     return;
   }
 
-  cyclus::PrefMap<Material>::type::iterator reqit;
+  cyclus::MUMap<Material>::type::iterator reqit;
 
-  // Loop over all requests
-  for (reqit = prefs.begin(); reqit != prefs.end(); ++reqit) {
+  // Loop over all requests - adjust MU (marginal utility) since we're the requester
+  for (reqit = mu_prefs.begin(); reqit != mu_prefs.end(); ++reqit) {
     std::vector<Bid<Material>*> bids_vector;
     std::map<Bid<Material>*, double>::iterator mit;
     for (mit = reqit->second.begin(); mit != reqit->second.end(); ++mit) {
@@ -137,7 +138,7 @@ void Enrichment::AdjustMatlPrefs(
     for (int bidit = 0; bidit < bids_vector.size(); bidit++) {
       int new_pref = bidit + 1;
 
-      // For any bids with U-235 qty=0, set pref to zero.
+      // For any bids with U-235 qty=0, set pref to -1 to reject the trade
       if (!u235_mass) {
         Material::Ptr mat = bids_vector[bidit]->offer();
         cyclus::toolkit::MatQuery mq(mat);

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -46,7 +46,8 @@ void Enrichment::Build(cyclus::Agent* parent) {
   Facility::Build(parent);
   if (initial_feed > 0) {
     inventory.Push(Material::Create(this, initial_feed,
-                                    context()->GetRecipe(feed_recipe)));
+                                    context()->GetRecipe(feed_recipe), 
+                                    cyclus::Package::unpackaged_name(), 0.0));
   }
 
   LOG(cyclus::LEV_DEBUG2, "EnrFac") << "Enrichment "
@@ -58,7 +59,7 @@ void Enrichment::EnterNotify() {
   cyclus::Facility::EnterNotify();
   InitializePosition();
   InitializeMarginalCost();
-
+  
   // Need these to be vectorized because of the function signature...
   feed_commod_vec.push_back(feed_commod);
   feed_pref_vec.push_back(feed_commod_pref);
@@ -67,7 +68,6 @@ void Enrichment::EnterNotify() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::Tick() {
   current_swu_capacity = SwuCapacity();
-
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -210,8 +210,6 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Enrichment::GetMatlBids(
         Material::Ptr m = mats[k];
         Request<Material>* req = *it;
 
-        std::cout << "Unit Value (Tails): " << m->UnitValue() << std::endl;
-        std::cout << "Marginal Cost (Tails): " << CalcMarginalCost(m->UnitValue()) << std::endl;
         double tails_marginal_cost = CalcMarginalCost(m->UnitValue());
         tails_port->AddBid(req, m, this, false, tails_marginal_cost);
       }
@@ -259,7 +257,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Enrichment::GetMatlBids(
         double avg_unit_value = (total_qty > 0) ? (total_cost / total_qty) : 0.0;
         double input_material_cost = input_material_qty * avg_unit_value;
         double marginal_cost = (input_material_cost + swu_cost * swu_req) / offer->quantity();
-        
+
         commod_port->AddBid(req, offer, this, false, marginal_cost);
       }
     }
@@ -378,8 +376,7 @@ void Enrichment::AddMat_(Material::Ptr mat) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Material::Ptr Enrichment::Request_() {
   double qty = std::max(0.0, inventory.capacity() - inventory.quantity());
-  return Material::CreateUntracked(qty,
-                                           context()->GetRecipe(feed_recipe));
+  return Material::CreateUntracked(qty, context()->GetRecipe(feed_recipe));
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -186,6 +186,10 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Enrichment::GetMatlBids(
   using cyclus::Request;
   using cyclus::toolkit::MatVec;
   using cyclus::toolkit::RecordTimeSeries;
+  using cyclus::toolkit::Assays;
+  using cyclus::toolkit::UraniumAssayMass;
+  using cyclus::toolkit::SwuRequired;
+  using cyclus::toolkit::FeedQty;
 
   std::set<BidPortfolio<Material>::Ptr> ports;
 
@@ -206,6 +210,8 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Enrichment::GetMatlBids(
         Material::Ptr m = mats[k];
         Request<Material>* req = *it;
 
+        std::cout << "Unit Value (Tails): " << m->UnitValue() << std::endl;
+        std::cout << "Marginal Cost (Tails): " << CalcMarginalCost(m->UnitValue()) << std::endl;
         double tails_marginal_cost = CalcMarginalCost(m->UnitValue());
         tails_port->AddBid(req, m, this, false, tails_marginal_cost);
       }
@@ -229,13 +235,31 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Enrichment::GetMatlBids(
     for (it = commod_requests.begin(); it != commod_requests.end(); ++it) {
       Request<Material>* req = *it;
       Material::Ptr mat = req->target();
-      double request_enrich = cyclus::toolkit::UraniumAssayMass(mat);
+      double request_enrich = UraniumAssayMass(mat);
       if (ValidReq(req->target()) &&
           ((request_enrich < max_enrich) ||
            (cyclus::AlmostEq(request_enrich, max_enrich)))) {
         Material::Ptr offer = Offer_(req->target());
 
-        double marginal_cost = CalcMarginalCost(offer->UnitValue());
+        Assays assays(FeedAssay(), UraniumAssayMass(mat), tails_assay);
+        double swu_cost = GetEconParameter("variable_cost_per_unit");
+        double swu_req = SwuRequired(offer->quantity(), assays);
+        double input_material_qty = FeedQty(offer->quantity(), assays);
+
+        // Calculate average unit value of feed materials (quantity-weighted)
+        double total_cost = 0.0;
+        double total_qty = 0.0;
+        MatVec feed_materials = inventory.PopN(inventory.count());
+        for (const auto& mat : feed_materials) {
+          total_cost += mat->quantity() * mat->UnitValue();
+          total_qty += mat->quantity();
+        }
+        inventory.Push(feed_materials);
+        
+        double avg_unit_value = (total_qty > 0) ? (total_cost / total_qty) : 0.0;
+        double input_material_cost = input_material_qty * avg_unit_value;
+        double marginal_cost = (input_material_cost + swu_cost * swu_req) / offer->quantity();
+        
         commod_port->AddBid(req, offer, this, false, marginal_cost);
       }
     }

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -57,6 +57,11 @@ void Enrichment::Build(cyclus::Agent* parent) {
 void Enrichment::EnterNotify() {
   cyclus::Facility::EnterNotify();
   InitializePosition();
+  InitializeMarginalCost();
+
+  // Need these to be vectorized because of the function signature...
+  feed_commod_vec.push_back(feed_commod);
+  feed_pref_vec.push_back(feed_commod_pref);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -87,8 +92,14 @@ Enrichment::GetMatlRequests() {
   Material::Ptr mat = Request_();
   double amt = mat->quantity();
 
+  // Calculate Marginal Utility for the feed commodity using its preference
+  auto mu_results = CalcMarginalUtility(feed_commod_vec, feed_pref_vec);
+  std::vector<std::string> mu_commods = mu_results.first;
+  std::vector<double> mu_values = mu_results.second;
+
   if (amt > cyclus::eps_rsrc()) {
-    port->AddRequest(mat, this, feed_commod);
+    // Since there's only one feed commodity we just use the first element
+    port->AddRequest(mat, this, mu_commods[0], mu_values[0]);
     ports.insert(port);
   }
 
@@ -194,7 +205,9 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Enrichment::GetMatlBids(
       for (int k = 0; k < mats.size(); k++) {
         Material::Ptr m = mats[k];
         Request<Material>* req = *it;
-        tails_port->AddBid(req, m, this);
+
+        double tails_marginal_cost = CalcMarginalCost(m->UnitValue());
+        tails_port->AddBid(req, m, this, false, tails_marginal_cost);
       }
     }
     // overbidding (bidding on every offer)
@@ -221,7 +234,9 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Enrichment::GetMatlBids(
           ((request_enrich < max_enrich) ||
            (cyclus::AlmostEq(request_enrich, max_enrich)))) {
         Material::Ptr offer = Offer_(req->target());
-        commod_port->AddBid(req, offer, this);
+
+        double marginal_cost = CalcMarginalCost(offer->UnitValue());
+        commod_port->AddBid(req, offer, this, false, marginal_cost);
       }
     }
 

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -202,7 +202,8 @@ class Enrichment
   /// @brief The Enrichment adjusts preferences for offers of
   /// natural uranium it has received to maximize U-235 content
   /// Any offers that have zero U-235 content are not accepted
-  virtual void AdjustMatlPrefs(cyclus::PrefMap<cyclus::Material>::type& prefs);
+  virtual void AdjustMatlPrefs(cyclus::MCMap<cyclus::Material>::type& mc_prefs,
+                                cyclus::MUMap<cyclus::Material>::type& mu_prefs);
 
   /// @brief The Enrichment place accepted trade Materials in their
   /// Inventory

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -254,6 +254,8 @@ class Enrichment
  private:
   // Code Injection:
   #include "toolkit/position.cycpp.h"
+  #include "toolkit/marginal_cost.cycpp.h"
+  #include "toolkit/marginal_utility.cycpp.h"
 
   ///   @brief adds a material into the natural uranium inventory
   ///   @throws if the material is not the same composition as the feed_recipe
@@ -286,6 +288,15 @@ class Enrichment
     "uitype": "incommodity" \
   }
   std::string feed_commod;
+
+  #pragma cyclus var { \
+    "default": 1.0, \
+    "tooltip": "feed commodity preference", \
+    "doc": "preference for the feed commodity", \
+    "uilabel": "Feed Commodity Preference", \
+    "uitype": "range" \
+  }
+  double feed_commod_pref; 
 
   #pragma cyclus var { \
     "tooltip": "feed recipe",						\
@@ -388,7 +399,8 @@ class Enrichment
   // these help enable time series generation.
   double intra_timestep_swu_;
   double intra_timestep_feed_;
-
+  std::vector<std::string> feed_commod_vec;
+  std::vector<double> feed_pref_vec;
   friend class EnrichmentTest;
   // ---
 

--- a/src/fuel_fab.cc
+++ b/src/fuel_fab.cc
@@ -138,6 +138,9 @@ FuelFab::FuelFab(cyclus::Context* ctx)
 
 void FuelFab::EnterNotify() {
   cyclus::Facility::EnterNotify();
+  InitializeMarginalCost();
+  // No benefit to initializing Marginal Utility because we have multiple lists
+  // of commodities and preferences that need to be stored separately.
 
   if (fiss_commod_prefs.empty()) {
     for (int i = 0; i < fiss_commods.size(); i++) {
@@ -181,10 +184,14 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> FuelFab::GetMatlRequests() {
     }
 
     std::vector<cyclus::Request<Material>*> reqs;
-    for (int i = 0; i < fiss_commods.size(); i++) {
-      std::string commod = fiss_commods[i];
-      double pref = fiss_commod_prefs[i];
-      reqs.push_back(port->AddRequest(m, this, commod, pref, exclusive));
+    auto mu_results_fiss = CalcMarginalUtility(fiss_commods, fiss_commod_prefs);
+
+    // We make new vectors here to ensure they're all in the right order.
+    std::vector<std::string> mu_fiss_commods = mu_results_fiss.first;
+    std::vector<double> mu_fiss_values = mu_results_fiss.second;
+    
+    for (int i = 0; i < mu_fiss_commods.size(); i++) {
+      reqs.push_back(port->AddRequest(m, this, mu_fiss_commods[i], mu_fiss_values[i], exclusive));
       req_inventories_[reqs.back()] = "fiss";
     }
     port->AddMutualReqs(reqs);
@@ -201,10 +208,14 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> FuelFab::GetMatlRequests() {
     }
 
     std::vector<cyclus::Request<Material>*> reqs;
-    for (int i = 0; i < fill_commods.size(); i++) {
-      std::string commod = fill_commods[i];
-      double pref = fill_commod_prefs[i];
-      reqs.push_back(port->AddRequest(m, this, commod, pref, exclusive));
+
+    // Same as above but now for the fill commodities
+    auto mu_results_fill = CalcMarginalUtility(fill_commods, fill_commod_prefs);
+    std::vector<std::string> mu_fill_commods = mu_results_fill.first;
+    std::vector<double> mu_fill_values = mu_results_fill.second;
+
+    for (int i = 0; i < mu_fill_commods.size(); i++) {
+      reqs.push_back(port->AddRequest(m, this, mu_fill_commods[i], mu_fill_values[i], exclusive));
       req_inventories_[reqs.back()] = "fill";
     }
     port->AddMutualReqs(reqs);
@@ -219,8 +230,17 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> FuelFab::GetMatlRequests() {
       Composition::Ptr c = context()->GetRecipe(topup_recipe);
       m = Material::CreateUntracked(topup.space(), c);
     }
+
+    // Unfortunately, these need to be vectorized because of the function
+    // signature...
+    std::vector<std::string> topup_commod_vec = {topup_commod};
+    std::vector<double> topup_pref_vec = {topup_pref};
+    auto mu_results_topup = CalcMarginalUtility(topup_commod_vec, topup_pref_vec);
+    std::vector<std::string> mu_topup_commods = mu_results_topup.first;
+    std::vector<double> mu_topup_values = mu_results_topup.second;
+
     cyclus::Request<Material>* r =
-        port->AddRequest(m, this, topup_commod, topup_pref, exclusive);
+        port->AddRequest(m, this, mu_topup_commods[0], mu_topup_values[0], exclusive);
     req_inventories_[r] = "topup";
     ports.insert(port);
   }
@@ -331,12 +351,20 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> FuelFab::GetMatlBids(
       double fill_frac = 1 - fiss_frac;
       fiss_frac = AtomToMassFrac(fiss_frac, c_fiss, c_fill);
       fill_frac = AtomToMassFrac(fill_frac, c_fill, c_fiss);
-      Material::Ptr m1 = Material::CreateUntracked(fiss_frac * tgt_qty, c_fiss);
-      Material::Ptr m2 = Material::CreateUntracked(fill_frac * tgt_qty, c_fill);
+
+      // Since these are bulk buffers, the matl unit_values get averaged over
+      // all historical trades automatically.
+      double fiss_matl_cost = fiss.Peek()->UnitValue();
+      double fill_matl_cost = fill.Peek()->UnitValue();
+      
+      Material::Ptr m1 = Material::CreateUntracked(fiss_frac * tgt_qty, c_fiss, fiss_matl_cost);
+      Material::Ptr m2 = Material::CreateUntracked(fill_frac * tgt_qty, c_fill, fill_matl_cost);
       m1->Absorb(m2);
 
+      double marginal_cost = CalcMarginalCost(m1->UnitValue());
+
       bool exclusive = false;
-      port->AddBid(req, m1, this, exclusive);
+      port->AddBid(req, m1, this, exclusive, marginal_cost);
     } else if (topup.count() > 0 && ValidWeights(w_fiss, w_tgt, w_topup)) {
       // only bid with topup if we have filler - otherwise we might be able to
       // meet target with filler when we get it. we should only use topup
@@ -345,13 +373,21 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> FuelFab::GetMatlBids(
       double fiss_frac = 1 - topup_frac;
       fiss_frac = AtomToMassFrac(fiss_frac, c_fiss, c_topup);
       topup_frac = AtomToMassFrac(topup_frac, c_topup, c_fiss);
+
+      // Since these are bulk buffers, the matl unit_values get averaged over
+      // all historical trades automatically.
+      double fiss_matl_cost = fiss.Peek()->UnitValue();
+      double topup_matl_cost = topup.Peek()->UnitValue();
+
       Material::Ptr m1 =
-          Material::CreateUntracked(topup_frac * tgt_qty, c_topup);
-      Material::Ptr m2 = Material::CreateUntracked(fiss_frac * tgt_qty, c_fiss);
+          Material::CreateUntracked(topup_frac * tgt_qty, c_topup, topup_matl_cost);
+      Material::Ptr m2 = Material::CreateUntracked(fiss_frac * tgt_qty, c_fiss, fiss_matl_cost);
       m1->Absorb(m2);
 
+      double marginal_cost = CalcMarginalCost(m1->UnitValue());
+
       bool exclusive = false;
-      port->AddBid(req, m1, this, exclusive);
+      port->AddBid(req, m1, this, exclusive, marginal_cost);
     } else if (fiss.count() > 0 && fill.count() > 0 ||
                fiss.count() > 0 && topup.count() > 0) {
       // else can't meet the target weight - don't bid.  Just a plain else

--- a/src/fuel_fab.cc
+++ b/src/fuel_fab.cc
@@ -354,8 +354,14 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> FuelFab::GetMatlBids(
 
       // Since these are bulk buffers, the matl unit_values get averaged over
       // all historical trades automatically.
-      double fiss_matl_cost = fiss.Peek()->UnitValue();
-      double fill_matl_cost = fill.Peek()->UnitValue();
+      double fiss_matl_cost = 0;
+      if (!fiss.empty()) {
+        fiss_matl_cost = fiss.Peek()->UnitValue();
+      }
+      double fill_matl_cost = 0;
+      if (!fill.empty()) {
+        fill_matl_cost = fill.Peek()->UnitValue();
+      }
       
       Material::Ptr m1 = Material::CreateUntracked(fiss_frac * tgt_qty, c_fiss, fiss_matl_cost);
       Material::Ptr m2 = Material::CreateUntracked(fill_frac * tgt_qty, c_fill, fill_matl_cost);
@@ -376,8 +382,14 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> FuelFab::GetMatlBids(
 
       // Since these are bulk buffers, the matl unit_values get averaged over
       // all historical trades automatically.
-      double fiss_matl_cost = fiss.Peek()->UnitValue();
-      double topup_matl_cost = topup.Peek()->UnitValue();
+      double fiss_matl_cost = 0;
+      if (!fiss.empty()) {
+        fiss_matl_cost = fiss.Peek()->UnitValue();
+      }
+      double topup_matl_cost = 0;
+      if (!topup.empty()) {
+        topup_matl_cost = topup.Peek()->UnitValue();
+      }
 
       Material::Ptr m1 =
           Material::CreateUntracked(topup_frac * tgt_qty, c_topup, topup_matl_cost);

--- a/src/fuel_fab.h
+++ b/src/fuel_fab.h
@@ -136,6 +136,8 @@ class FuelFab
  private:
   // Code Injection:
   #include "toolkit/position.cycpp.h"
+  #include "toolkit/marginal_cost.cycpp.h"
+  #include "toolkit/marginal_utility.cycpp.h"
 
   #pragma cyclus var { \
     "doc": "Ordered list of commodities on which to requesting filler stream material.", \

--- a/src/mixer.cc
+++ b/src/mixer.cc
@@ -59,6 +59,11 @@ void Mixer::EnterNotify() {
     in_commods.push_back(streams_[i].second);
   }
 
+  // Optional recipe per stream: size to match streams_, use "" where not set
+  if (in_stream_recipes.size() < streams_.size()) {
+    in_stream_recipes.resize(streams_.size(), "");
+  }
+
   // ratio normalisation
   if (mixing_ratios.size() != in_commods.size()) {
     std::stringstream ss;
@@ -89,6 +94,13 @@ void Mixer::EnterNotify() {
   }
 
   sell_policy.Init(this, &output, "output").Set(out_commod).Start();
+
+  // Register output recipe name at sim start so it exists before first mix.
+  // Placeholder composition is overwritten with the real blend when we push.
+  if (!out_recipe.empty()) {
+    cyclus::CompMap empty;
+    context()->AddRecipe(out_recipe, cyclus::Composition::CreateFromMass(empty));
+  }
 
   InitializeMarginalCost();
   InitializePosition();
@@ -122,6 +134,9 @@ void Mixer::Tick() {
         }
       }
 
+      if (!out_recipe.empty()) {
+        context()->AddRecipe(out_recipe, m->comp());
+      }
       output.Push(m);
     }
   }
@@ -169,7 +184,12 @@ Mixer::GetMatlRequests() {
           new RequestPortfolio<cyclus::Material>());
 
       cyclus::Material::Ptr m;
-      m = cyclus::NewBlankMaterial(streambufs[name].space());
+      if (i < in_stream_recipes.size() && !in_stream_recipes[i].empty()) {
+        cyclus::Composition::Ptr rec = context()->GetRecipe(in_stream_recipes[i]);
+        m = cyclus::Material::CreateUntracked(streambufs[name].space(), rec);
+      } else {
+        m = cyclus::NewBlankMaterial(streambufs[name].space());
+      }
 
       std::vector<cyclus::Request<cyclus::Material>*> reqs;
 

--- a/src/mixer.cc
+++ b/src/mixer.cc
@@ -57,8 +57,6 @@ void Mixer::EnterNotify() {
       streambufs[name].capacity(cap);
     }
     in_commods.push_back(streams_[i].second);
-
-    InitializePosition();
   }
 
   // ratio normalisation
@@ -91,9 +89,14 @@ void Mixer::EnterNotify() {
   }
 
   sell_policy.Init(this, &output, "output").Set(out_commod).Start();
+
+  InitializeMarginalCost();
+  InitializePosition();
 }
 
 void Mixer::Tick() {
+  using cyclus::toolkit::MatVec;
+
   if (output.quantity() < output.capacity()) {
     double tgt_qty = output.space();
 
@@ -118,9 +121,24 @@ void Mixer::Tick() {
           m->Absorb(m_);
         }
       }
+
       output.Push(m);
     }
   }
+  // Calculate quantity-weighted average unit value of the output buffer
+  // NOTE: We can't just use m->UnitValue().
+  double total_cost = 0.0;
+  double total_qty = 0.0;
+  MatVec output_mats = output.PopN(output.count());
+  for (const auto& mat : output_mats) {
+    total_cost += mat->quantity() * mat->UnitValue();
+    total_qty += mat->quantity();
+  }
+  output.Push(output_mats);
+
+  double avg_unit_value = (total_qty > 0) ? (total_cost / total_qty) : 0.0;
+  sell_policy.set_cost_per_unit(variable_cost_per_unit);
+
   cyclus::toolkit::RecordTimeSeries<double>("supply"+out_commod, this, output.quantity());
 }
 
@@ -155,11 +173,18 @@ Mixer::GetMatlRequests() {
 
       std::vector<cyclus::Request<cyclus::Material>*> reqs;
 
-      std::map<std::string, double>::iterator it;
-      for (it = in_commods[i].begin() ; it != in_commods[i].end(); it++) {
-        std::string commod = it->first;
-        double pref = it->second;
-        reqs.push_back(port->AddRequest(m, this, commod , pref, false));
+      // in_commods[i] is map<commodity_name, pref>; extract vectors for CalcMarginalUtility
+      std::vector<std::string> commods;
+      std::vector<double> prefs;
+      for (const auto& kv : in_commods[i]) {
+        commods.push_back(kv.first);   // commodity name
+        prefs.push_back(kv.second);    // pref
+      }
+      auto mu_results = CalcMarginalUtility(commods, prefs);
+      std::vector<std::string> mu_commods = mu_results.first;
+      std::vector<double> mu_values = mu_results.second;
+      for (int i = 0; i < mu_commods.size(); i++) {
+        reqs.push_back(port->AddRequest(m, this, mu_commods[i], mu_values[i], false));
         req_inventories_[reqs.back()] = name;
       }
       port->AddMutualReqs(reqs);

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -76,11 +76,30 @@ class Mixer
   // state var.
   std::map<std::string, cyclus::toolkit::ResBuf<cyclus::Material> > streambufs;
 
+#pragma cyclus var { \
+    "default": [], \
+    "doc": "Optional recipe name for each input stream (same order as in_streams). " \
+           "If set, requests on that stream use this recipe so suppliers (e.g. Enrichment) " \
+           "can match. Empty string or omitted means no recipe (blank/dummy composition).", \
+    "uilabel": "Input Stream Recipes", \
+    "uitype": ["oneormore", "inrecipe"] \
+  }
+  std::vector<std::string> in_stream_recipes;
 
 #pragma cyclus var {                                                 \
   "doc" : "Commodity on which to offer/supply mixed fuel material.", \
   "uilabel" : "Output Commodity", "uitype" : "outcommodity", }
   std::string out_commod;
+
+#pragma cyclus var { \
+    "default": "", \
+    "doc": "Optional name to register the blended composition under. If set, " \
+           "the mixed material's composition is registered as this recipe name " \
+           "in the context (no transmutation); the blend is kept and just named.", \
+    "uilabel": "Output Recipe", \
+    "uitype": "outrecipe", \
+  }
+  std::string out_recipe;
 
 #pragma cyclus var { \
     "doc" : "Maximum amount of mixed material that can be stored." \

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -117,6 +117,8 @@ class Mixer
   private:
   // Code Injection:
   #include "toolkit/position.cycpp.h"
+  #include "toolkit/marginal_cost.cycpp.h"
+  #include "toolkit/marginal_utility.cycpp.h"
   
 };
 

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -109,6 +109,7 @@ void Reactor::EnterNotify() {
     throw ValueError(ss.str());
   }
   
+  InitializeMarginalCost();
   InitializePosition();
 }
 
@@ -231,16 +232,19 @@ std::set<cyclus::RequestPortfolio<Material>::Ptr> Reactor::GetMatlRequests() {
   for (int i = 0; i < n_assem_order; i++) {
     RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
     std::vector<Request<Material>*> mreqs;
+    auto mu_results = CalcMarginalUtility(fuel_incommods, fuel_prefs);
+    std::vector<std::string> mu_commods = mu_results.first;
+    std::vector<double> mu_values = mu_results.second;
     for (int j = 0; j < fuel_incommods.size(); j++) {
-      std::string commod = fuel_incommods[j];
-      double pref = fuel_prefs[j];
+      
       cyclus::Composition::Ptr recipe = context()->GetRecipe(fuel_inrecipes[j]);
       m = Material::CreateUntracked(assem_size, recipe);
 
-      Request<Material>* r = port->AddRequest(m, this, commod, pref, true);
+      Request<Material>* r = port->AddRequest(m, this, mu_commods[j], mu_values[j], true);
       mreqs.push_back(r);
     }
 
+    // This finds the most-preferred commodity and records demand for it.
     std::vector<double>::iterator result;
     result = std::max_element(fuel_prefs.begin(), fuel_prefs.end());
     int max_index = std::distance(fuel_prefs.begin(), result);
@@ -334,7 +338,14 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Reactor::GetMatlBids(
       for (int k = 0; k < mats.size(); k++) {
         Material::Ptr m = mats[k];
         tot_bid += m->quantity();
-        port->AddBid(req, m, this, true);
+
+        // We need to be a bit careful here, since this is "waste" material.
+        // For now, we'll set the MC to 0.0, since otherwise we'd have
+        // to figure out how reactors bid on this, given that we can't have
+        // negative arcs.
+        double marginal_cost = 0.0;
+
+        port->AddBid(req, m, this, true, marginal_cost);
         if (tot_bid >= req->target()->quantity()) {
           break;
         }

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -4,6 +4,8 @@
 #include "cyclus.h"
 #include "cycamore_version.h"
 
+#pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
+
 namespace cycamore {
 
 /// Reactor is a simple, general reactor based on static compositional
@@ -136,6 +138,8 @@ class Reactor : public cyclus::Facility,
  private:
   // Code Injection:
   #include "toolkit/position.cycpp.h"
+  #include "toolkit/marginal_cost.cycpp.h"
+  #include "toolkit/marginal_utility.cycpp.h"
 
   std::string fuel_incommod(cyclus::Material::Ptr m);
   std::string fuel_outcommod(cyclus::Material::Ptr m);
@@ -245,6 +249,16 @@ class Reactor : public cyclus::Facility,
     "uitype": ["oneormore", "incommodity"], \
   }
   std::vector<std::string> recipe_change_commods;
+
+  #pragma cyclus var { \
+    "default": [], \
+    "uilabel": "Preference for Changed Fresh/Spent Fuel Recipe", \
+    "doc": "The preference for each type of fresh fuel requested corresponding"\
+           " to each input commodity (same order).  If no preferences are " \
+           "specified, 1.0 is used for all fuel requests (default).", \
+    "uitype": ["oneormore", "range"], \
+  }
+  std::vector<double> recipe_change_prefs;
 
   #pragma cyclus var { \
     "default": [], \

--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -484,10 +484,16 @@ TEST(ReactorTests, PrefChange) {
   sim.AddSource("enriched_u").Finalize();
   sim.AddRecipe("lwr_fresh", c_uox());
   sim.AddRecipe("lwr_spent", c_spentuox());
+  
   int id = sim.Run();
-
-  QueryResult qr = sim.db().Query("Transactions", NULL);
-  EXPECT_EQ(25, qr.rows.size()) << "failed to adjust preferences properly";
+  
+  // Negative preference values are now silently rejected (arcs removed from graph)
+  // After time 25 when preference becomes -1, no more transactions should occur
+  std::vector<Cond> conds;
+  conds.push_back(Cond("Commodity", "==", std::string("enriched_u")));
+  QueryResult qr = sim.db().Query("Transactions", &conds);
+  // Should have transactions up to time 25, then none after preference becomes -1
+  EXPECT_EQ(25, qr.rows.size()) << "failed to reject trades after negative preference set";
 }
 
 TEST(ReactorTests, RecipeChange) {

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -334,7 +334,7 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
         tot_bid += m->quantity();
 
 
-        double marginal_cost = CalcMarginalCost(m->UnitValue());
+        double marginal_cost = 0.0; // Set to zero since this is a waste stream?
 
         // this fix the problem of the cyclus exchange manager which crashes
         // when a bid with a quantity <=0 is offered.

--- a/src/separations.cc
+++ b/src/separations.cc
@@ -64,6 +64,7 @@ void Separations::EnterNotify() {
     }
 
     InitializePosition();
+    InitializeMarginalCost();
   }
 
   std::vector<int> eff_pb_;
@@ -220,10 +221,12 @@ Separations::GetMatlRequests() {
   }
 
   std::vector<Request<Material>*> reqs;
+  auto mu_results = CalcMarginalUtility(feed_commods, feed_commod_prefs);
+  std::vector<std::string> mu_commods = mu_results.first;
+  std::vector<double> mu_values = mu_results.second;
   for (int i = 0; i < feed_commods.size(); i++) {
     std::string commod = feed_commods[i];
-    double pref = feed_commod_prefs[i];
-    reqs.push_back(port->AddRequest(m, this, commod, pref, exclusive));
+    reqs.push_back(port->AddRequest(m, this, mu_commods[i], mu_values[i], exclusive));
   }
   port->AddMutualReqs(reqs);
   ports.insert(port);
@@ -295,10 +298,12 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
         Material::Ptr m = mats[k];
         tot_bid += m->quantity();
 
+        double marginal_cost = CalcMarginalCost(m->UnitValue());
+
         // this fix the problem of the cyclus exchange manager which crashes
         // when a bid with a quantity <=0 is offered.
         if (m->quantity() > cyclus::eps_rsrc()) {
-          port->AddBid(req, m, this, exclusive);
+          port->AddBid(req, m, this, exclusive, marginal_cost);
         }
 
         if (tot_bid >= req->target()->quantity()) {
@@ -328,10 +333,13 @@ std::set<cyclus::BidPortfolio<Material>::Ptr> Separations::GetMatlBids(
         Material::Ptr m = mats[k];
         tot_bid += m->quantity();
 
+
+        double marginal_cost = CalcMarginalCost(m->UnitValue());
+
         // this fix the problem of the cyclus exchange manager which crashes
         // when a bid with a quantity <=0 is offered.
         if (m->quantity() > cyclus::eps_rsrc()) {
-          port->AddBid(req, m, this, exclusive);
+          port->AddBid(req, m, this, exclusive, marginal_cost);
         }
 
         if (tot_bid >= req->target()->quantity()) {

--- a/src/separations.h
+++ b/src/separations.h
@@ -107,6 +107,8 @@ class Separations
  private:
  // Code Injection:
  #include "toolkit/position.cycpp.h"
+ #include "toolkit/marginal_utility.cycpp.h"
+ #include "toolkit/marginal_cost.cycpp.h"
 
   #pragma cyclus var { \
     "doc": "Ordered list of commodities on which to request feed material to " \

--- a/src/sink.cc
+++ b/src/sink.cc
@@ -43,6 +43,8 @@ void Sink::EnterNotify() {
 
   inventory.keep_packaging(keep_packaging);
 
+  InitializeMarginalUtility(in_commods, in_commod_prefs);
+
   if (in_commod_prefs.size() == 0) {
     for (int i = 0; i < in_commods.size(); ++i) {
       in_commod_prefs.push_back(cyclus::kDefaultPref);
@@ -106,6 +108,11 @@ Sink::GetMatlRequests() {
   RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
   Material::Ptr mat;
 
+  // Calculate Marginal Utility for each commodity using its preference
+  auto mu_results = CalcMarginalUtility(in_commods, in_commod_prefs);
+  std::vector<std::string> mu_commods = mu_results.first;
+  std::vector<double> mu_values = mu_results.second;
+
   /// for testing
   if (requestAmt > SpaceAvailable()) {
     SetRequestAmt();
@@ -121,7 +128,7 @@ Sink::GetMatlRequests() {
   if (requestAmt > cyclus::eps()) {  
     std::vector<Request<Material>*> mutuals;
     for (int i = 0; i < in_commods.size(); i++) {
-      mutuals.push_back(port->AddRequest(mat, this, in_commods[i], in_commod_prefs[i]));
+      mutuals.push_back(port->AddRequest(mat, this, mu_commods[i], mu_values[i]));
 
     }
     port->AddMutualReqs(mutuals);

--- a/src/sink.h
+++ b/src/sink.h
@@ -117,6 +117,7 @@ class Sink
  private:
   // Code Injection:
   #include "toolkit/position.cycpp.h"
+  #include "toolkit/marginal_utility.cycpp.h"
 
   double requestAmt;
   int nextBuyTime;

--- a/src/source.cc
+++ b/src/source.cc
@@ -53,6 +53,7 @@ std::string Source::str() {
 void Source::EnterNotify() {
   cyclus::Facility::EnterNotify();
   InitializePosition();
+  InitializeMarginalCost();
 }
 
 void Source::Build(cyclus::Agent* parent) {
@@ -81,6 +82,8 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
   using cyclus::Request;
   using cyclus::TransportUnit;
 
+  // We pass through a material input cost of 0.0, since this is where it comes from
+  double cost = CalcMarginalCost(0.0);
   double max_qty = std::min(throughput, inventory.quantity());
   cyclus::toolkit::RecordTimeSeries<double>("supply"+outcommod, this,
                                             max_qty);
@@ -119,7 +122,7 @@ std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(
       m = outrecipe.empty() ? \
           Material::CreateUntracked(*bit, target->comp()) : \
           Material::CreateUntracked(*bit, context()->GetRecipe(outrecipe));
-      port->AddBid(req, m, this);
+      port->AddBid(req, m, this, false, cost);
     }
   }
 

--- a/src/source.h
+++ b/src/source.h
@@ -83,6 +83,7 @@ class Source : public cyclus::Facility,
  private:
  // Code Injection:
  #include "toolkit/position.cycpp.h"
+ #include "toolkit/marginal_cost.cycpp.h"
 
   #pragma cyclus var { \
     "tooltip": "source output commodity", \

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -45,6 +45,9 @@ void Storage::InitFrom(cyclus::QueryableBackend* b) {
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Storage::EnterNotify() {
+  InitializeMarginalCost();
+  // TODO: need to add MU here later.
+  
   cyclus::Facility::EnterNotify();
 
   inventory_tracker.set_capacity(max_inv_size);
@@ -102,7 +105,7 @@ void Storage::EnterNotify() {
   std::string tu_name_ = context()->GetTransportUnit(transport_unit)->name();
   if (out_commods.size() == 1) {
     sell_policy.Init(this, &stocks, std::string("stocks"), cyclus::CY_LARGE_DOUBLE, false,
-                     sell_quantity, package_name_, tu_name_)
+                     sell_quantity, package_name_, tu_name_, variable_cost_per_unit)
       .Set(out_commods.front())
       .Start();
 

--- a/src/storage.h
+++ b/src/storage.h
@@ -235,6 +235,7 @@ class Storage
   #include "toolkit/matl_buy_policy.cycpp.h"
   #include "toolkit/matl_sell_policy.cycpp.h"
   #include "toolkit/position.cycpp.h"
+  #include "toolkit/marginal_cost.cycpp.h"
 
 };
 


### PR DESCRIPTION
<!-- If this PR adds a CEP, do not repeat all of the information in the CEP document in the summary. Instead, provide a short description of the CEP's purpose.  -->

# Summary of Changes
<!--- In one or more sentences, describe the PR you are submitting. -->
This PR implements some of the changes required for Cycamore agents to use the new DRE structure. Altogether, it modifies the:

- Source
- Conversion
- Enrichment
- FuelFab
- Separations
- Reactor
- Sink

archetypes to allow them to submit MC and MU in their bids. It also modifies unit tests when specific values were expected which needed to be updated given the new DRE structure.

## Design Notes
<!--- Describe any design decisions or trade-offs you made. -->
Most of this should be fairly boilerplate (by design). Every facility (besides source and sink) now pulls in the marginal_cost and marginal_utility toolkit features then bids using their marginal cost and requests with their marginal utility. 

Some of the facilities have little extra weird things, for instance Reactor bids its waste at zero cost as a placeholder for more sophisticated behavior later, and enrichment needs to figure out how much input material it needs to create the enrichment that's being requested before actually making that material so it uses the average value of all the feed in its inventory (again, something that will likely need to be changed down the road to something more sophisticated but which I figured was probably fine for now). 

Check the box if your change does not break any of the following:
- [x] API for Cyclus modules
- [ ] Input files
- [x] Output tables for post processing tools


# Associated Developers
<!--- Please mention any developers who should be alerted of this PR. -->
Cursor AI (auto) 🖥️ 


# Testing and Validation
<!--- Describe how this change was tested. -->
Manually, I need to add unit tests but wanted to make sure everything looked good by getting this in front of people sooner rather than later before I did that.

- [x] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [x] I have compiled and run the code locally
- [ ] I have added or updated relevant tests
- [ ] I have added documentation for new or changed features
- [x] This code follows the style guide
- [ ] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).