### PR TITLE
TimeSeries Tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Since last release
 ======================
 
 **Added:**
+* Added tests for all Agent TimeSeries in Cycamore as of 8 June 2026 (#689)
 * Added tests for Conversion Facility (#658)
 * Added Conversion Facility (#657)
 * Replaced manual matl_buy/sell_policy code in storage with code injection (#639)

--- a/src/enrichment_tests.cc
+++ b/src/enrichment_tests.cc
@@ -770,6 +770,73 @@ TEST_F(EnrichmentTest, PositionInitialize2) {
 }
 
 
+TEST_F(EnrichmentTest, TimeSeriesTests) {
+  // Begin with 10 kg natural uranium and enrich 1 kg of 4% LEU at time 0.
+  // The product sink retires after that trade; a tails sink starts at time 1
+  // so the second step records the remaining feed and generated tails.
+  std::string config =
+    "   <feed_commod>natu</feed_commod> "
+    "   <feed_recipe>natu1</feed_recipe> "
+    "   <product_commod>enr_u</product_commod> "
+    "   <tails_commod>tails</tails_commod> "
+    "   <tails_assay>0.003</tails_assay> "
+    "   <initial_feed>10</initial_feed> ";
+
+  int simdur = 2;
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Enrichment"), config, simdur);
+  sim.AddRecipe("natu1", c_natu1());
+  sim.AddRecipe("leu", c_leu());
+  sim.AddSink("enr_u").recipe("leu").capacity(1).lifetime(1).Finalize();
+  sim.AddSink("tails").start(1).Finalize();
+  int id = sim.Run();
+
+  cyclus::toolkit::Assays assays(0.007, 0.04, 0.003);
+  double exp_feed = cyclus::toolkit::FeedQty(1, assays);
+  double exp_swu = cyclus::toolkit::SwuRequired(1, assays);
+  double exp_tails = cyclus::toolkit::TailsQty(1, assays);
+  double obs;
+
+  // Feed and SWU record process use, so they are nonzero only on the step
+  // where LEU is produced.
+  QueryResult qr = sim.db().Query("TimeSeriesEnrichmentFeed", NULL);
+  ASSERT_EQ(simdur, qr.rows.size());
+  obs = qr.GetVal<double>("Value", 0);
+  EXPECT_NEAR(exp_feed, obs, cyclus::CY_NEAR_ZERO);
+  obs = qr.GetVal<double>("Value", 1);
+  EXPECT_DOUBLE_EQ(0, obs);
+
+  qr = sim.db().Query("TimeSeriesEnrichmentSWU", NULL);
+  ASSERT_EQ(simdur, qr.rows.size());
+  obs = qr.GetVal<double>("Value", 0);
+  EXPECT_NEAR(exp_swu, obs, cyclus::CY_NEAR_ZERO);
+  obs = qr.GetVal<double>("Value", 1);
+  EXPECT_DOUBLE_EQ(0, obs);
+
+  qr = sim.db().Query("TimeSeriesdemandnatu", NULL);
+  ASSERT_EQ(simdur, qr.rows.size());
+  obs = qr.GetVal<double>("Value", 0);
+  EXPECT_NEAR(exp_feed, obs, cyclus::CY_NEAR_ZERO);
+  obs = qr.GetVal<double>("Value", 1);
+  EXPECT_DOUBLE_EQ(0, obs);
+
+  qr = sim.db().Query("TimeSeriessupplyenr_u", NULL);
+  ASSERT_EQ(simdur, qr.rows.size());
+  // Enrichment's product supply series records feed inventory available to
+  // support product bids: 10 kg initially, then 10 kg minus consumed feed.
+  obs = qr.GetVal<double>("Value", 0);
+  EXPECT_DOUBLE_EQ(10, obs);
+  obs = qr.GetVal<double>("Value", 1);
+  EXPECT_NEAR(10 - exp_feed, obs, cyclus::CY_NEAR_ZERO);
+
+  qr = sim.db().Query("TimeSeriessupplytails", NULL);
+  ASSERT_EQ(simdur, qr.rows.size());
+  obs = qr.GetVal<double>("Value", 0);
+  EXPECT_DOUBLE_EQ(0, obs);
+  obs = qr.GetVal<double>("Value", 1);
+  EXPECT_NEAR(exp_tails, obs, cyclus::CY_NEAR_ZERO);
+}
+
 }  // namespace cycamore
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/mixer_tests.cc
+++ b/src/mixer_tests.cc
@@ -519,4 +519,85 @@ TEST(MixerTests, PositionInitialize) {
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 0.0);
 }
 
+TEST(MixerTests, TimeSeriesTests) {
+  // One kilogram of output requires 0.8, 0.15, and 0.05 kg from the three
+  // input streams. Sources add 1 kg to each stream per step, while the output
+  // sink removes each mixed kilogram before the next step.
+  std::string config =
+      "<in_streams>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.8</mixing_ratio>"
+            "<buf_size>2.5</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<item><commodity>stream1</commodity><pref>1</pref></item>"
+          "</commodities>"
+        "</stream>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.15</mixing_ratio>"
+            "<buf_size>3</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<item><commodity>stream2</commodity><pref>1</pref></item>"
+          "</commodities>"
+        "</stream>"
+        "<stream>"
+          "<info>"
+            "<mixing_ratio>0.05</mixing_ratio>"
+            "<buf_size>5</buf_size>"
+          "</info>"
+          "<commodities>"
+            "<item><commodity>stream3</commodity><pref>1</pref></item>"
+          "</commodities>"
+        "</stream>"
+      "</in_streams>"
+      "<out_commod>mixedstream</out_commod>"
+      "<outputbuf_size>10</outputbuf_size>"
+      "<throughput>1</throughput>";
+  int simdur = 3;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Mixer"), config, simdur);
+  sim.AddSource("stream1").recipe("unatstream").capacity(1).Finalize();
+  sim.AddSource("stream2").recipe("uoxstream").capacity(1).Finalize();
+  sim.AddSource("stream3").recipe("pustream").capacity(1).Finalize();
+  sim.AddRecipe("unatstream", c_natu());
+  sim.AddRecipe("uoxstream", c_pustream());
+  sim.AddRecipe("pustream", c_uox());
+  sim.AddSink("mixedstream").capacity(10).Finalize();
+  int id = sim.Run();
+
+  double obs;
+  double exp;
+  QueryResult qr = sim.db().Query("TimeSeriessupplymixedstream", NULL);
+  ASSERT_EQ(simdur, qr.rows.size());
+  obs = qr.GetVal<double>("Value", 0);
+  exp = 0;
+  EXPECT_DOUBLE_EQ(exp, obs);
+  obs = qr.GetVal<double>("Value", 1);
+  exp = 1;
+  EXPECT_DOUBLE_EQ(exp, obs);
+  obs = qr.GetVal<double>("Value", 2);
+  exp = 1;
+  EXPECT_DOUBLE_EQ(exp, obs);
+
+  const std::string commods[] = {"stream1", "stream2", "stream3"};
+  const double initial_space[] = {2.5, 3, 5};
+  const double exp_second[] = {2.3, 2.15, 4.05};
+  const double exp_third[] = {2.1, 1.3, 3.1};
+  for (int i = 0; i < 3; ++i) {
+    qr = sim.db().Query("TimeSeriesdemand" + commods[i], NULL);
+    ASSERT_EQ(simdur, qr.rows.size());
+    obs = qr.GetVal<double>("Value", 0);
+    exp = initial_space[i];
+    EXPECT_DOUBLE_EQ(exp, obs);
+    obs = qr.GetVal<double>("Value", 1);
+    exp = exp_second[i];
+    EXPECT_NEAR(exp, obs, cyclus::CY_NEAR_ZERO);
+    obs = qr.GetVal<double>("Value", 2);
+    exp = exp_third[i];
+    EXPECT_NEAR(exp, obs, cyclus::CY_NEAR_ZERO);
+  }
+}
+
 }  // namespace cycamore

--- a/src/reactor_tests.cc
+++ b/src/reactor_tests.cc
@@ -758,6 +758,62 @@ TEST(ReactorTests, MultipleByProduct) {
 
 }
 
+TEST(ReactorTests, TimeSeriesTests) {
+  std::string config =
+     "  <fuel_inrecipes>  <val>uox</val>      </fuel_inrecipes>  "
+     "  <fuel_outrecipes> <val>spentuox</val> </fuel_outrecipes>  "
+     "  <fuel_incommods>  <val>uox</val>      </fuel_incommods>  "
+     "  <fuel_outcommods> <val>waste</val>    </fuel_outcommods>  "
+     "  <cycle_time>2</cycle_time>  "
+     "  <refuel_time>2</refuel_time>  "
+     "  <assem_size>1</assem_size>  "
+     "  <n_assem_core>1</n_assem_core>  "
+     "  <n_assem_batch>1</n_assem_batch>  "
+     "  <power_cap>10</power_cap>  ";
+
+  int simdur = 7;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Reactor"), config, simdur);
+  sim.AddSource("uox").Finalize();
+  sim.AddSink("waste").Finalize();
+  sim.AddRecipe("uox", c_uox());
+  sim.AddRecipe("spentuox", c_spentuox());
+  int id = sim.Run();
+
+  QueryResult qr = sim.db().Query("TimeSeriesPower", NULL);
+  ASSERT_EQ(simdur, qr.rows.size());
+  // Two operating steps are followed by two refueling steps. The second
+  // cycle begins at time 4 and ends with another discharge at time 6.
+  const double exp_power[] = {10, 10, 0, 0, 10, 10, 0};
+  for (int i = 0; i < simdur; ++i)
+    EXPECT_DOUBLE_EQ(exp_power[i], qr.GetVal<double>("Value", i));
+
+  qr = sim.db().Query("TimeSeriessupplyPOWER", NULL);
+  ASSERT_EQ(simdur, qr.rows.size());
+  for (int i = 0; i < simdur; ++i)
+    EXPECT_DOUBLE_EQ(exp_power[i], qr.GetVal<double>("Value", i));
+
+  qr = sim.db().Query("TimeSeriesdemanduox", NULL);
+  ASSERT_EQ(3, qr.rows.size());
+  // Fuel demand is recorded only when an assembly is requested: once for the
+  // initial core and once after each discharge. No demand row is recorded
+  // while the reactor has a full core and is operating.
+  EXPECT_EQ(0, qr.GetVal<int>("Time", 0));
+  EXPECT_EQ(2, qr.GetVal<int>("Time", 1));
+  EXPECT_EQ(6, qr.GetVal<int>("Time", 2));
+  EXPECT_DOUBLE_EQ(1, qr.GetVal<double>("Value", 0));
+  EXPECT_DOUBLE_EQ(1, qr.GetVal<double>("Value", 1));
+  EXPECT_DOUBLE_EQ(1, qr.GetVal<double>("Value", 2));
+
+  qr = sim.db().Query("TimeSeriessupplywaste", NULL);
+  ASSERT_EQ(2, qr.rows.size());
+  // Spent-fuel supply is recorded when a cycle ends and an assembly moves
+  // from the core into spent inventory. The sink removes each assembly before
+  // the next discharge, so both recorded supplies are one assembly.
+  EXPECT_EQ(2, qr.GetVal<int>("Time", 0));
+  EXPECT_EQ(6, qr.GetVal<int>("Time", 1));
+  EXPECT_DOUBLE_EQ(1, qr.GetVal<double>("Value", 0));
+  EXPECT_DOUBLE_EQ(1, qr.GetVal<double>("Value", 1));
+}
+
 } // namespace reactortests
 } // namespace cycamore
