### PR TITLE
Source Option to Create Material "Just In Time"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Since last release
 ======================
 
 **Added:**
+* Just in time mode for Source (#695)
 * Added tests for Conversion Facility (#658)
 * Added Conversion Facility (#657)
 * Replaced manual matl_buy/sell_policy code in storage with code injection (#639)

--- a/src/source.cc
+++ b/src/source.cc
@@ -9,10 +9,12 @@ namespace cycamore {
 
 Source::Source(cyclus::Context* ctx)
     : cyclus::Facility(ctx),
-      throughput(std::numeric_limits<double>::max()),
       inventory_size(std::numeric_limits<double>::max()),
+      throughput(std::numeric_limits<double>::max()),
       package(cyclus::Package::unpackaged_name()),
-      transport_unit(cyclus::TransportUnit::unrestricted_name()) {}
+      transport_unit(cyclus::TransportUnit::unrestricted_name()),
+      just_in_time(false),
+      total_material_created(0.0) {}
 
 Source::~Source() {}
 
@@ -62,14 +64,34 @@ void Source::Build(cyclus::Agent* parent) {
   using cyclus::Composition;
   using cyclus::Material;
 
-  // create all source inventory and place into buf
-  cyclus::Material::Ptr all_inv;
-  Composition::Ptr blank_comp = Composition::CreateFromMass(CompMap());
-  all_inv = (outrecipe.empty() || context() == NULL) ? \
-          Material::Create(this, inventory_size, blank_comp) : \
-          Material::Create(this, inventory_size, context()->GetRecipe(outrecipe));
-  inventory.Push(all_inv);
+  if (!just_in_time) {
+    // create all source inventory and place into buf
+    cyclus::Material::Ptr all_inv;
+    Composition::Ptr blank_comp = Composition::CreateFromMass(CompMap());
+    all_inv = (outrecipe.empty() || context() == NULL) ? \
+            Material::Create(this, inventory_size, blank_comp) : \
+            Material::Create(this, inventory_size, context()->GetRecipe(outrecipe));
+    inventory.Push(all_inv);
+  }
+}
 
+void Source::Tick() {
+  using cyclus::CompMap;
+  using cyclus::Composition;
+  using cyclus::Material;
+
+  if (just_in_time) {
+    // create material equal to throughput and place into buf
+    cyclus::Material::Ptr new_mat;
+    double qty_to_create =
+          std::min(throughput, inventory_size - total_material_created);
+    Composition::Ptr blank_comp = Composition::CreateFromMass(CompMap());
+    new_mat = (outrecipe.empty() || context() == NULL) ? \
+            Material::Create(this, qty_to_create, blank_comp) : \
+            Material::Create(this, qty_to_create, context()->GetRecipe(outrecipe));
+    inventory.Push(new_mat);
+    total_material_created += qty_to_create;
+  }
 }
 
 std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr> Source::GetMatlBids(

--- a/src/source.h
+++ b/src/source.h
@@ -58,7 +58,7 @@ class Source : public cyclus::Facility,
 
   virtual void InitFrom(cyclus::QueryableBackend* b);
 
-  virtual void Tick() {};
+  virtual void Tick();
 
   virtual void Tock() {};
 
@@ -149,8 +149,23 @@ class Source : public cyclus::Facility,
   std::string transport_unit;
 
   #pragma cyclus var { \
+    "default": 0, \
+    "doc": "Setting just_in_time to true will force the Source to call " \
+           "Material::Create every time step to create the material it " \
+           "produces up to its throughput 'just in time' instead of " \
+           "creating everything at the start of the simulation.", \
+    "tooltip": "Produce material just in time", \
+    "uilabel": "Just-in-Time Production", \
+    "uitype": "bool", \
+  }
+  bool just_in_time;
+
+  #pragma cyclus var { \
     "tooltip":"Material buffer"}
   cyclus::toolkit::ResBuf<cyclus::Material> inventory;
+
+  #pragma cyclus var {"default": 0.0, "internal": True}
+  double total_material_created;
 
   void SetPackage();
 };


### PR DESCRIPTION
<!-- If this PR adds a CEP, do not repeat all of the information in the CEP document in the summary. Instead, provide a short description of the CEP's purpose.  -->

# Summary of Changes
<!--- In one or more sentences, describe the PR you are submitting. -->
Previously, the Source created its entire inventory on build, when it entered the simulation. This was fine for a mine or something, especially for stable or long-lived fission isotopes, but some strangeness with Decay for shorter-lived isotopes especially in manual decay mode was noticed. It was possible, for example, for a 50 year old CANDU (Tritium Source) to advertise that it could sell 1kg of Tritium, but upon receipt if the requester called decay they would find that they actually had 62g of tritium and a bunch  of He-3 (not what you want). This PR adds an option to source called `just_in_time` which, when `true` causes the source to just create up to its throughput (or `inventory_size - total_material_created`, whichever is smaller) of whatever it's a source for every timestep.

## Design Notes
<!--- Describe any design decisions or trade-offs you made. -->
It would still be good, probably, to add an option for the source to create material "On Demand" based on the requests it gets, but that is distinct behavior from what I am doing here, so I think it makes sense to have as a third option instead of just making this one do that. For example, it may make sense to make your throughput every timestep and stockpile it even if nobody wants to buy it right now, say, if you were anticipating irregular requests for your material in excess of your per-timestep throughput.

It may also make sense to add a decay-extract loop to Source for stockpiling reasons, but that felt outside the scope of this specific addition.

Check the box if your change does not break any of the following:
- [x] API for Cyclus modules
- [x] Input files
- [x] Output tables for post processing tools

# Related CEPs and Issues
<!--- Reference the issue that this PR closes, any related CEPs, and describe how this PR contributes to or addresses the problem. -->
Fixes #694


# Associated Developers
<!--- Please mention any developers who should be alerted of this PR. -->
Codex


# Testing and Validation
<!--- Describe how this change was tested. -->
## THIS PR DOES NOT HAVE TESTS DO NOT MERGE
-----------------------------
Code compiles and runs. Did a basic check to make sure this works how I expected it to, but have not added formal testing yet. 

- [x] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [x] I have compiled and run the code locally
- [ ] I have added or updated relevant tests
- [x] I have added documentation for new or changed features
- [x] This code follows the style guide
- [ ] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).