### PR TITLE
Specifying initial facility inventories for User defined commodities/recipes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Since last release
 * Added support for Ubuntu 24.04 (#633)
 * Added (negative)binomial distributions for disruption modeling to storage (#635)
 * Added new variable to Deploy Institution to shift the deployment times (#677)
+* Added variables to enrichment facility for initial tails inventory (#680)
+* Added variable to specify initial spent, fresh, and core inventory for reactor facility (#680)
 
 **Changed:**
 * Cleaned up manual definitions of Position in favor of code injection (#641)

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -45,27 +45,18 @@ std::string Enrichment::str() {
 void Enrichment::Build(cyclus::Agent* parent) {
   Facility::Build(parent);
 
-  if (initial_inventory.size() != initial_inventory_amt.size()) {
-      throw cyclus::Error("Number of initial inventory quantities must match the number of initial quantities");
-            }
-
-  for (int i = 0; i<initial_inventory.size(); i++){
-        if (initial_inventory[i] ==  feed_commod) {
-              inventory.Push(Material::Create(this, initial_inventory_amt[i],
+  if (initial_feed > 0) {
+    inventory.Push(Material::Create(this, initial_feed,
                                     context()->GetRecipe(feed_recipe)));
-              }
-        else if (initial_inventory[i] == product_commod) {
-              throw cyclus::Error("Product commodity cannot have initial inventory as bespoke enrichment is defined upon demand.");
-              }
-        else if (initial_inventory[i] == tails_commod){
-              cyclus::Composition::Ptr blank_comp = cyclus::Composition::CreateFromMass(cyclus::CompMap());
-              tails.Push(Material::Create(this, initial_inventory_amt[i],
-                                    blank_comp));
-              } 
-        else { 
-              throw cyclus::Error(initial_inventory[i] + " is not associated with any commodity");
-              }
-            }
+  }
+
+  if (initial_tails > 0) {
+    if (initial_tails_recipe == ""){
+      throw cyclus::KeyError("Recipe for initial tails inventory must be defined.");;
+    }
+    tails.Push(Material::Create(this, initial_feed,
+                                    context()->GetRecipe(initial_tails_recipe)));
+  }
 
   LOG(cyclus::LEV_DEBUG2, "EnrFac") << "Enrichment "
                                     << " entering the simuluation: ";

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -50,27 +50,23 @@ void Enrichment::Build(cyclus::Agent* parent) {
             }
 
   for (int i = 0; i<initial_inventory.size(); i++){
-        std::cout << initial_inventory[i];
         if (initial_inventory[i] ==  feed_commod) {
-              std::cout<< "Feed";
               inventory.Push(Material::Create(this, initial_inventory_amt[i],
                                     context()->GetRecipe(feed_recipe)));
               }
         else if (initial_inventory[i] == product_commod) {
-                std::cout<< "product";
               throw cyclus::Error("Product commodity cannot have initial inventory as bespoke enrichment is defined upon demand.");
               }
         else if (initial_inventory[i] == tails_commod){
-              std::cout<< "tails";
               cyclus::Composition::Ptr blank_comp = cyclus::Composition::CreateFromMass(cyclus::CompMap());
               tails.Push(Material::Create(this, initial_inventory_amt[i],
                                     blank_comp));
               } 
         else { 
-              std::cout<< "nothing";
               throw cyclus::Error(initial_inventory[i] + " is not associated with any commodity");
               }
             }
+
   LOG(cyclus::LEV_DEBUG2, "EnrFac") << "Enrichment "
                                     << " entering the simuluation: ";
   LOG(cyclus::LEV_DEBUG2, "EnrFac") << str();

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -48,15 +48,13 @@ void Enrichment::Build(cyclus::Agent* parent) {
   if (initial_feed > 0) {
     inventory.Push(Material::Create(this, initial_feed,
                                     context()->GetRecipe(feed_recipe)));
-  }
-
-  if (initial_tails > 0) {
-    if (initial_tails_recipe == ""){
-      throw cyclus::KeyError("Recipe for initial tails inventory must be defined.");;
     }
-    tails.Push(Material::Create(this, initial_feed,
-                                    context()->GetRecipe(initial_tails_recipe)));
-  }
+  if (initial_tails > 0) {
+      cyclus::CompMap comp;
+      comp[922350000] = tails_assay;
+      comp[922380000] = 1 - tails_assay;
+      tails.Push(Material::Create(this, initial_tails, cyclus::Composition::CreateFromAtom(comp)));
+    }
 
   LOG(cyclus::LEV_DEBUG2, "EnrFac") << "Enrichment "
                                     << " entering the simuluation: ";

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -45,28 +45,30 @@ std::string Enrichment::str() {
 void Enrichment::Build(cyclus::Agent* parent) {
   Facility::Build(parent);
 
-  if (initial_inventory.size() != initial_quantities.size()) {
-      cyclus::Error("Number of initial inventory quantities must match the number of initial quantities");
+  if (initial_inventory.size() != initial_inventory_amt.size()) {
+      throw cyclus::Error("Number of initial inventory quantities must match the number of initial quantities");
             }
-  for (std::<vector>::iterator inv_name = initial_inventory_amt.begin();
-        inv_name != initial_inventory.end();
-        inv_name++){
-          switch (inv_name) {
-            case feed_commod:
-              inventory.Push(Material::Create(this, initial_feed,
+
+  for (int i = 0; i<initial_inventory.size(); i++){
+        std::cout << initial_inventory[i];
+        if (initial_inventory[i] ==  feed_commod) {
+              std::cout<< "Feed";
+              inventory.Push(Material::Create(this, initial_inventory_amt[i],
                                     context()->GetRecipe(feed_recipe)));
-              break;
-            case product_commod:
-              cyclus::Error("Product commodity cannot have initial inventory as bespoke 
-                enrichment is defined upon demand.");
-              break;
-            case tails_commod:
-              Composition::Ptr blank_comp = Composition::CreateFromMass(CompMap())
-              tails.Push(Material::Create(this, initial_feed,
+              }
+        else if (initial_inventory[i] == product_commod) {
+                std::cout<< "product";
+              throw cyclus::Error("Product commodity cannot have initial inventory as bespoke enrichment is defined upon demand.");
+              }
+        else if (initial_inventory[i] == tails_commod){
+              std::cout<< "tails";
+              cyclus::Composition::Ptr blank_comp = cyclus::Composition::CreateFromMass(cyclus::CompMap());
+              tails.Push(Material::Create(this, initial_inventory_amt[i],
                                     blank_comp));
-              break; 
-            default: 
-              cyclus::Error(inv_name << "is not associated with any commodity");
+              } 
+        else { 
+              std::cout<< "nothing";
+              throw cyclus::Error(initial_inventory[i] + " is not associated with any commodity");
               }
             }
   LOG(cyclus::LEV_DEBUG2, "EnrFac") << "Enrichment "

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -45,38 +45,30 @@ std::string Enrichment::str() {
 void Enrichment::Build(cyclus::Agent* parent) {
   Facility::Build(parent);
 
-  std::vector<string> enrich_commods = {feed_commod, product_commod, tails_commod}
-  for (std::<vector>::iterator inv_name = initial_inventory.begin();
+  if (initial_inventory.size() != initial_quantities.size()) {
+      cyclus::Error("Number of initial inventory quantities must match the number of initial quantities");
+            }
+  for (std::<vector>::iterator inv_name = initial_inventory_amt.begin();
         inv_name != initial_inventory.end();
         inv_name++){
-          switch (day) {
+          switch (inv_name) {
             case feed_commod:
               inventory.Push(Material::Create(this, initial_feed,
                                     context()->GetRecipe(feed_recipe)));
               break;
             case product_commod:
-              inventory.Push(Material::Create(this, initial_feed,
-                                    context()->GetRecipe(product_recipe)));
+              cyclus::Error("Product commodity cannot have initial inventory as bespoke 
+                enrichment is defined upon demand.");
               break;
             case tails_commod:
-              inventory.Push(Material::Create(this, initial_feed,
-                                    context()->GetRecipe(tails_r)));
+              Composition::Ptr blank_comp = Composition::CreateFromMass(CompMap())
+              tails.Push(Material::Create(this, initial_feed,
+                                    blank_comp));
               break; 
-
-          // auto it = std::find(enrich_commods.begin(),enrich_commods.end(),inv_name)
-          // int index = std::distance(enrich_commods.begin(),it)
-          // if(index > ) 
-        }
-  if(initial_inventory.size() > 0){
-
-
-  }
-
-  if (initial_feed > 0) {
-    inventory.Push(Material::Create(this, initial_feed,
-                                    context()->GetRecipe(feed_recipe)));
-  }
-
+            default: 
+              cyclus::Error(inv_name << "is not associated with any commodity");
+              }
+            }
   LOG(cyclus::LEV_DEBUG2, "EnrFac") << "Enrichment "
                                     << " entering the simuluation: ";
   LOG(cyclus::LEV_DEBUG2, "EnrFac") << str();

--- a/src/enrichment.cc
+++ b/src/enrichment.cc
@@ -44,6 +44,34 @@ std::string Enrichment::str() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Enrichment::Build(cyclus::Agent* parent) {
   Facility::Build(parent);
+
+  std::vector<string> enrich_commods = {feed_commod, product_commod, tails_commod}
+  for (std::<vector>::iterator inv_name = initial_inventory.begin();
+        inv_name != initial_inventory.end();
+        inv_name++){
+          switch (day) {
+            case feed_commod:
+              inventory.Push(Material::Create(this, initial_feed,
+                                    context()->GetRecipe(feed_recipe)));
+              break;
+            case product_commod:
+              inventory.Push(Material::Create(this, initial_feed,
+                                    context()->GetRecipe(product_recipe)));
+              break;
+            case tails_commod:
+              inventory.Push(Material::Create(this, initial_feed,
+                                    context()->GetRecipe(tails_r)));
+              break; 
+
+          // auto it = std::find(enrich_commods.begin(),enrich_commods.end(),inv_name)
+          // int index = std::distance(enrich_commods.begin(),it)
+          // if(index > ) 
+        }
+  if(initial_inventory.size() > 0){
+
+
+  }
+
   if (initial_feed > 0) {
     inventory.Push(Material::Create(this, initial_feed,
                                     context()->GetRecipe(feed_recipe)));

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -328,6 +328,23 @@ class Enrichment
   double initial_feed;
 
   #pragma cyclus var {							\
+    "default": 0, "tooltip": "initial tails (kg)",		\
+    "uilabel": "Initial tails Inventory",				\
+    "doc": "amount of tails stored at the enrichment "	\
+    "facility at the beginning of the simulation (kg) (based on recipe)"			\
+  }
+  double initial_tails;
+
+  #pragma cyclus var { \
+    "default": "", \
+    "tooltip": "initial tails recipe",						\
+    "doc": "recipe for enrichment facility tails commodity",		\
+    "uilabel": "Initial tails recipe",                                   \
+    "uitype": "outrecipe" \
+  }
+  std::string initial_tails_recipe;
+
+  #pragma cyclus var {							\
     "default": CY_LARGE_DOUBLE, "tooltip": "max inventory of feed material (kg)", \
     "uilabel": "Maximum Feed Inventory", \
     "uitype": "range", \
@@ -336,18 +353,6 @@ class Enrichment
            "the enrichment facility (kg)"     \
   }
   double max_feed_inventory;
-
-  #pragma cyclus var  {							\
-    "default": [],		\
-    "uilabel": "Initial commodity inventory",				\
-  }
-  std::vector<std::string> initial_inventory;
-
-  #pragma cyclus var  {							\
-    "default": [],\
-    "uilabel": "Initial amount of commodity inventory",				\
-  }
-  std::vector<double> initial_inventory_amt;
 
   #pragma cyclus var { \
     "default": 1.0,						\

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -338,13 +338,13 @@ class Enrichment
   double max_feed_inventory;
 
   #pragma cyclus var  {							\
-    "default": [], "Commodity with an initial inventory (tails, feed, enriched product)",		\
+    "default": [],		\
     "uilabel": "Initial commodity inventory",				\
   }
-  std::vector<string> initial_inventory;
+  std::vector<std::string> initial_inventory;
 
   #pragma cyclus var  {							\
-    "default": [], "Quantity of commodity with an initial inventory (tails, feed, enriched product)",		\
+    "default": [],\
     "uilabel": "Initial amount of commodity inventory",				\
   }
   std::vector<double> initial_inventory_amt;

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -347,7 +347,7 @@ class Enrichment
     "default": [], "Quantity of commodity with an initial inventory (tails, feed, enriched product)",		\
     "uilabel": "Initial amount of commodity inventory",				\
   }
-  std::vector<string> initial_inventory_amt;
+  std::vector<double> initial_inventory_amt;
 
   #pragma cyclus var { \
     "default": 1.0,						\

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -335,15 +335,6 @@ class Enrichment
   }
   double initial_tails;
 
-  #pragma cyclus var { \
-    "default": "", \
-    "tooltip": "initial tails recipe",						\
-    "doc": "recipe for enrichment facility tails commodity",		\
-    "uilabel": "Initial tails recipe",                                   \
-    "uitype": "outrecipe" \
-  }
-  std::string initial_tails_recipe;
-
   #pragma cyclus var {							\
     "default": CY_LARGE_DOUBLE, "tooltip": "max inventory of feed material (kg)", \
     "uilabel": "Maximum Feed Inventory", \

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -337,6 +337,18 @@ class Enrichment
   }
   double max_feed_inventory;
 
+  #pragma cyclus var  {							\
+    "default": [], "Commodity with an initial inventory (tails, feed, enriched product)",		\
+    "uilabel": "Initial commodity inventory",				\
+  }
+  std::vector<string> initial_inventory;
+
+  #pragma cyclus var  {							\
+    "default": [], "Quantity of commodity with an initial inventory (tails, feed, enriched product)",		\
+    "uilabel": "Initial amount of commodity inventory",				\
+  }
+  std::vector<string> initial_inventory_amt;
+
   #pragma cyclus var { \
     "default": 1.0,						\
     "tooltip": "maximum allowed enrichment fraction",		\

--- a/src/enrichment_tests.cc
+++ b/src/enrichment_tests.cc
@@ -165,6 +165,44 @@ TEST_F(EnrichmentTest, CheckCapConstraint) {
     "traded quantity exceeds capacity constraint";
 }
 
+TEST_F(EnrichmentTest, CheckInitialInventory) {
+  // Tests that a request for more material than is available in
+  // inventory is partially filled with only the inventory quantity.
+
+  std::string config =
+    "   <feed_commod>natu</feed_commod> "
+    "   <feed_recipe>natu1</feed_recipe> "
+    "   <product_commod>enr_u</product_commod> "
+    "   <tails_commod>tails</tails_commod> "
+    "   <tails_assay>0.003</tails_assay> "
+    "   <initial_tails>500</initial_tails> ";
+
+  int simdur = 1;
+
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Enrichment"), config, simdur);
+
+  sim.AddRecipe("natu1", c_natu1());
+  sim.AddRecipe("leu", c_heu());
+
+  sim.AddSource("natu")
+    .recipe("natu1")
+    .Finalize();
+  sim.AddSink("enr_u")
+    .recipe("leu")
+    .Finalize();
+   sim.AddSink("tails")
+    .Finalize();
+
+  int id = sim.Run();
+
+  std::vector<Cond> conds;
+  conds.push_back(Cond("Time", "==", 0));
+  QueryResult qr = sim.db().Query("TimeSeriessupplytails", &conds);
+  
+  EXPECT_EQ(500, qr.GetVal<double>("Value"));
+}
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(EnrichmentTest, RequestEnrich) {
   // this tests verifies that requests for output material exceeding

--- a/src/enrichment_tests.cc
+++ b/src/enrichment_tests.cc
@@ -200,7 +200,9 @@ TEST_F(EnrichmentTest, CheckInitialInventory) {
   conds.push_back(Cond("Time", "==", 0));
   QueryResult qr = sim.db().Query("TimeSeriessupplytails", &conds);
   
-  EXPECT_EQ(500, qr.GetVal<double>("Value"));
+  double tails_qty = 500.0;
+
+  EXPECT_EQ(tails_qty, qr.GetVal<double>("Value"));
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -131,9 +131,7 @@ void Reactor::EnterNotify() {
 
 void Reactor::Build(cyclus::Agent* parent) {
   Facility::Build(parent);
-  LoadInitial(initial_fresh_recipes,initial_fresh_amt, fresh);
-  LoadInitial(initial_core_recipes,initial_core_amt, core);
-  LoadInitial(initial_spent_recipes,initial_spent_amt, spent);
+  PushInitialInv(); // load initial inventory into resource buffers 
 }
 
 bool Reactor::CheckDecommissionCondition() {
@@ -469,7 +467,6 @@ bool Reactor::Discharge() {
   return true;
 }
 
-// make sure that the 
 void Reactor::LoadInitial(std::vector<std::string>& initial_recipes,
                      std::vector<int>& initial_amts, 
                      cyclus::toolkit::ResBuf<cyclus::Material>& buffer) {
@@ -490,6 +487,12 @@ void Reactor::LoadInitial(std::vector<std::string>& initial_recipes,
     avail -= n_init_assems;
     idx++;
   }
+}
+
+void Reactor::PushInitialInv(){
+  LoadInitial(initial_fresh_recipes,initial_fresh_amt, fresh);
+  LoadInitial(initial_core_recipes,initial_core_amt, core);
+  LoadInitial(initial_spent_recipes,initial_spent_amt, spent);
 }
 
 

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -455,14 +455,13 @@ void Reactor::InitializeMaterials() {
   // initialize fresh inv
   for(int i = 0; i<initial_fresh.size(); i++){
     InitialRecipes(initial_fresh, fuel_inrecipes);
-    int initial_assem = static_cast<int>(std::floor(initial_fresh_amt[i]/assem_size)); 
     int rmd_space = n_assem_fresh - fresh.count();
-    if (initial_assem > rmd_space) {
+    if (initial_fresh_amt[i] > rmd_space) {
       cyclus::Warn<cyclus::VALUE_WARNING>("Mass exceeds the capacity of fresh fuel inventory. Inventory will be partially filled.");
-      initial_assem = rmd_space;
+      initial_fresh_amt[i] = rmd_space;
       }
     else  {
-      for(int assem = 0; assem<initial_assem; assem++) {
+      for(int assem = 0; assem<initial_fresh_amt[i]; assem++) {
           cyclus::Composition::Ptr recipe = context()->GetRecipe(initial_fresh[i]);
           Material::Ptr m = Material::Create(this, assem_size, recipe);
           fresh.Push(m);
@@ -473,14 +472,13 @@ void Reactor::InitializeMaterials() {
   //initialize core inv
   for(int i = 0; i<initial_core.size(); i++){
     InitialRecipes(initial_core, fuel_inrecipes);
-    int initial_assem = static_cast<int>(std::floor(initial_core_amt[i]/assem_size)); 
     int rmd_space = n_assem_core - core.count();
-    if (initial_assem > rmd_space) {
+    if (initial_core_amt[i] > rmd_space) {
       cyclus::Warn<cyclus::VALUE_WARNING>("Mass exceeds the capacity of core. Inventory will be partially filled.");
-      initial_assem = rmd_space;
+      initial_core_amt[i] = rmd_space;
       }
     else  {
-      for(int assem = 0; assem<initial_assem; assem++) {
+      for(int assem = 0; assem<initial_core_amt[i]; assem++) {
           cyclus::Composition::Ptr recipe = context()->GetRecipe(initial_core[i]);
           Material::Ptr m = Material::Create(this, assem_size, recipe);
           core.Push(m);

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -105,23 +105,26 @@ void Reactor::EnterNotify() {
        << " pref_change_values vals, expected " << n << "\n";
   }
 
+  if (initial_core_recipes.size() != initial_core_amt.size()) {
+      ss << "Number of entries for initial core recipes, " << initial_core_recipes.size() 
+      << ", must match the number of entries for initial core assemblies, " << initial_core_amt.size() << "\n";
+    }
+  if (initial_fresh_recipes.size() != initial_fresh_amt.size()) {
+      ss << "Number of entries for initial fresh recipes, " << initial_fresh_recipes.size() 
+      << ", must match the number of entries for initial fresh assemblies, " << initial_fresh_amt.size() << "\n";
+    }
+  if (initial_spent_recipes.size() != initial_spent_amt.size()) {
+      ss << "Number of entries for initial spent recipes, " << initial_spent_recipes.size() 
+      << ", must match the number of entries for initial spent assemblies, " << initial_spent_amt.size() << "\n";
+    }
+  
   if (ss.str().size() > 0) {
     throw ValueError(ss.str());
   }
 
-  InitialRecipes(initial_fresh_recipes, fuel_inrecipes);
-  InitialRecipes(initial_core_recipes, fuel_inrecipes);
-  InitialRecipes(initial_spent_recipes, fuel_outrecipes);
-
-  if (initial_core_recipes.size() != initial_core_amt.size()) {
-      throw ValueError("Number of entries for initial core recipes must match the number of entries for initial core assemblies.");
-    }
-  if (initial_fresh_recipes.size() != initial_fresh_amt.size()) {
-      throw ValueError("Number of entries for initial fresh recipes must match the number of entries for initial fresh assemblies.");
-    }
-  if (initial_spent_recipes.size() != initial_spent_amt.size()) {
-      throw ValueError("Number of entries for initial spent recipes must match the number of entries for initial spent assemblies.");
-    }
+  ValidateInitialRecipes(initial_fresh_recipes, fuel_inrecipes);
+  ValidateInitialRecipes(initial_core_recipes, fuel_inrecipes);
+  ValidateInitialRecipes(initial_spent_recipes, fuel_outrecipes);
   
   InitializePosition();
 }
@@ -490,7 +493,7 @@ void Reactor::LoadInitial(std::vector<std::string>& initial_recipes,
 }
 
 
-void Reactor::InitialRecipes(std::vector<std::string> int_invs, std::vector<std::string> recipes){
+void Reactor::ValidateInitialRecipes(std::vector<std::string> int_invs, std::vector<std::string> recipes){
   for (int i = 0; i<int_invs.size(); i++) {
     if (std::find(recipes.begin(), recipes.end(), int_invs[i]) == recipes.end()) {
     throw KeyError("Recipe not associated with an in-commodity or out-commodity");

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -108,13 +108,29 @@ void Reactor::EnterNotify() {
   if (ss.str().size() > 0) {
     throw ValueError(ss.str());
   }
+
+  InitialRecipes(initial_fresh_recipes, fuel_inrecipes);
+  InitialRecipes(initial_core_recipes, fuel_inrecipes);
+  InitialRecipes(initial_spent_recipes, fuel_outrecipes);
+
+  if (initial_core_recipes.size() != initial_core_amt.size()) {
+      throw ValueError("Number of entries for initial core recipes must match the number of entries for initial core amount.");
+    }
+  if (initial_fresh_recipes.size() != initial_fresh_amt.size()) {
+      throw ValueError("Number of entries for initial core recipes must match the number of entries for initial core amount.");
+    }
+  if (initial_spent_recipes.size() != initial_spent_amt.size()) {
+      throw ValueError("Number of entries for initial core recipes must match the number of entries for initial core amount.");
+    }
   
   InitializePosition();
 }
 
 void Reactor::Build(cyclus::Agent* parent) {
   Facility::Build(parent);
-  InitializeMaterials();
+  LoadInitial(initial_fresh_recipes,initial_fresh_amt, fresh);
+  LoadInitial(initial_core_recipes,initial_core_amt, core);
+  LoadInitial(initial_spent_recipes,initial_spent_amt, spent);
 }
 
 bool Reactor::CheckDecommissionCondition() {
@@ -450,57 +466,33 @@ bool Reactor::Discharge() {
   return true;
 }
 
-void Reactor::InitializeMaterials() {
-
-  // initialize fresh inv
-  for(int i = 0; i<initial_fresh.size(); i++){
-    InitialRecipes(initial_fresh, fuel_inrecipes);
-    int rmd_space = n_assem_fresh - fresh.count();
-    if (initial_fresh_amt[i] > rmd_space) {
-      cyclus::Warn<cyclus::VALUE_WARNING>("Mass exceeds the capacity of fresh fuel inventory. Inventory will be partially filled.");
-      initial_fresh_amt[i] = rmd_space;
-      }
-    else  {
-      for(int assem = 0; assem<initial_fresh_amt[i]; assem++) {
-          cyclus::Composition::Ptr recipe = context()->GetRecipe(initial_fresh[i]);
-          Material::Ptr m = Material::Create(this, assem_size, recipe);
-          fresh.Push(m);
+// make sure that the 
+void Reactor::LoadInitial(std::vector<std::string>& initial_recipes,
+                     std::vector<int>& initial_amts, 
+                     cyclus::toolkit::ResBuf<cyclus::Material>& buffer) {
+  int idx = 0;
+  int avail = int(buffer.space()/assem_size);
+  while (idx < initial_recipes.size() && avail > 0) {
+    int n_init_assems = std::min(initial_amts[idx], avail);
+    if (n_init_assems < initial_amts[idx]) {
+      std::stringstream ss;
+      ss << "Number of " << initial_recipes[idx] << " assemblies has exceeded the inventory capacity. " 
+        << "Not all initial inventory will be filled.";
+      cyclus::Warn<cyclus::VALUE_WARNING>(ss.str());
+    }
+    cyclus::Composition::Ptr recipe = context()->GetRecipe(initial_recipes[idx]);
+    for (int assem = 0; assem < n_init_assems; assem++) {
+       buffer.Push(Material::Create(this, assem_size, recipe));
         }
-      }
-    }
-
-  //initialize core inv
-  for(int i = 0; i<initial_core.size(); i++){
-    InitialRecipes(initial_core, fuel_inrecipes);
-    int rmd_space = n_assem_core - core.count();
-    if (initial_core_amt[i] > rmd_space) {
-      cyclus::Warn<cyclus::VALUE_WARNING>("Mass exceeds the capacity of core. Inventory will be partially filled.");
-      initial_core_amt[i] = rmd_space;
-      }
-    else  {
-      for(int assem = 0; assem<initial_core_amt[i]; assem++) {
-          cyclus::Composition::Ptr recipe = context()->GetRecipe(initial_core[i]);
-          Material::Ptr m = Material::Create(this, assem_size, recipe);
-          core.Push(m);
-        }
-      }
-    }
-
-  //intialize spent fuel inv
-  for (int i = 0; i<initial_spent.size(); i++)  {
-    InitialRecipes(initial_spent, fuel_outrecipes);
-    cyclus::Composition::Ptr recipe = context()->GetRecipe(initial_spent[i]);
-    Material::Ptr m = Material::Create(this, initial_spent_amt[i], recipe);
-    spent.Push(m);
-    cyclus::toolkit::RecordTimeSeries<double>("supply"+initial_spent[i], this, initial_spent_amt[i]);
-    }
+    avail -= n_init_assems;
+    idx++;
   }
+}
 
 
 void Reactor::InitialRecipes(std::vector<std::string> int_invs, std::vector<std::string> recipes){
   for (int i = 0; i<int_invs.size(); i++) {
-    if (std::find(recipes.begin(), recipes.end(), int_invs[i]) != recipes.end()) {}
-    else {
+    if (std::find(recipes.begin(), recipes.end(), int_invs[i]) == recipes.end()) {
     throw KeyError("Recipe not associated with an in-commodity or out-commodity");
     }
   }

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -65,7 +65,7 @@ void Reactor::EnterNotify() {
   core.keep_packaging(keep_packaging);
   spent.keep_packaging(keep_packaging);
 
-  InitializeMaterials();
+  //InitializeMaterials();
 
   // If the user ommitted fuel_prefs, we set it to zeros for each fuel
   // type.  Without this segfaults could occur - yuck.
@@ -114,6 +114,11 @@ void Reactor::EnterNotify() {
   InitializePosition();
 }
 
+void Reactor::Build(cyclus::Agent* parent) {
+  Facility::Build(parent);
+  InitializeMaterials();
+}
+
 bool Reactor::CheckDecommissionCondition() {
   return core.count() == 0 && spent.count() == 0;
 }
@@ -125,7 +130,6 @@ void Reactor::Tick() {
   // they
   // can't go at the beginnin of the Tock is so that resource exchange has a
   // chance to occur after the discharge on this same time step.
-
   if (retired()) {
     Record("RETIRED", "");
 
@@ -450,57 +454,59 @@ bool Reactor::Discharge() {
 
 void Reactor::InitializeMaterials() {
 
-  // initialize core
+  // initialize fresh inv
   for(int i = 0; i<initial_fresh.size(); i++){
-    InitialRecipes(initial_fresh, fuel_inrecipes)
-    int initial_assem = std::floor(initial_fresh_amt[i]/assem_size); 
+    InitialRecipes(initial_fresh, fuel_inrecipes);
+    int initial_assem = static_cast<int>(std::floor(initial_fresh_amt[i]/assem_size)); 
     int rmd_space = n_assem_fresh - fresh.count();
     if (initial_assem > rmd_space) {
-      throw cyclus::Error<VALUE_WARNING>("Mass exceeds the capacity of fresh fuel inventory. Inventory will be partially filled.");
-          initial_assem = rmd_space;
-          }
+      cyclus::Warn<cyclus::VALUE_WARNING>("Mass exceeds the capacity of fresh fuel inventory. Inventory will be partially filled.");
+      initial_assem = rmd_space;
+      }
     else  {
-      for(int assem = 0; assem<initial_assem.size(), assem++) {
+      for(int assem = 0; assem<initial_assem; assem++) {
           cyclus::Composition::Ptr recipe = context()->GetRecipe(initial_fresh[i]);
-          m = Material::Create(this, assem_size, recipe);
-          fresh.push(m);
+          Material::Ptr m = Material::Create(this, assem_size, recipe);
+          fresh.Push(m);
         }
       }
     }
 
-  //initialize fresh inv
+  //initialize core inv
   for(int i = 0; i<initial_core.size(); i++){
-    InitialRecipes(initial_core, fuel_inrecipes)
-    int initial_assem = std::floor(initial_core_amt[i]/assem_size);
-    int rmd_space = n_assem_fresh - core.count();
+    InitialRecipes(initial_core, fuel_inrecipes);
+    int initial_assem = static_cast<int>(std::floor(initial_core_amt[i]/assem_size)); 
+    int rmd_space = n_assem_core - core.count();
     if (initial_assem > rmd_space) {
-      throw cyclus::Error<VALUE_WARNING>("Mass exceeds the capacity of core. Inventory will be partially filled.");
-          initial_assem = rmd_space;
-          }
+      cyclus::Warn<cyclus::VALUE_WARNING>("Mass exceeds the capacity of core. Inventory will be partially filled.");
+      initial_assem = rmd_space;
+      }
     else  {
-      for(int assem = 0; assem<initial_assem.size(), assem++) {
+      for(int assem = 0; assem<initial_assem; assem++) {
           cyclus::Composition::Ptr recipe = context()->GetRecipe(initial_core[i]);
-          m = Material::Create(this, assem_size, recipe);
-          core.push(m);
+          Material::Ptr m = Material::Create(this, assem_size, recipe);
+          core.Push(m);
         }
       }
     }
 
   //intialize spent fuel inv
   for (int i = 0; i<initial_spent.size(); i++)  {
-    InitialRecipes(initial_spent, fuel_outrecipes)
+    InitialRecipes(initial_spent, fuel_outrecipes);
     cyclus::Composition::Ptr recipe = context()->GetRecipe(initial_spent[i]);
-    m = Material::Create(this, initial_spent_amt[i] recipe) 
-    spent.push(m)
-    // check if exceeds the resource buffer
+    Material::Ptr m = Material::Create(this, initial_spent_amt[i], recipe);
+    spent.Push(m);
+    cyclus::toolkit::RecordTimeSeries<double>("supply"+initial_spent[i], this, initial_spent_amt[i]);
     }
   }
 
 
 void Reactor::InitialRecipes(std::vector<std::string> int_invs, std::vector<std::string> recipes){
   for (int i = 0; i<int_invs.size(); i++) {
-    if (std::find(recipes.begin(), recipes.end(), int_invs[i]) = recipes.end());
+    if (std::find(recipes.begin(), recipes.end(), int_invs[i]) != recipes.end()) {}
+    else {
     throw KeyError("Recipe not associated with an in-commodity or out-commodity");
+    }
   }
 }
 

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -114,13 +114,13 @@ void Reactor::EnterNotify() {
   InitialRecipes(initial_spent_recipes, fuel_outrecipes);
 
   if (initial_core_recipes.size() != initial_core_amt.size()) {
-      throw ValueError("Number of entries for initial core recipes must match the number of entries for initial core amount.");
+      throw ValueError("Number of entries for initial core recipes must match the number of entries for initial core assemblies.");
     }
   if (initial_fresh_recipes.size() != initial_fresh_amt.size()) {
-      throw ValueError("Number of entries for initial core recipes must match the number of entries for initial core amount.");
+      throw ValueError("Number of entries for initial fresh recipes must match the number of entries for initial fresh assemblies.");
     }
   if (initial_spent_recipes.size() != initial_spent_amt.size()) {
-      throw ValueError("Number of entries for initial core recipes must match the number of entries for initial core amount.");
+      throw ValueError("Number of entries for initial spent recipes must match the number of entries for initial spent assemblies.");
     }
   
   InitializePosition();

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -65,6 +65,8 @@ void Reactor::EnterNotify() {
   core.keep_packaging(keep_packaging);
   spent.keep_packaging(keep_packaging);
 
+  InitializeMaterials();
+
   // If the user ommitted fuel_prefs, we set it to zeros for each fuel
   // type.  Without this segfaults could occur - yuck.
   if (fuel_prefs.size() == 0) {
@@ -444,6 +446,62 @@ bool Reactor::Discharge() {
   }
 
   return true;
+}
+
+void Reactor::InitializeMaterials() {
+
+  // initialize core
+  for(int i = 0; i<initial_fresh.size(); i++){
+    InitialRecipes(initial_fresh, fuel_inrecipes)
+    int initial_assem = std::floor(initial_fresh_amt[i]/assem_size); 
+    int rmd_space = n_assem_fresh - fresh.count();
+    if (initial_assem > rmd_space) {
+      throw cyclus::Error<VALUE_WARNING>("Mass exceeds the capacity of fresh fuel inventory. Inventory will be partially filled.");
+          initial_assem = rmd_space;
+          }
+    else  {
+      for(int assem = 0; assem<initial_assem.size(), assem++) {
+          cyclus::Composition::Ptr recipe = context()->GetRecipe(initial_fresh[i]);
+          m = Material::Create(this, assem_size, recipe);
+          fresh.push(m);
+        }
+      }
+    }
+
+  //initialize fresh inv
+  for(int i = 0; i<initial_core.size(); i++){
+    InitialRecipes(initial_core, fuel_inrecipes)
+    int initial_assem = std::floor(initial_core_amt[i]/assem_size);
+    int rmd_space = n_assem_fresh - core.count();
+    if (initial_assem > rmd_space) {
+      throw cyclus::Error<VALUE_WARNING>("Mass exceeds the capacity of core. Inventory will be partially filled.");
+          initial_assem = rmd_space;
+          }
+    else  {
+      for(int assem = 0; assem<initial_assem.size(), assem++) {
+          cyclus::Composition::Ptr recipe = context()->GetRecipe(initial_core[i]);
+          m = Material::Create(this, assem_size, recipe);
+          core.push(m);
+        }
+      }
+    }
+
+  //intialize spent fuel inv
+  for (int i = 0; i<initial_spent.size(); i++)  {
+    InitialRecipes(initial_spent, fuel_outrecipes)
+    cyclus::Composition::Ptr recipe = context()->GetRecipe(initial_spent[i]);
+    m = Material::Create(this, initial_spent_amt[i] recipe) 
+    spent.push(m)
+    // check if exceeds the resource buffer
+    }
+  }
+
+
+void Reactor::InitialRecipes(std::vector<std::string> int_invs, std::vector<std::string> recipes){
+  for (int i = 0; i<int_invs.size(); i++) {
+    if (std::find(recipes.begin(), recipes.end(), int_invs[i]) = recipes.end());
+    throw KeyError("Recipe not associated with an in-commodity or out-commodity");
+  }
 }
 
 void Reactor::Load() {

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -65,8 +65,6 @@ void Reactor::EnterNotify() {
   core.keep_packaging(keep_packaging);
   spent.keep_packaging(keep_packaging);
 
-  //InitializeMaterials();
-
   // If the user ommitted fuel_prefs, we set it to zeros for each fuel
   // type.  Without this segfaults could occur - yuck.
   if (fuel_prefs.size() == 0) {

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -188,7 +188,7 @@ class Reactor : public cyclus::Facility,
                      std::vector<int>& initial_amts, 
                      cyclus::toolkit::ResBuf<cyclus::Material>& buffer);
 
-  void InitialRecipes(std::vector<std::string>, std::vector<std::string>);
+  void ValidateInitialRecipes(std::vector<std::string>, std::vector<std::string>);
 
   /////// fuel specifications /////////
   #pragma cyclus var { \

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -116,6 +116,7 @@ class Reactor : public cyclus::Facility,
   virtual void Tock();
   virtual void EnterNotify();
   virtual bool CheckDecommissionCondition();
+  virtual void Build(cyclus::Agent* parent);
 
   virtual void AcceptMatlTrades(const std::vector<std::pair<
       cyclus::Trade<cyclus::Material>, cyclus::Material::Ptr> >& responses);
@@ -185,7 +186,7 @@ class Reactor : public cyclus::Facility,
 
   void InitializeMaterials();
 
-  void InitialRecipes();
+  void InitialRecipes(std::vector<std::string>, std::vector<std::string>);
 
   /////// fuel specifications /////////
   #pragma cyclus var { \

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -349,7 +349,7 @@ class Reactor : public cyclus::Facility,
 
   #pragma cyclus var { \
   "default": [], \
-  "uilabel": "Number of assemblies for initial fresh fuel inventory", \
+  "uilabel": " for initial fresh fuel inventory", \
   "doc": "Specify an amount associated with an in-commidity recipe" \
           "Same order as initial fresh recipes.", \
   }
@@ -365,7 +365,7 @@ class Reactor : public cyclus::Facility,
 
   #pragma cyclus var { \
   "default": [], \
-  "uilabel": "Mass amounts for initial spent fuel inventory", \
+  "uilabel": "Number of assemblies for initial spent fuel inventory", \
   "doc": "Specify an amount associated with an out-commidity recipe" \
           "Same order as initial spent recipes.", \
   }

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -331,11 +331,11 @@ class Reactor : public cyclus::Facility,
 
   #pragma cyclus var { \
   "default": [], \
-  "uilabel": "Mass amounts for initial core inventory", \
+  "uilabel": "Number of assemblies for initial core inventory", \
   "doc": "Specify an amount associated with an in-commidity recipe" \
           "Same order as initial core recipes.", \
   }
-  std::vector<double> initial_core_amt;
+  std::vector<int> initial_core_amt;
 
   #pragma cyclus var { \
   "default": [], \
@@ -347,11 +347,11 @@ class Reactor : public cyclus::Facility,
 
   #pragma cyclus var { \
   "default": [], \
-  "uilabel": "Mass amounts for initial fresh fuel inventory", \
+  "uilabel": "Number of assemblies for initial fresh fuel inventory", \
   "doc": "Specify an amount associated with an in-commidity recipe" \
           "Same order as initial fresh recipes.", \
   }
-  std::vector<double> initial_fresh_amt;
+  std::vector<int> initial_fresh_amt;
 
   #pragma cyclus var { \
   "default": [], \

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -183,6 +183,10 @@ class Reactor : public cyclus::Facility,
   /// from the spent fuel buffer.
   std::map<std::string, cyclus::toolkit::MatVec> PeekSpent();
 
+  void InitializeMaterials();
+
+  void InitialRecipes();
+
   /////// fuel specifications /////////
   #pragma cyclus var { \
     "uitype": ["oneormore", "incommodity"], \
@@ -314,6 +318,56 @@ class Reactor : public cyclus::Facility,
            " reactor operation stalls.", \
   }
   int n_assem_spent;
+
+     ///////// initial inventory ///////////
+  #pragma cyclus var { \
+  "default": [], \
+  "uilabel": "Recipe names for initial core inventory", \
+  "doc": "Specify an in-commodity recipe name that should have" \
+          "an initial inventory. This material will be added to the core as an assembly.", \
+  }
+  std::vector<std::string> initial_core;
+
+  #pragma cyclus var { \
+  "default": [], \
+  "uilabel": "Mass amounts for initial core inventory", \
+  "doc": "Specify an amount associated with an in-commidity recipe" \
+          "Same order as initial core recipes.", \
+  }
+  std::vector<double> initial_core_amt;
+
+  #pragma cyclus var { \
+  "default": [], \
+  "uilabel": "Recipe names for initial fresh fuel", \
+  "doc": "Specify an in-commodity recipe name that should have" \
+          "an initial inventory. This material will be added to the on-hand fresh fuel inventory as an assembly.", \
+  }
+  std::vector<std::string> initial_fresh;
+
+  #pragma cyclus var { \
+  "default": [], \
+  "uilabel": "Mass amounts for initial fresh fuel inventory", \
+  "doc": "Specify an amount associated with an in-commidity recipe" \
+          "Same order as initial fresh recipes.", \
+  }
+  std::vector<double> initial_fresh_amt;
+
+  #pragma cyclus var { \
+  "default": [], \
+  "uilabel": "Recipe names for initial spent fuel inventory", \
+  "doc": "Specify an out-commodity recipe name that should have" \
+          "an initial inventory. This material will be added to the on-site spent fuel as a --.", \
+  }
+  std::vector<std::string> initial_spent;
+
+  #pragma cyclus var { \
+  "default": [], \
+  "uilabel": "Mass amounts for initial spent fuel inventory", \
+  "doc": "Specify an amount associated with an out-commidity recipe" \
+          "Same order as initial spent recipes.", \
+  }
+  std::vector<double> initial_spent_amt;
+  
 
    ///////// cycle params ///////////
   #pragma cyclus var { \

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -184,9 +184,13 @@ class Reactor : public cyclus::Facility,
   /// from the spent fuel buffer.
   std::map<std::string, cyclus::toolkit::MatVec> PeekSpent();
 
+  //loads any spent or fresh fuel assemblies into resource buffer
   void LoadInitial(std::vector<std::string>& initial_recipes,
                      std::vector<int>& initial_amts, 
                      cyclus::toolkit::ResBuf<cyclus::Material>& buffer);
+
+  //to be run with LoadInitial()
+  void PushInitialInv();
 
   void ValidateInitialRecipes(std::vector<std::string>, std::vector<std::string>);
 
@@ -324,50 +328,50 @@ class Reactor : public cyclus::Facility,
 
      ///////// initial inventory ///////////
   #pragma cyclus var { \
-  "default": [], \
-  "uilabel": "Recipe names for initial core inventory", \
-  "doc": "Specify an in-commodity recipe name that should have" \
-          "an initial inventory. This material will be added to the core as an assembly.", \
+    "default": [], \
+    "uilabel": "Recipe names for initial core inventory", \
+    "doc": "Specify an in-commodity recipe name that should have" \
+            "an initial inventory. This material will be added to the core as an assembly.", \
   }
   std::vector<std::string> initial_core_recipes;
 
   #pragma cyclus var { \
-  "default": [], \
-  "uilabel": "Number of assemblies for initial core inventory", \
-  "doc": "Specify an amount associated with an in-commidity recipe" \
-          "Same order as initial core recipes.", \
+    "default": [], \
+    "uilabel": "Number of assemblies for initial core inventory", \
+    "doc": "Specify an amount associated with an in-commidity recipe" \
+            "Same order as initial core recipes.", \
   }
   std::vector<int> initial_core_amt;
 
-  #pragma cyclus var { \
-  "default": [], \
-  "uilabel": "Recipe names for initial fresh fuel", \
-  "doc": "Specify an in-commodity recipe name that should have" \
-          "an initial inventory. This material will be added to the on-hand fresh fuel inventory as an assembly.", \
+    #pragma cyclus var { \
+    "default": [], \
+    "uilabel": "Recipe names for initial fresh fuel", \
+    "doc": "Specify an in-commodity recipe name that should have" \
+            "an initial inventory. This material will be added to the on-hand fresh fuel inventory as an assembly.", \
   }
   std::vector<std::string> initial_fresh_recipes;
 
   #pragma cyclus var { \
-  "default": [], \
-  "uilabel": " for initial fresh fuel inventory", \
-  "doc": "Specify an amount associated with an in-commidity recipe" \
-          "Same order as initial fresh recipes.", \
+    "default": [], \
+    "uilabel": "Number of assemblies for initial fresh fuel inventory", \
+    "doc": "Specify an amount associated with an in-commidity recipe" \
+            "Same order as initial fresh recipes.", \
   }
   std::vector<int> initial_fresh_amt;
 
   #pragma cyclus var { \
-  "default": [], \
-  "uilabel": "Recipe names for initial spent fuel inventory", \
-  "doc": "Specify an out-commodity recipe name that should have" \
-          "an initial inventory. This material will be added to the on-site spent fuel as a --.", \
+    "default": [], \
+    "uilabel": "Recipe names for initial spent fuel inventory", \
+    "doc": "Specify an out-commodity recipe name that should have" \
+            "an initial inventory.", \
   }
   std::vector<std::string> initial_spent_recipes;
 
   #pragma cyclus var { \
-  "default": [], \
-  "uilabel": "Number of assemblies for initial spent fuel inventory", \
-  "doc": "Specify an amount associated with an out-commidity recipe" \
-          "Same order as initial spent recipes.", \
+    "default": [], \
+    "uilabel": "Number of assemblies for initial spent fuel inventory", \
+    "doc": "Specify an amount associated with an out-commidity recipe" \
+            "Same order as initial spent recipes.", \
   }
   std::vector<int> initial_spent_amt;
   

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -184,7 +184,9 @@ class Reactor : public cyclus::Facility,
   /// from the spent fuel buffer.
   std::map<std::string, cyclus::toolkit::MatVec> PeekSpent();
 
-  void InitializeMaterials();
+  void LoadInitial(std::vector<std::string>& initial_recipes,
+                     std::vector<int>& initial_amts, 
+                     cyclus::toolkit::ResBuf<cyclus::Material>& buffer);
 
   void InitialRecipes(std::vector<std::string>, std::vector<std::string>);
 
@@ -327,7 +329,7 @@ class Reactor : public cyclus::Facility,
   "doc": "Specify an in-commodity recipe name that should have" \
           "an initial inventory. This material will be added to the core as an assembly.", \
   }
-  std::vector<std::string> initial_core;
+  std::vector<std::string> initial_core_recipes;
 
   #pragma cyclus var { \
   "default": [], \
@@ -343,7 +345,7 @@ class Reactor : public cyclus::Facility,
   "doc": "Specify an in-commodity recipe name that should have" \
           "an initial inventory. This material will be added to the on-hand fresh fuel inventory as an assembly.", \
   }
-  std::vector<std::string> initial_fresh;
+  std::vector<std::string> initial_fresh_recipes;
 
   #pragma cyclus var { \
   "default": [], \
@@ -359,7 +361,7 @@ class Reactor : public cyclus::Facility,
   "doc": "Specify an out-commodity recipe name that should have" \
           "an initial inventory. This material will be added to the on-site spent fuel as a --.", \
   }
-  std::vector<std::string> initial_spent;
+  std::vector<std::string> initial_spent_recipes;
 
   #pragma cyclus var { \
   "default": [], \
@@ -367,7 +369,7 @@ class Reactor : public cyclus::Facility,
   "doc": "Specify an amount associated with an out-commidity recipe" \
           "Same order as initial spent recipes.", \
   }
-  std::vector<double> initial_spent_amt;
+  std::vector<int> initial_spent_amt;
   
 
    ///////// cycle params ///////////

--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -421,33 +421,34 @@ TEST(ReactorTests, InitialMaterialInventory) {
 
 TEST(ReactorTests, InitialMaterialInventoryErrors) {
 
-  std::string error1 =
+  std::string missing_amt_err =
     ""
     " <initial_fresh_recipes> <val>uox</val> <val>mox</val> </initial_fresh_recipes> "
     " <initial_fresh_amt> <val>6</val> </initial_fresh_amt> ";
 
-    EXPECT_THROW(MaterialInvErrorInput(error1).Run(), cyclus::ValueError);
+    EXPECT_THROW(MaterialInvErrorInput(missing_amt_err).Run(), cyclus::ValueError);
 
-  std::string error2 =
+  std::string invalid_recipe_err =
     ""
     " <initial_core_recipes> <val>mox</val> <val>fueluox</val> </initial_core_recipes> "
     " <initial_core_amt> <val>1</val> <val>2</val> </initial_core_amt> ";
-    EXPECT_THROW(MaterialInvErrorInput(error2).Run(), cyclus::KeyError);
+    EXPECT_THROW(MaterialInvErrorInput(invalid_recipe_err).Run(), cyclus::KeyError);
 
   //the reactor spent fuel buffer will never start to fill with the spentmox amount
   //because already filled 
-  std::string error3 =
+  std::string capacity_exceed_err =
     ""
     " <initial_spent_recipes> <val>spentuox</val> <val>spentmox</val> </initial_spent_recipes> "
     " <initial_spent_amt> <val>40</val> <val>7</val> </initial_spent_amt> ";
     cyclus::warn_as_error = true;
-    EXPECT_THROW(MaterialInvErrorInput(error3).Run(), cyclus::ValueError);
+    EXPECT_THROW(MaterialInvErrorInput(capacity_exceed_err).Run(), cyclus::ValueError);
 
-    std::string error4 =
+    //capacity exceeded with two different recipes in spent buffer 
+    std::string mixed_capacity_exceed_err =
     ""
     " <initial_spent_recipes> <val>spentuox</val> <val>spentmox</val> </initial_spent_recipes> "
     " <initial_spent_amt> <val>2</val> <val>6</val> </initial_spent_amt> ";
-    EXPECT_THROW(MaterialInvErrorInput(error4).Run(), cyclus::ValueError);
+    EXPECT_THROW(MaterialInvErrorInput(mixed_capacity_exceed_err).Run(), cyclus::ValueError);
     cyclus::warn_as_error = false;
 }
 

--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -430,7 +430,7 @@ TEST(ReactorTests, InitialMaterialInventoryErrors) {
 
   std::string invalid_recipe_err =
     ""
-    " <initial_core_recipes> <val>mox</val> <val>fueluox</val> </initial_core_recipes> "
+    " <initial_core_recipes> <val>mox</val> <val>invalid_recipe</val> </initial_core_recipes> "
     " <initial_core_amt> <val>1</val> <val>2</val> </initial_core_amt> ";
     EXPECT_THROW(MaterialInvErrorInput(invalid_recipe_err).Run(), cyclus::KeyError);
 

--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -52,6 +52,36 @@ Composition::Ptr c_water() {
   return Composition::CreateFromAtom(m);
 };
 
+cyclus::MockSim MaterialInvErrorInput(std::string error_string){
+  std::string start_config =
+     "  <fuel_inrecipes>  <val>uox</val>      <val>mox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> <val>spentmox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      <val>mox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    <val>waste</val>    </fuel_outcommods>  "
+    ""
+    " <cycle_time>1</cycle_time> "
+    " <refuel_time>0</refuel_time> "
+    " <assem_size>8</assem_size> "
+    " <n_assem_core>8</n_assem_core> "
+    " <n_assem_batch>2</n_assem_batch> "
+    " <n_assem_fresh>5</n_assem_fresh> "
+    " <n_assem_spent>3</n_assem_spent> "
+    " <power_cap>100</power_cap> "
+    "";
+  
+  std::string config = start_config + error_string;
+
+  int simdur = 0;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
+  sim.AddSource("uox").capacity(2).Finalize();
+  sim.AddSource("mox").capacity(2).Finalize();
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  sim.AddRecipe("mox", c_spentuox());
+  sim.AddRecipe("spentmox", c_spentuox());
+  return sim;
+};
+
 // Test that with a zero refuel_time and a zero capacity fresh fuel buffer
 // (the default), fuel can be ordered and the cycle started with no time step
 // delay.
@@ -389,6 +419,37 @@ TEST(ReactorTests, InitialMaterialInventory) {
 
 }
 
+TEST(ReactorTests, InitialMaterialInventoryErrors) {
+
+  std::string error1 =
+    ""
+    " <initial_fresh_recipes> <val>uox</val> <val>mox</val> </initial_fresh_recipes> "
+    " <initial_fresh_amt> <val>6</val> </initial_fresh_amt> ";
+
+    EXPECT_THROW(MaterialInvErrorInput(error1).Run(), cyclus::ValueError);
+
+  std::string error2 =
+    ""
+    " <initial_core_recipes> <val>mox</val> <val>fueluox</val> </initial_core_recipes> "
+    " <initial_core_amt> <val>1</val> <val>2</val> </initial_core_amt> ";
+    EXPECT_THROW(MaterialInvErrorInput(error2).Run(), cyclus::KeyError);
+
+  //the reactor spent fuel buffer will never start to fill with the spentmox amount
+  //because already filled 
+  std::string error3 =
+    ""
+    " <initial_spent_recipes> <val>spentuox</val> <val>spentmox</val> </initial_spent_recipes> "
+    " <initial_spent_amt> <val>40</val> <val>7</val> </initial_spent_amt> ";
+    cyclus::warn_as_error = true;
+    EXPECT_THROW(MaterialInvErrorInput(error3).Run(), cyclus::ValueError);
+
+    std::string error4 =
+    ""
+    " <initial_spent_recipes> <val>spentuox</val> <val>spentmox</val> </initial_spent_recipes> "
+    " <initial_spent_amt> <val>2</val> <val>6</val> </initial_spent_amt> ";
+    EXPECT_THROW(MaterialInvErrorInput(error4).Run(), cyclus::ValueError);
+    cyclus::warn_as_error = false;
+}
 
 
 // tests that the reactor cycle is delayed as expected when it is unable to

--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -333,6 +333,64 @@ TEST(ReactorTests, FullSpentInventoryShutdown) {
 
 }
 
+// tests that that the initial core, fresh fuel, and spent fuel buffers 
+// are filled with the specified number of assemblies and recipes
+TEST(ReactorTests, InitialMaterialInventory) {
+  std::string config =
+    " <fuel_inrecipes> <val>uox</val> </fuel_inrecipes> "
+    " <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes> "
+    " <fuel_incommods> <val>uox</val> </fuel_incommods> "
+    " <fuel_outcommods> <val>waste</val> </fuel_outcommods> "
+    ""
+    " <cycle_time>1</cycle_time> "
+    " <refuel_time>0</refuel_time> "
+    " <assem_size>8</assem_size> "
+    " <n_assem_core>8</n_assem_core> "
+    " <n_assem_batch>2</n_assem_batch> "
+    " <n_assem_fresh>5</n_assem_fresh> "
+    " <n_assem_spent>3</n_assem_spent> "
+    " <power_cap>100</power_cap> "
+    ""
+    " <initial_core_recipes> <val>uox</val> </initial_core_recipes> "
+    " <initial_fresh_recipes> <val>uox</val> </initial_fresh_recipes> "
+    " <initial_spent_recipes> <val>spentuox</val> </initial_spent_recipes> "
+    " <initial_core_amt> <val>6</val> </initial_core_amt> "
+    " <initial_fresh_amt> <val>6</val> </initial_fresh_amt> "
+    " <initial_spent_amt> <val>2</val> </initial_spent_amt> ";
+
+  int simdur = 0;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
+  sim.AddSource("uox").Finalize();
+  sim.AddSink("waste").Finalize();
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  int id = sim.Run();
+
+
+  std::vector<Cond> conds;
+  QueryResult qr;
+
+  //check the initial inventory of the fresh at timestep 0
+  conds.push_back(Cond("SimTime", "==", 0));
+  conds.push_back(Cond("AgentId","==",id));
+  conds.push_back(Cond("InventoryName","==",std::string("fresh")));
+  qr = sim.db().Query("AgentStateInventories", &conds);
+  EXPECT_EQ(5, qr.rows.size());
+
+  // check the initial inventory of the spent fuel at timestep 0
+  conds[2] = Cond("InventoryName","==",std::string("spent"));
+  qr = sim.db().Query("AgentStateInventories", &conds);
+  EXPECT_EQ(2, qr.rows.size());
+
+  // check the initial inventory of the core at timestep 0
+  conds[2] = Cond("InventoryName","==",std::string("core"));
+  qr = sim.db().Query("AgentStateInventories", &conds);
+  EXPECT_EQ(6, qr.rows.size());
+
+}
+
+
+
 // tests that the reactor cycle is delayed as expected when it is unable to
 // acquire fuel in time for the next cycle start.  This checks that after a
 // cycle is delayed past an original scheduled start time, as soon as enough fuel is


### PR DESCRIPTION
<!-- If this PR adds a CEP, do not repeat all of the information in the CEP document in the summary. Instead, provide a short description of the CEP's purpose.  -->

# Summary of Changes
<!--- In one or more sentences, describe the PR you are submitting. -->
This is a suggestion to resolve Issue #673 by implementing changes to individual Cycamore agents. Please comment any critiques, corrections, and improvements, so that a formal PR can be submitted!


For now, only enrichment and reactor facility have been changed so they are built with the option of having an initial inventory. This can percolate to other facilities if this method is approved.

The enrichment facility can have tails and/or feed on hand. Initial product is not allowed to be specified by user. (Some initial inventory feature would mean that the ```initial_feed``` can be retired). 

Alternatively, the reactor can have initial assemblies in the core,  initial fresh fuel (if ``n_assem_fresh`` allows) ,and/or spent fuel inventory. Fresh and core initial inventories must be in discrete assembly sizes. The user may specify a mass quantity but it will be translated to "assembly". Any amount over the capacity is unused. Spent fuel, currently does not have a discrete loading mass (user can specify any mass and all will be added). This could be changed so user can only specify initial spent fuel batches. 


## Design Notes
<!--- Describe any design decisions or trade-offs you made. -->

Currently, reactor accepts user recipe names for establishing initial inventory. Enrichment accepts user commodity names. Is one more preferable identification than the other?

Adjustments are made to update the spent fuel supply in the database output. 




Check the box if your change does not break any of the following:
- [ ] API for Cyclus modules
- [ ] Input files
- [ ] Output tables for post processing tools

# Related CEPs and Issues
<!--- Reference the issue that this PR closes, any related CEPs, and describe how this PR contributes to or addresses the problem. -->
Fixes # 673. 

# Testing and Validation
<!--- Describe how this change was tested. -->

No updates were performed to tests yet. It has been compiled locally and tested with various input files. 

- [ ] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [ ] I have compiled and run the code locally
- [ ] I have added or updated relevant tests
- [ ] I have added documentation for new or changed features
- [ ] This code follows the style guide
- [ ] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).