-

--- a/src/separations_tests.cc
+++ b/src/separations_tests.cc
@@ -418,5 +418,62 @@ TEST(SeparationsTests, Retire) {
   EXPECT_EQ(qr.GetVal<double>("Latitude"), 10.0);
   EXPECT_EQ(qr.GetVal<double>("Longitude"), 15.0);
  }
-} // namespace cycamore
 
+TEST(SeparationsTests, TimeSeriesTests) {
+  std::string config =
+      "<streams>"
+      "  <item>"
+      "    <commod>stream1</commod>"
+      "    <info>"
+      "      <buf_size>-1</buf_size>"
+      "      <efficiencies>"
+      "        <item><comp>U</comp><eff>0.6</eff></item>"
+      "      </efficiencies>"
+      "    </info>"
+      "  </item>"
+      "</streams>"
+      "<leftover_commod>waste</leftover_commod>"
+      "<throughput>20</throughput>"
+      "<feedbuf_size>100</feedbuf_size>"
+      "<feed_commods><val>feed</val></feed_commods>";
+  CompMap comp;
+  comp[id("U235")] = 0.1;
+  comp[id("U238")] = 0.9;
+  Composition::Ptr recipe = Composition::CreateFromMass(comp);
+
+  int simdur = 3;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Separations"),
+                      config, simdur);
+  sim.AddSource("feed").recipe("recipe").capacity(40).Finalize();
+  sim.AddSink("stream1").capacity(100).Finalize();
+  sim.AddSink("waste").capacity(100).Finalize();
+  sim.AddRecipe("recipe", recipe);
+  int id = sim.Run();
+
+  QueryResult qr = sim.db().Query("TimeSeriesdemandfeed", NULL);
+  ASSERT_EQ(simdur, qr.rows.size());
+  // The source adds 40 kg per step while Separations processes 20 kg, so
+  // buffered feed grows and the remaining feed capacity falls by 20 kg.
+  EXPECT_DOUBLE_EQ(100, qr.GetVal<double>("Value", 0));
+  EXPECT_DOUBLE_EQ(80, qr.GetVal<double>("Value", 1));
+  EXPECT_DOUBLE_EQ(60, qr.GetVal<double>("Value", 2));
+
+  qr = sim.db().Query("TimeSeriessupplystream1", NULL);
+  ASSERT_EQ(simdur - 1, qr.rows.size());
+  // Each processed 20 kg batch is split into 12 kg uranium stream and
+  // 8 kg leftovers. There is no supply row before feed arrives, and both
+  // outputs are sold before the next batch is processed.
+  EXPECT_EQ(1, qr.GetVal<int>("Time", 0));
+  EXPECT_EQ(2, qr.GetVal<int>("Time", 1));
+  EXPECT_NEAR(12, qr.GetVal<double>("Value", 0), cyclus::CY_NEAR_ZERO);
+  EXPECT_NEAR(12, qr.GetVal<double>("Value", 1), cyclus::CY_NEAR_ZERO);
+
+  qr = sim.db().Query("TimeSeriessupplywaste", NULL);
+  ASSERT_EQ(simdur - 1, qr.rows.size());
+  EXPECT_EQ(1, qr.GetVal<int>("Time", 0));
+  EXPECT_EQ(2, qr.GetVal<int>("Time", 1));
+  EXPECT_NEAR(8, qr.GetVal<double>("Value", 0), cyclus::CY_NEAR_ZERO);
+  EXPECT_NEAR(8, qr.GetVal<double>("Value", 1), cyclus::CY_NEAR_ZERO);
+}
+
+} // namespace cycamore

