### PR TITLE
Remove Double Position from Cycamore

### DIFF
--- a/.github/workflows/changelog_test.yml
+++ b/.github/workflows/changelog_test.yml
@@ -11,18 +11,11 @@ env:
 jobs:
   changelog_update:
     runs-on: ubuntu-latest
-    container:
-      image: alpine:3.14
 
     name: Is Changelog up-to-date ?
     steps:
-      - name: Install latest git
-        run: |
-          apk add --no-cache bash git openssh
-          git --version
-
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,7 +29,6 @@ Since last release
 * Updated Doxygen homepage (#632)
 
 **Fixed:**
-
 * Schedule Decommission in ``Reactor::Tick()`` instead of Decommission (#609)
 * When trades fail in Source due to packaging, send empty material instead of seg faulting (#629)
 * Logging of resource moves between ResBufs in Storage is INFO4 not INFO1 (#625)
@@ -37,7 +36,7 @@ Since last release
 * Update conributing guide to match current practice (#662)
 
 **Removed:**
-
+* Removed inheritance of toolkit position by Cycamore agents (#692)
 * Removed references to deprecated ``ResourceBuff`` class (#604)
 * Removed ``Libxml++`` from build requirements (#634)
 

--- a/src/conversion.h
+++ b/src/conversion.h
@@ -21,8 +21,7 @@ class Context;
 /// to its output commodity. It has a fixed throughput (per time step), and 
 /// converts without regard to the composition of the input material.
 class Conversion
-  : public cyclus::Facility,
-    public cyclus::toolkit::Position  {
+  : public cyclus::Facility {
   friend class ConversionTest;
  public:
   Conversion(cyclus::Context* ctx);
@@ -132,4 +131,3 @@ class Conversion
 }  // namespace cycamore
 
 #endif  // CYCAMORE_SRC_CONVERSION_H_
-

--- a/src/deploy_inst.h
+++ b/src/deploy_inst.h
@@ -21,8 +21,7 @@ typedef std::map<int, std::vector<std::string> > BuildSched;
 // lifetimes.
 class DeployInst : 
   public cyclus::Institution, 
-  public cyclus::toolkit::CommodityProducerManager,
-  public cyclus::toolkit::Position {
+  public cyclus::toolkit::CommodityProducerManager {
   #pragma cyclus note { \
     "doc": \
       "Builds and manages agents (facilities) according to a manually" \

--- a/src/enrichment.h
+++ b/src/enrichment.h
@@ -120,8 +120,7 @@ class NatUConverter : public cyclus::Converter<cyclus::Material> {
 ///  tails inventory.
 
 class Enrichment
-  : public cyclus::Facility,
-    public cyclus::toolkit::Position {
+  : public cyclus::Facility {
 #pragma cyclus note {   	  \
   "niche": "enrichment facility",				  \
   "doc":								\

--- a/src/fuel_fab.h
+++ b/src/fuel_fab.h
@@ -56,8 +56,7 @@ namespace cycamore {
 ///     Breeding. Economics, and Safety in Large Fast Power Reactors. 1963.
 /// @endcode
 class FuelFab
-  : public cyclus::Facility,
-    public cyclus::toolkit::Position {
+  : public cyclus::Facility {
 #pragma cyclus note { \
 "niche": "fabrication", \
 "doc": \

--- a/src/growth_region.h
+++ b/src/growth_region.h
@@ -35,8 +35,7 @@ typedef std::vector<
 /// multiple commodities being demanded.
 ///
 /// @warning The growth region is experimental
-class GrowthRegion : public cyclus::Region,
-  public cyclus::toolkit::Position {
+class GrowthRegion : public cyclus::Region {
   friend class GrowthRegionTests;
  public:
   /// The default constructor for the GrowthRegion

--- a/src/manager_inst.h
+++ b/src/manager_inst.h
@@ -13,8 +13,7 @@ namespace cycamore {
 class ManagerInst
     : public cyclus::Institution,
       public cyclus::toolkit::CommodityProducerManager,
-      public cyclus::toolkit::Builder,
-      public cyclus::toolkit::Position {
+      public cyclus::toolkit::Builder {
  public:
   /// Default constructor
   ManagerInst(cyclus::Context* ctx);

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -15,8 +15,7 @@ namespace cycamore {
 /// mixed material is constrained by available inventory of mixed material
 /// quantities.
 class Mixer
-  : public cyclus::Facility,
-    public cyclus::toolkit::Position {
+  : public cyclus::Facility {
 #pragma cyclus note {   	  \
     "niche": "mixing facility",				  \
     "doc": "Mixer mixes N streams with fixed, static, user-specified" \

--- a/src/reactor.h
+++ b/src/reactor.h
@@ -53,8 +53,7 @@ namespace cycamore {
 /// compositions.
 
 class Reactor : public cyclus::Facility,
-  public cyclus::toolkit::CommodityProducer,
-  public cyclus::toolkit::Position {
+  public cyclus::toolkit::CommodityProducer {
 #pragma cyclus note { \
 "niche": "reactor", \
 "doc": \

--- a/src/separations.h
+++ b/src/separations.h
@@ -37,8 +37,7 @@ cyclus::Material::Ptr SepMaterial(std::map<int, double> effs,
 /// streams, further processing/separations of feed material will halt until
 /// room is again available in the output streams.
 class Separations
-  : public cyclus::Facility,
-    public cyclus::toolkit::Position {
+  : public cyclus::Facility {
 #pragma cyclus note { \
   "niche": "separations", \
   "doc": \

--- a/src/sink.h
+++ b/src/sink.h
@@ -21,8 +21,7 @@ class Context;
 /// default to infinite. If a recipe is provided, it will request material with
 /// that recipe. Requests are made for any number of specified commodities.
 class Sink
-  : public cyclus::Facility,
-    public cyclus::toolkit::Position  {
+  : public cyclus::Facility {
  public:
   Sink(cyclus::Context* ctx);
 

--- a/src/source.h
+++ b/src/source.h
@@ -23,8 +23,7 @@ class Context;
 /// inventory, and when the inventory size reaches zero, the source can provide
 /// no more material.
 class Source : public cyclus::Facility,
-  public cyclus::toolkit::CommodityProducer,
-  public cyclus::toolkit::Position {
+  public cyclus::toolkit::CommodityProducer {
   friend class SourceTest;
  public:
 


### PR DESCRIPTION
# Summary of Changes
<!--- In one or more sentences, describe the PR you are submitting. -->
This one's pretty straightforward. #663 identified that we did position stuff in two different ways. This PR removes one of them (the direct inheritance of position by Agents). Now everything is code injection.

## Design Notes
<!--- Describe any design decisions or trade-offs you made. -->
I double checked with Codex that doing this wouldn't have any undesirable downstream effects and it seems convinced that this one's pretty cut and dry.

Check the box if your change does not break any of the following:
- [x] API for Cyclus modules
- [x] Input files
- [x] Output tables for post processing tools

# Related CEPs and Issues
<!--- Reference the issue that this PR closes, any related CEPs, and describe how this PR contributes to or addresses the problem. -->
Fixes #663 


# Associated Developers
<!--- Please mention any developers who should be alerted of this PR. -->
Codex (🖥️)


# Testing and Validation
<!--- Describe how this change was tested. -->
Clean built and ran tests for both Cyclus and Cycamore (both because of what happened with the Progress Bar)

- [x] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [x] I have compiled and run the code locally
- [ ] I have added or updated relevant tests
- [ ] I have added documentation for new or changed features
- [x] This code follows the style guide
- [x] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).