### PR TITLE
Storage Header Fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Since last release
 * Added variable to specify initial spent, fresh, and core inventory for reactor facility (#680)
 
 **Changed:**
+* Some language in the storage cyclus note to make it match actual behavior (#690)
 * Cleaned up manual definitions of Position in favor of code injection (#641)
 * Rely on ``python3`` in environment instead of ``python`` (#602)
 * Link against ``libxml++`` imported target in CMake instead of ``LIBXMLXX_LIBRARIES`` (#608)

--- a/src/storage.h
+++ b/src/storage.h
@@ -80,7 +80,7 @@ class Storage
                               "the residence time has passed. The material is then passed into a 'ready' buffer where it is "\
                               "queued for removal. Currently, all input commodities are lumped into a single output commodity. "\
                               "Storage also has the functionality to handle materials in discrete or continuous batches. Discrete "\
-                              "mode, which is the default, does not split or combine material batches. Continuous mode, however, "\
+                              "mode does not split or combine material batches. Continuous mode, which is the default, however, "\
                               "divides material batches if necessary in order to push materials through the facility as quickly "\
                               "as possible."}
 


### PR DESCRIPTION
# Summary of Changes
<!--- In one or more sentences, describe the PR you are submitting. -->
This is a super quick fix to bring the `#pragma cyclus note` of the storage facility in line with its actual behavior. 

## Design Notes
<!--- Describe any design decisions or trade-offs you made. -->
I just moved the ", which is the default," from after "Discrete mode" to after "Continuous mode". There are a lot of commas in that sentence, but I THINK it's grammatically correct. Other options are equally weird (parentheses, moving "however" somewhere else, dropping "however", etc).

Check the box if your change does not break any of the following:
- [x] API for Cyclus modules
- [x] Input files
- [x] Output tables for post processing tools

# Related CEPs and Issues
<!--- Reference the issue that this PR closes, any related CEPs, and describe how this PR contributes to or addresses the problem. -->
Fixes #540


# Associated Developers
<!--- Please mention any developers who should be alerted of this PR. -->

None

# Testing and Validation
<!--- Describe how this change was tested. -->
I re-built and re-ran the tests. Everything was fine.

- [x] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [x] I have compiled and run the code locally
- [x] I have added or updated relevant tests
- [x] I have added documentation for new or changed features
- [x] This code follows the style guide
- [x] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).