--- a/src/sink_tests.cc
+++ b/src/sink_tests.cc
@@ -572,6 +572,35 @@ cyclus::Agent* SinkConstructor(cyclus::Context* ctx) {
   return new cycamore::Sink(ctx);
 }
 
+TEST_F(SinkTest, TimeSeriesTests) {
+  std::string config =
+    "   <in_commods>"
+    "     <val>commod1</val>"
+    "     <val>commod2</val>"
+    "   </in_commods>"
+    "   <capacity>4</capacity>"
+    "   <max_inv_size>5</max_inv_size>";
+
+  int simdur = 3;
+  cyclus::MockSim sim(cyclus::AgentSpec
+          (":cycamore:Sink"), config, simdur);
+  // The two commodities are alternatives in one mutual request. A source
+  // supplies 3 kg at time 0, leaving 2 kg of inventory space for time 1.
+  // Once that final 2 kg is received, demand is zero and no third row is
+  // recorded.
+  sim.AddSource("commod1").capacity(3).Finalize();
+  int id = sim.Run();
+
+  const std::string commods[] = {"commod1", "commod2"};
+  for (int i = 0; i < 2; ++i) {
+    cyclus::QueryResult qr =
+        sim.db().Query("TimeSeriesdemand" + commods[i], NULL);
+    ASSERT_EQ(simdur - 1, qr.rows.size());
+    EXPECT_DOUBLE_EQ(4, qr.GetVal<double>("Value", 0));
+    EXPECT_DOUBLE_EQ(2, qr.GetVal<double>("Value", 1));
+  }
+}
+
 // required to get functionality in cyclus agent unit tests library
 #ifndef CYCLUS_AGENT_TESTS_CONNECTED
 int ConnectAgentTests();

--- a/src/source_tests.cc
+++ b/src/source_tests.cc
@@ -241,6 +241,33 @@ SourceTest::GetContext(int nreqs, std::string commod) {
   return ec;
 }
 
+TEST_F(SourceTest, TimeSeriesTests) {
+  std::string config =
+    "<outcommod>commod</outcommod>"
+    "<inventory_size>8</inventory_size>"
+    "<throughput>5</throughput>";
+  int simdur = 3;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Source"), config, simdur);
+  // The source sells 3 kg in each of the first two steps. Its 5 kg throughput
+  // controls the first two offers; the final offer is limited by inventory.
+  sim.AddSink("commod").capacity(3).Finalize();
+  int id = sim.Run();
+
+  cyclus::QueryResult qr = sim.db().Query("TimeSeriessupplycommod", NULL);
+  ASSERT_EQ(simdur, qr.rows.size());
+  double obs;
+  double exp;
+  obs = qr.GetVal<double>("Value", 0);
+  exp = 5;
+  EXPECT_DOUBLE_EQ(exp, obs);
+  obs = qr.GetVal<double>("Value", 1);
+  exp = 5;
+  EXPECT_DOUBLE_EQ(exp, obs);
+  obs = qr.GetVal<double>("Value", 2);
+  exp = 2;
+  EXPECT_DOUBLE_EQ(exp, obs);
+}
+
 } // namespace cycamore
 
 cyclus::Agent* SourceConstructor(cyclus::Context* ctx) {
@@ -256,4 +283,3 @@ static int cyclus_agent_tests_connected = ConnectAgentTests();
 
 INSTANTIATE_TEST_SUITE_P(SourceFac, FacilityTests, Values(&SourceConstructor));
 INSTANTIATE_TEST_SUITE_P(SourceFac, AgentTests, Values(&SourceConstructor));
-

--- a/src/storage_tests.cc
+++ b/src/storage_tests.cc
@@ -1156,6 +1156,39 @@ TEST_F(StorageTest, TransportUnit) {
   EXPECT_EQ(1, qr_res.GetVal<double>("Quantity", 5));
 }
 
+TEST_F(StorageTest, TimeSeriesTests) {
+  std::string config =
+    "   <in_commods> <val>spent_fuel</val> </in_commods> "
+    "   <out_commods> <val>dry_spent</val> </out_commods> "
+    "   <residence_time>1</residence_time>"
+    "   <throughput>4</throughput>"
+    "   <max_inv_size>10</max_inv_size>";
+
+  int simdur = 4;
+  cyclus::MockSim sim(cyclus::AgentSpec(":cycamore:Storage"),
+                      config, simdur);
+  // Three kilograms arrive each step, wait one step, and then enter stocks.
+  // The sink removes 2 kg per step once stocks become available.
+  sim.AddSource("spent_fuel").capacity(3).Finalize();
+  sim.AddSink("dry_spent").capacity(2).Finalize();
+  int id = sim.Run();
+
+  cyclus::QueryResult qr =
+      sim.db().Query("TimeSeriesdemandspent_fuel", NULL);
+  ASSERT_EQ(simdur, qr.rows.size());
+  EXPECT_DOUBLE_EQ(7, qr.GetVal<double>("Value", 0));
+  EXPECT_DOUBLE_EQ(4, qr.GetVal<double>("Value", 1));
+  EXPECT_DOUBLE_EQ(3, qr.GetVal<double>("Value", 2));
+  EXPECT_DOUBLE_EQ(2, qr.GetVal<double>("Value", 3));
+
+  qr = sim.db().Query("TimeSeriessupplydry_spent", NULL);
+  ASSERT_EQ(simdur, qr.rows.size());
+  EXPECT_DOUBLE_EQ(0, qr.GetVal<double>("Value", 0));
+  EXPECT_DOUBLE_EQ(3, qr.GetVal<double>("Value", 1));
+  EXPECT_DOUBLE_EQ(4, qr.GetVal<double>("Value", 2));
+  EXPECT_DOUBLE_EQ(5, qr.GetVal<double>("Value", 3));
+}
+
 } // namespace cycamore
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
# Summary of Changes
<!--- In one or more sentences, describe the PR you are submitting. -->
#539 points out that the testing for the Cycamore TimeSeries was lacking. This PR adds one big test to each Agent which has at least one TimeSeries to test all of that agent's TimeSeries'. 

## Design Notes
<!--- Describe any design decisions or trade-offs you made. -->
Since these were fairly straightforward and VERY repetitive, I had Codex spin these tests up and then we spent some time refining them.  I think they landed in a really good spot. 

Additionally, it occurred to me to try to consolidate some of the config strings in all theses tests, but A. it was hard to tell how much overlap there really was for each one on a case-by-case basis, and B. it felt like even if there was overlap, consolidating ran the risk of obscuring what some of these tests do, so I decided that this was not something that this PR needed. Especially because that would likely distract from the real changes which are those tests.

Check the box if your change does not break any of the following:
- [x] API for Cyclus modules
- [x] Input files
- [x] Output tables for post processing tools

# Related CEPs and Issues
<!--- Reference the issue that this PR closes, any related CEPs, and describe how this PR contributes to or addresses the problem. -->
Fixes #539 


# Associated Developers
<!--- Please mention any developers who should be alerted of this PR. -->
OpenAI's Codex


# Testing and Validation
<!--- Describe how this change was tested. -->
This PR is all about tests. I had Codex add them, and then spent around an hour going over them and having it refine the tests to be better.

- [x] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [x] I have compiled and run the code locally
- [x] I have added or updated relevant tests
- [x] I have added documentation for new or changed features
- [x] This code follows the style guide
- [x] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).